### PR TITLE
bug double validation employé

### DIFF
--- a/App/ProtoControllers/Responsable/Traitement/Conge.php
+++ b/App/ProtoControllers/Responsable/Traitement/Conge.php
@@ -187,7 +187,7 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
                 }
                 log_action($infoDemande['p_num'], 'refus', '', $infoDemande['p_login'], 'traitement demande ' . $id_conge . ' (' . $infoDemande['p_login'] . ') (' . $infoDemande['p_nb_jours'] . ' jours) : refus');
             } elseif (\App\Models\Conge::ACCEPTE === $statut) {
-                if (\App\ProtoControllers\Responsable::isDoubleValGroupe($infoDemande['p_login']) && !\App\ProtoControllers\Responsable::isRespDeUtilisateur($_SESSION['userlogin'], $infoDemande['p_login'])) {
+                if (\App\ProtoControllers\Responsable::isDoubleValGroupe($infoDemande['p_login'])) {
                     $return = $this->updateStatutPremiereValidation($id_conge);
                     if($_SESSION['config']['mail_valid_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $infoDemande['p_login'], $infoDemande['p_num'], "valid_conges");


### PR DESCRIPTION
une tentative (b1a25990fe46a7801b1af7d49956d9cbdd66c197) raté de correction du cas d'un responsable/employé d'un groupe à double validation. 
Le seul moyen d'avoir un comportement normal du traitement de ce cas est de ne pas être responsable ET employé d'un groupe, ce qui est prévu dans la refonte des groupes (#219).