### PR TITLE
[Traitement des heures] correction bug valeur double dans badge + erreur lors du traitement des repos

### DIFF
--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -111,23 +111,26 @@ abstract Class ANotification {
      */
     protected function getContenu($id) {
         $data = $this->getData($id);
-        switch ($data['statut']) {
-            case \App\Models\AHeure::STATUT_DEMANDE:
-                $NotifContent[] = $this->getContenuDemande($data);
-                break;
-            case \App\Models\AHeure::STATUT_PREMIERE_VALIDATION:
-                $NotifContent[] = $this->getContenuEmployePremierValidation($data);
-                $NotifContent[] = $this->getContenuGrandResponsablePremiereValidation($data);
-                break;
-            case \App\Models\AHeure::STATUT_VALIDATION_FINALE:
-                $NotifContent[] = $this->getContenuValidationFinale($data);
-                break;
-            case \App\Models\AHeure::STATUT_REFUS:
-                $NotifContent[] = $this->getContenuRefus($data);
-                break;
-            case \App\Models\AHeure::STATUT_ANNUL:
-                $NotifContent[] = $this->getContenuAnnulation($data);
-                break;
+        $NotifContent = [];
+        if (isset($data['statut'])) {
+            switch ($data['statut']) {
+                case \App\Models\AHeure::STATUT_DEMANDE:
+                    $NotifContent[] = $this->getContenuDemande($data);
+                    break;
+                case \App\Models\AHeure::STATUT_PREMIERE_VALIDATION:
+                    $NotifContent[] = $this->getContenuEmployePremierValidation($data);
+                    $NotifContent[] = $this->getContenuGrandResponsablePremiereValidation($data);
+                    break;
+                case \App\Models\AHeure::STATUT_VALIDATION_FINALE:
+                    $NotifContent[] = $this->getContenuValidationFinale($data);
+                    break;
+                case \App\Models\AHeure::STATUT_REFUS:
+                    $NotifContent[] = $this->getContenuRefus($data);
+                    break;
+                case \App\Models\AHeure::STATUT_ANNUL:
+                    $NotifContent[] = $this->getContenuAnnulation($data);
+                    break;
+            }
         }
         return $NotifContent;
     }

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -111,26 +111,23 @@ abstract Class ANotification {
      */
     protected function getContenu($id) {
         $data = $this->getData($id);
-        $NotifContent = [];
-        if (isset($data['statut'])) {
-            switch ($data['statut']) {
-                case \App\Models\AHeure::STATUT_DEMANDE:
-                    $NotifContent[] = $this->getContenuDemande($data);
-                    break;
-                case \App\Models\AHeure::STATUT_PREMIERE_VALIDATION:
-                    $NotifContent[] = $this->getContenuEmployePremierValidation($data);
-                    $NotifContent[] = $this->getContenuGrandResponsablePremiereValidation($data);
-                    break;
-                case \App\Models\AHeure::STATUT_VALIDATION_FINALE:
-                    $NotifContent[] = $this->getContenuValidationFinale($data);
-                    break;
-                case \App\Models\AHeure::STATUT_REFUS:
-                    $NotifContent[] = $this->getContenuRefus($data);
-                    break;
-                case \App\Models\AHeure::STATUT_ANNUL:
-                    $NotifContent[] = $this->getContenuAnnulation($data);
-                    break;
-            }
+        switch ($data['statut']) {
+            case \App\Models\AHeure::STATUT_DEMANDE:
+                $NotifContent[] = $this->getContenuDemande($data);
+                break;
+            case \App\Models\AHeure::STATUT_PREMIERE_VALIDATION:
+                $NotifContent[] = $this->getContenuEmployePremierValidation($data);
+                $NotifContent[] = $this->getContenuGrandResponsablePremiereValidation($data);
+                break;
+            case \App\Models\AHeure::STATUT_VALIDATION_FINALE:
+                $NotifContent[] = $this->getContenuValidationFinale($data);
+                break;
+            case \App\Models\AHeure::STATUT_REFUS:
+                $NotifContent[] = $this->getContenuRefus($data);
+                break;
+            case \App\Models\AHeure::STATUT_ANNUL:
+                $NotifContent[] = $this->getContenuAnnulation($data);
+                break;
         }
         return $NotifContent;
     }

--- a/App/Libraries/Notification/Additionnelle.php
+++ b/App/Libraries/Notification/Additionnelle.php
@@ -138,7 +138,7 @@ Class Additionnelle extends \App\Libraries\ANotification {
         $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
         $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['expediteur']['nom'] = $infoResp['u_nom']." ".$infoResp['u_prenom'];
-        foreach ($responsables as $responsable) {
+        foreach ($grandResponsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 

--- a/App/Libraries/Notification/Repos.php
+++ b/App/Libraries/Notification/Repos.php
@@ -141,7 +141,7 @@ Class Repos extends \App\Libraries\ANotification {
         $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
         $return['expediteur']['nom'] = $infoResp['u_nom']." ".$infoResp['u_prenom'];
 
-        foreach ($responsables as $responsable) {
+        foreach ($grandResponsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 

--- a/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
+++ b/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
@@ -102,7 +102,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
             $return = NIL_INT;
         }
         if( 0 < $return) {
-            $notif = new \App\Libraries\Notification\Additionnelle($id);
+            $notif = new \App\Libraries\Notification\Additionnelle();
             if (!$notif->send()) {
                 $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
                 $return = NIL_INT;

--- a/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
+++ b/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
@@ -102,7 +102,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
             $return = NIL_INT;
         }
         if( 0 < $return) {
-            $notif = new \App\Libraries\Notification\Additionnelle();
+            $notif = new \App\Libraries\Notification\Additionnelle($id_heure);
             if (!$notif->send()) {
                 $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
                 $return = NIL_INT;

--- a/App/ProtoControllers/Responsable/Traitement/Conge.php
+++ b/App/ProtoControllers/Responsable/Traitement/Conge.php
@@ -400,12 +400,13 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
     {
         $groupId = \App\ProtoControllers\Responsable::getIdGroupeResp($resp);
 
-
         $usersResp = [];
         $usersResp = \App\ProtoControllers\Groupe\Utilisateur::getListUtilisateurByGroupeIds($groupId);
         $usersRespDirect = \App\ProtoControllers\Responsable::getUsersRespDirect($resp);
-        $usersResp = array_merge($usersResp,$usersRespDirect);
 
+        // merge tous les utilisateurs dont il est le responsable direct et tous les utilisateurs dont il est le chef de groupe
+        // si un utilisateur est dans les deux tableaux on supprime le doublon
+        $usersResp = array_unique(array_merge($usersResp,$usersRespDirect));
         // un utilisateur ne peut etre son propre responsable
         $usersResp = array_diff($usersResp,[$_SESSION['userlogin']]);
 

--- a/App/ProtoControllers/Responsable/Traitement/Repos.php
+++ b/App/ProtoControllers/Responsable/Traitement/Repos.php
@@ -104,7 +104,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         }
         
         if( 0 < $return) {
-            $notif = new \App\Libraries\Notification\Repos();
+            $notif = new \App\Libraries\Notification\Repos($id_heure);
             $send = $notif->send();
 
             if (false === $send) {

--- a/App/ProtoControllers/Responsable/Traitement/Repos.php
+++ b/App/ProtoControllers/Responsable/Traitement/Repos.php
@@ -104,7 +104,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         }
         
         if( 0 < $return) {
-            $notif = new \App\Libraries\Notification\Repos($id);
+            $notif = new \App\Libraries\Notification\Repos();
             $send = $notif->send();
 
             if (false === $send) {
@@ -295,7 +295,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         $sql = \includes\SQL::singleton();
         $req = 'SELECT id_heure AS id
                 FROM heure_repos
-                WHERE login IN (\'' . implode(',', $usersResp) . '\')
+                WHERE login IN (\'' . implode('\',\'', $usersResp) . '\')
                 AND statut = '.AHeure::STATUT_DEMANDE;
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {
@@ -323,7 +323,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         $sql = \includes\SQL::singleton();
         $req = 'SELECT id_heure AS id
                 FROM heure_repos
-                WHERE login IN (\'' . implode(',', $usersResp) . '\')
+                WHERE login IN (\'' . implode('\',\'', $usersResp) . '\')
                 AND statut = '.AHeure::STATUT_PREMIERE_VALIDATION;
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {


### PR DESCRIPTION
Fix le bug d'affichage des badges en double dans le cas où l'utilisateur avait le même responsable direct que le chef de groupe

Le traitement des heures de repos par le responsable et le grand responsable ne fonctionnait pas
Le commit fix aussi un problème dans notification lors du traitement des heures par le grand responsable.

A bien tester surtout le dernier commit car je n'ai corrigé que les erreurs et ce que je connais de la fonctionnalité mais je n'ai pas testé la partie notification (envoie de mail)