### PR TITLE
Auto indentation de l'ensemble des fichiers en utilisant Codeformatter

### DIFF
--- a/App/Helpers/Formatter.php
+++ b/App/Helpers/Formatter.php
@@ -68,7 +68,7 @@ class Formatter
             throw new \Exception(_('Heure_mal_formee'));
         }
 
-        return ($matches[1]*3600+$matches[5]*60);
+        return ($matches[1] * 3600 + $matches[5] * 60);
     }
 
     /**
@@ -100,13 +100,13 @@ class Formatter
     public static function timestamp2Duree($timestamp)
     {
         $timestamp = (int) $timestamp;
-        $secondes = abs($timestamp/60%60);
-        $heures = abs($timestamp/3600);
-        $duree = sprintf('%02d:%02d', $heures, $secondes);
+        $secondes  = abs($timestamp / 60 % 60);
+        $heures    = abs($timestamp / 3600);
+        $duree     = sprintf('%02d:%02d', $heures, $secondes);
 
         return (0 < $timestamp)
-            ? $duree
-            : '-' . $duree
+        ? $duree
+        : '-' . $duree
         ;
     }
 }

--- a/App/Libraries/ANotification.php
+++ b/App/Libraries/ANotification.php
@@ -4,41 +4,43 @@ namespace App\Libraries;
 
 /**
  * Objet de gestion des notifications
- * 
- * 
+ *
+ *
  */
-abstract Class ANotification {
+abstract class ANotification
+{
 
     protected $contenuNotification;
     protected $envoiMail;
 
     /**
-     * 
+     *
      * implémente les informations de la demande d'heure
      * ainsi que du contenu du mail
-     * 
+     *
      * @param int $id
-     * 
+     *
      */
-    public function __construct($id) {
-        $id = (int)$id;
-        if(is_int($id)){
+    public function __construct($id)
+    {
+        $id = (int) $id;
+        if (is_int($id)) {
             $this->contenuNotification = $this->getContenu($id);
         } else {
             throw new Exception('erreur id');
         }
     }
 
-
     /**
-     * 
+     *
      * Transmet les notifications par mail
-     * 
+     *
      * @return boolean
      */
-    public function send() {
+    public function send()
+    {
 
-    $return = [];
+        $return = [];
 
         // init du mail
         $mail = new \PHPMailer();
@@ -64,29 +66,29 @@ abstract Class ANotification {
             }
         } else {
             if (file_exists('/usr/sbin/sendmail')) {
-                $mail->IsSendmail();   // send message using the $Sendmail program
+                $mail->IsSendmail(); // send message using the $Sendmail program
             } elseif (file_exists('/var/qmail/bin/sendmail')) {
                 $mail->IsQmail(); // send message using the qmail MTA
             } else {
                 $mail->IsMail(); // send message using PHP mail() function
             }
         }
-        
-        foreach ($this->contenuNotification as $notification){
+
+        foreach ($this->contenuNotification as $notification) {
             if (empty($notification['destinataire'][0])) {
                 continue;
             }
-            if($this->canSend($notification['config'])){
+            if ($this->canSend($notification['config'])) {
                 $mail->ClearAddresses();
-                $mail->From = $notification['expediteur']['mail'];
+                $mail->From     = $notification['expediteur']['mail'];
                 $mail->FromName = $notification['expediteur']['nom'];
                 foreach ($notification['destinataire'] as $destinataire) {
                     $mail->AddAddress($destinataire);
                 }
-                $mail->SetLanguage( 'fr', ROOT_PATH . 'vendor/phpmailer/phpmailer/language/');
-        
-                $mail->Subject = utf8_decode ( $notification['sujet'] );
-                $mail->Body = utf8_decode ( $notification['message'] );
+                $mail->SetLanguage('fr', ROOT_PATH . 'vendor/phpmailer/phpmailer/language/');
+
+                $mail->Subject = utf8_decode($notification['sujet']);
+                $mail->Body    = utf8_decode($notification['message']);
 
                 $return[] = $mail->Send();
             }
@@ -96,20 +98,21 @@ abstract Class ANotification {
 
     /**
      * récupère les données de l'évenemment
-     * 
+     *
      * @todo déplacer la requete vers le protocontroller
      * @param int $id
-     * 
+     *
      * @return array
      */
     abstract protected function getData($id);
 
     /**
      * selection du contenu de la notification
-     * 
+     *
      * @return array
      */
-    protected function getContenu($id) {
+    protected function getContenu($id)
+    {
         $data = $this->getData($id);
         switch ($data['statut']) {
             case \App\Models\AHeure::STATUT_DEMANDE:
@@ -131,71 +134,72 @@ abstract Class ANotification {
         }
         return $NotifContent;
     }
-    
+
     /**
      * Controle de l'option d'envoi de mails selon la notification
-     * 
+     *
      * @param string $optionName
      * @return boolean
      * @throws Exception
-     * 
+     *
      */
-    private function canSend($optionName) {
+    private function canSend($optionName)
+    {
         return isset($_SESSION['config'][$optionName]) ? $_SESSION['config'][$optionName] : false;
     }
 
     /**
      * notification d'une nouvelle demande d'heures
      * au responsable du demandeur
-     * 
+     *
      * @param array $data
      * @return array
      */
     abstract protected function getContenuDemande($data);
-    
+
     /**
-     * notification d'une première validation 
+     * notification d'une première validation
      * au demandeur d'heures
-     * 
+     *
      * @param array $data
      * @return array
      */
     abstract protected function getContenuEmployePremierValidation($data);
-    
+
     /**
      * notification d'une validation finale
      * au demandeur d'heures
-     * 
+     *
      * @param array $data
      * @return array
      */
     abstract protected function getContenuValidationFinale($data);
-    
+
     /**
      * notification d'un refus
      * au demandeur d'heures
-     * 
+     *
      * @param array $data
      * @return array
      */
     abstract protected function getContenuRefus($data);
-    
+
     /**
      * notification d'une annulation par le demandeur
      * à son responsable
-     * 
+     *
      * @param array $data
      * @return array
      */
     abstract protected function getContenuAnnulation($data);
-    
+
     /**
      * notification d'une première validation
      * au grand responsable du demandeur d'heures
-     * 
+     *
      * @param array $data
      * @return array
      */
     abstract protected function getContenuGrandResponsablePremiereValidation($data);
-    
+
 }

--- a/App/Libraries/Calendrier/ACollection.php
+++ b/App/Libraries/Calendrier/ACollection.php
@@ -30,7 +30,7 @@ abstract class ACollection
     public function __construct(\DateTimeInterface $dateDebut, \DateTimeInterface $dateFin)
     {
         $this->dateDebut = clone $dateDebut;
-        $this->dateFin = clone $dateFin;
+        $this->dateFin   = clone $dateFin;
     }
 
     /**

--- a/App/Libraries/Calendrier/BusinessCollection.php
+++ b/App/Libraries/Calendrier/BusinessCollection.php
@@ -40,12 +40,12 @@ class BusinessCollection
     private $canVoirEnTransit;
 
     /**
-    * @var bool Si la gestion des groupes est demandée
+     * @var bool Si la gestion des groupes est demandée
      */
     private $isGroupesGeres;
 
     /**
-    * @var int Groupe dont on veut voir les événements
+     * @var int Groupe dont on veut voir les événements
      */
     private $groupeAConsulter;
 
@@ -65,15 +65,15 @@ class BusinessCollection
         $canVoirEnTransit,
         $isGroupesGeres,
         $groupeAConsulter = NIL_INT
-    ){
+    ) {
         $this->dateDebut = clone $dateDebut;
         /* Extension des bordures de dates */
         $this->dateDebut->modify('-1 week');
         $this->dateFin = clone $dateFin;
         $this->dateFin->modify('+1 week');
-        $this->utilisateur = (string) $utilisateur;
+        $this->utilisateur      = (string) $utilisateur;
         $this->canVoirEnTransit = (bool) $canVoirEnTransit;
-        $this->isGroupesGeres = (bool) $isGroupesGeres;
+        $this->isGroupesGeres   = (bool) $isGroupesGeres;
         $this->groupeAConsulter = (int) $groupeAConsulter;
     }
 
@@ -87,20 +87,20 @@ class BusinessCollection
         /* Logique métier « application wide » */
         $utilisateursATrouver = [];
         if (null === $this->evenements) {
-            if($this->isGroupesGeres) {
+            if ($this->isGroupesGeres) {
                 $groupesVisiblesUtilisateur = \App\ProtoControllers\Utilisateur::getListeGroupesVisibles($this->utilisateur);
-                $groupesATrouver = (NIL_INT !== $this->groupeAConsulter)
-                    ? array_intersect($groupesVisiblesUtilisateur, [$this->groupeAConsulter])
-                    : $groupesVisiblesUtilisateur;
+                $groupesATrouver            = (NIL_INT !== $this->groupeAConsulter)
+                ? array_intersect($groupesVisiblesUtilisateur, [$this->groupeAConsulter])
+                : $groupesVisiblesUtilisateur;
                 $utilisateursATrouver = \App\ProtoControllers\Groupe\Utilisateur::getListUtilisateurByGroupeIds($groupesATrouver);
-                $fermeture = new Collection\Fermeture($this->dateDebut, $this->dateFin, $groupesATrouver);
+                $fermeture            = new Collection\Fermeture($this->dateDebut, $this->dateFin, $groupesATrouver);
             } else {
                 $utilisateursATrouver = \App\ProtoControllers\Utilisateur::getListId();
-                $fermeture = new Collection\Fermeture($this->dateDebut, $this->dateFin, []);
+                $fermeture            = new Collection\Fermeture($this->dateDebut, $this->dateFin, []);
             }
 
-            $ferie = new Collection\Ferie($this->dateDebut, $this->dateFin);
-            $weekend = new Collection\Weekend($this->dateDebut, $this->dateFin);
+            $ferie            = new Collection\Ferie($this->dateDebut, $this->dateFin);
+            $weekend          = new Collection\Weekend($this->dateDebut, $this->dateFin);
             $this->evenements = array_merge(
                 $ferie->getListe(),
                 $weekend->getListe(),
@@ -108,9 +108,9 @@ class BusinessCollection
             );
 
             if (!empty($utilisateursATrouver)) {
-                $conge = new Collection\Conge($this->dateDebut, $this->dateFin, $utilisateursATrouver, $this->canVoirEnTransit);
-                $repos = new Collection\Heure\Repos($this->dateDebut, $this->dateFin, $utilisateursATrouver, $this->canVoirEnTransit);
-                $additionnelle = new Collection\Heure\Additionnelle($this->dateDebut, $this->dateFin, $utilisateursATrouver, $this->canVoirEnTransit);
+                $conge            = new Collection\Conge($this->dateDebut, $this->dateFin, $utilisateursATrouver, $this->canVoirEnTransit);
+                $repos            = new Collection\Heure\Repos($this->dateDebut, $this->dateFin, $utilisateursATrouver, $this->canVoirEnTransit);
+                $additionnelle    = new Collection\Heure\Additionnelle($this->dateDebut, $this->dateFin, $utilisateursATrouver, $this->canVoirEnTransit);
                 $this->evenements = array_merge(
                     $this->evenements,
                     $conge->getListe(),

--- a/App/Libraries/Calendrier/Collection/Conge.php
+++ b/App/Libraries/Calendrier/Collection/Conge.php
@@ -39,7 +39,7 @@ class Conge extends \App\Libraries\Calendrier\ACollection
     ) {
         parent::__construct($dateDebut, $dateFin);
         $this->utilisateursATrouver = $utilisateursATrouver;
-        $this->canVoirEnTransit = (bool) $canVoirEnTransit;
+        $this->canVoirEnTransit     = (bool) $canVoirEnTransit;
     }
 
     /**
@@ -52,16 +52,16 @@ class Conge extends \App\Libraries\Calendrier\ACollection
             $class = $jour['ta_type'] . ' ' . $jour['ta_type'] . '_' . $jour['p_etat'];
             /* TODO: unescape_string ? */
             $nomComplet = \App\ProtoControllers\Utilisateur::getNomComplet($jour['u_prenom'], $jour['u_nom'], true);
-            $name = $nomComplet . ' - ' . $jour['ta_libelle'];
+            $name       = $nomComplet . ' - ' . $jour['ta_libelle'];
             if (\App\Models\Conge::STATUT_VALIDATION_FINALE !== $jour['p_etat']) {
                 $name = '[En demande]  ' . $name;
             }
 
             $dateDebut = $this->getDebutPeriode($jour['p_date_deb'], $jour['p_demi_jour_deb']);
-            $dateFin = $this->getFinPeriode($jour['p_date_fin'], $jour['p_demi_jour_fin']);
+            $dateFin   = $this->getFinPeriode($jour['p_date_fin'], $jour['p_demi_jour_fin']);
 
-            $title = '[' . $jour['ta_type'] . '] ' . $jour['ta_libelle'] . ' de ' . $nomComplet . ' du ' . $dateDebut['date']->format('d/m/Y') . ' ' . $dateDebut['creneau'] . ' au ' . $dateFin['date']->format('d/m/Y') . ' ' . $dateFin['creneau'];
-            $uid = uniqid('ferie');
+            $title    = '[' . $jour['ta_type'] . '] ' . $jour['ta_libelle'] . ' de ' . $nomComplet . ' du ' . $dateDebut['date']->format('d/m/Y') . ' ' . $dateDebut['creneau'] . ' au ' . $dateFin['date']->format('d/m/Y') . ' ' . $dateFin['creneau'];
+            $uid      = uniqid('ferie');
             $conges[] = new Evenement\Commun($uid, $dateDebut['date'], $dateFin['date'], $name, $title, $class);
         }
 
@@ -71,11 +71,11 @@ class Conge extends \App\Libraries\Calendrier\ACollection
     private function getDebutPeriode($dateDebut, $demiJournee)
     {
         $debut = ('am' === $demiJournee)
-            ? $dateDebut
-            : $dateDebut . ' 11:59';
+        ? $dateDebut
+        : $dateDebut . ' 11:59';
         $creneau = ('am' === $demiJournee)
-            ? _('debut_matin')
-            : _('debut_apres-midi');
+        ? _('debut_matin')
+        : _('debut_apres-midi');
 
         return ['date' => new \DateTime($debut), 'creneau' => $creneau];
     }
@@ -83,20 +83,18 @@ class Conge extends \App\Libraries\Calendrier\ACollection
     private function getFinPeriode($dateFin, $demiJournee)
     {
         $fin = ('am' === $demiJournee)
-            ? $dateFin . ' 11:59'
-            : $dateFin . ' 23:59';
+        ? $dateFin . ' 11:59'
+        : $dateFin . ' 23:59';
         $creneau = ('am' === $demiJournee)
-            ? _('debut_apres-midi')
-            : _('fin_apres-midi');
+        ? _('debut_apres-midi')
+        : _('fin_apres-midi');
 
-            return ['date' => new \DateTime($fin), 'creneau' => $creneau];
+        return ['date' => new \DateTime($fin), 'creneau' => $creneau];
     }
-
 
     /*
      * SQL
      */
-
 
     /**
      * Retourne la liste des congés du stockage satisfaisant aux critères
@@ -106,12 +104,12 @@ class Conge extends \App\Libraries\Calendrier\ACollection
      */
     private function getListeSQL()
     {
-        $sql = \includes\SQL::singleton();
+        $sql     = \includes\SQL::singleton();
         $etats[] = \App\Models\Conge::STATUT_VALIDATION_FINALE;
         if ($this->canVoirEnTransit) {
             $etats = array_merge($etats, [
                 \App\Models\Conge::STATUT_DEMANDE,
-                \App\Models\Conge::STATUT_PREMIERE_VALIDATION
+                \App\Models\Conge::STATUT_PREMIERE_VALIDATION,
             ]);
         }
         $req = 'SELECT *
@@ -122,7 +120,7 @@ class Conge extends \App\Libraries\Calendrier\ACollection
                     AND p_date_deb <= "' . $this->dateFin->format('Y-m-d') . '"
                     AND p_login IN ("' . implode('","', $this->utilisateursATrouver) . '")
                     AND p_etat IN ("' . implode('","', $etats) . '")';
-        $res = $sql->query($req);
+        $res    = $sql->query($req);
         $conges = [];
         while ($data = $res->fetch_assoc()) {
             $conges[] = $data;

--- a/App/Libraries/Calendrier/Collection/Ferie.php
+++ b/App/Libraries/Calendrier/Collection/Ferie.php
@@ -23,23 +23,21 @@ class Ferie extends \App\Libraries\Calendrier\ACollection
     public function getListe()
     {
         $feries = [];
-        $name = 'Jour férié';
-        $title = null;
-        $class = 'ferie';
+        $name   = 'Jour férié';
+        $title  = null;
+        $class  = 'ferie';
         foreach ($this->getListeSQL() as $jour) {
             $dateJour = new \DateTime($jour['jf_date']);
-            $uid = uniqid('ferie');
+            $uid      = uniqid('ferie');
             $feries[] = new Evenement\Commun($uid, $dateJour, $dateJour, $name, $title, $class);
         }
 
         return $feries;
     }
 
-
     /*
      * SQL
      */
-
 
     /**
      * Retourne tous les jours fériés

--- a/App/Libraries/Calendrier/Collection/Fermeture.php
+++ b/App/Libraries/Calendrier/Collection/Fermeture.php
@@ -37,23 +37,21 @@ class Fermeture extends \App\Libraries\Calendrier\ACollection
     public function getListe()
     {
         $fermeture = [];
-        $name = 'Fermeture';
-        $title = null;
-        $class = 'fermeture';
+        $name      = 'Fermeture';
+        $title     = null;
+        $class     = 'fermeture';
         foreach ($this->getListeSQL() as $jour) {
-            $dateJour = new \DateTime($jour['jf_date']);
-            $uid = uniqid('fermeture');
+            $dateJour    = new \DateTime($jour['jf_date']);
+            $uid         = uniqid('fermeture');
             $fermeture[] = new Evenement\Commun($uid, $dateJour, $dateJour, $name, $title, $class);
         }
 
         return $fermeture;
     }
 
-
     /*
      * SQL
      */
-
 
     /**
      * Retourne les jours de fermeture satisfaisant aux critères de période

--- a/App/Libraries/Calendrier/Collection/Heure/Additionnelle.php
+++ b/App/Libraries/Calendrier/Collection/Heure/Additionnelle.php
@@ -39,7 +39,7 @@ class Additionnelle extends \App\Libraries\Calendrier\ACollection
     ) {
         parent::__construct($dateDebut, $dateFin);
         $this->utilisateursATrouver = $utilisateursATrouver;
-        $this->canVoirEnTransit = (bool) $canVoirEnTransit;
+        $this->canVoirEnTransit     = (bool) $canVoirEnTransit;
     }
 
     /**
@@ -49,10 +49,10 @@ class Additionnelle extends \App\Libraries\Calendrier\ACollection
     {
         $heures = [];
         foreach ($this->getListeSQL($this->getListeId()) as $heure) {
-            $class = 'heure heure_' . $heure['statut'];
-            $nomComplet = \App\ProtoControllers\Utilisateur::getNomComplet($heure['u_prenom'],  $heure['u_nom'], true);
-            $name = $nomComplet . ' - Heure(s) additionnelle(s)';
-            if (in_array($heure['statut'],[\App\Models\AHeure::STATUT_DEMANDE,\App\Models\AHeure::STATUT_PREMIERE_VALIDATION])) {
+            $class      = 'heure heure_' . $heure['statut'];
+            $nomComplet = \App\ProtoControllers\Utilisateur::getNomComplet($heure['u_prenom'], $heure['u_nom'], true);
+            $name       = $nomComplet . ' - Heure(s) additionnelle(s)';
+            if (in_array($heure['statut'], [\App\Models\AHeure::STATUT_DEMANDE, \App\Models\AHeure::STATUT_PREMIERE_VALIDATION])) {
                 $name = '[En demande]  ' . $name;
             }
             $dateDebut = new \DateTime();
@@ -61,19 +61,17 @@ class Additionnelle extends \App\Libraries\Calendrier\ACollection
             $dateFin->setTimestamp($heure['fin']);
             $statut = ' statut_' . $heure['statut'];
 
-            $title = 'Heure(s) additionnelle(s) de ' . $nomComplet . ' le ' . $dateDebut->format('d/m/Y') . ' de ' . $dateDebut->format('H\:i') . ' à ' . $dateFin->format('H\:i');
-            $uid = uniqid('additionnelle');
+            $title    = 'Heure(s) additionnelle(s) de ' . $nomComplet . ' le ' . $dateDebut->format('d/m/Y') . ' de ' . $dateDebut->format('H\:i') . ' à ' . $dateFin->format('H\:i');
+            $uid      = uniqid('additionnelle');
             $heures[] = new Evenement\Commun($uid, $dateDebut, $dateFin, $name, $title, $class);
         }
 
         return $heures;
     }
 
-
     /*
      * SQL
      */
-
 
     /**
      * Retourne la liste des id d'heures additionnelles satisfaisant aux critères
@@ -82,12 +80,12 @@ class Additionnelle extends \App\Libraries\Calendrier\ACollection
      */
     private function getListeId()
     {
-        $ids = [];
+        $ids     = [];
         $etats[] = \App\Models\AHeure::STATUT_VALIDATION_FINALE;
         if ($this->canVoirEnTransit) {
             $etats = array_merge($etats, [
                 \App\Models\AHeure::STATUT_DEMANDE,
-                \App\Models\AHeure::STATUT_PREMIERE_VALIDATION
+                \App\Models\AHeure::STATUT_PREMIERE_VALIDATION,
             ]);
         }
         $req = 'SELECT id_heure AS id
@@ -120,7 +118,7 @@ class Additionnelle extends \App\Libraries\Calendrier\ACollection
         }
 
         $listeId = array_map('intval', $listeId);
-        $req = 'SELECT *
+        $req     = 'SELECT *
                 FROM heure_additionnelle HA
                     INNER JOIN conges_users CU ON (HA.login = CU.u_login)
                 WHERE id_heure IN (' . implode(',', $listeId) . ')

--- a/App/Libraries/Calendrier/Collection/Heure/Repos.php
+++ b/App/Libraries/Calendrier/Collection/Heure/Repos.php
@@ -39,7 +39,7 @@ class Repos extends \App\Libraries\Calendrier\ACollection
     ) {
         parent::__construct($dateDebut, $dateFin);
         $this->utilisateursATrouver = $utilisateursATrouver;
-        $this->canVoirEnTransit = (bool) $canVoirEnTransit;
+        $this->canVoirEnTransit     = (bool) $canVoirEnTransit;
     }
 
     /**
@@ -49,10 +49,10 @@ class Repos extends \App\Libraries\Calendrier\ACollection
     {
         $heures = [];
         foreach ($this->getListeSQL($this->getListeId()) as $heure) {
-            $class = 'heure heure_' . $heure['statut'];
-            $nomComplet = \App\ProtoControllers\Utilisateur::getNomComplet($heure['u_prenom'],  $heure['u_nom'], true);
-            $name = $nomComplet . ' - Heure(s) de repos';
-            if (in_array($heure['statut'],[\App\Models\AHeure::STATUT_DEMANDE,\App\Models\AHeure::STATUT_PREMIERE_VALIDATION])) {
+            $class      = 'heure heure_' . $heure['statut'];
+            $nomComplet = \App\ProtoControllers\Utilisateur::getNomComplet($heure['u_prenom'], $heure['u_nom'], true);
+            $name       = $nomComplet . ' - Heure(s) de repos';
+            if (in_array($heure['statut'], [\App\Models\AHeure::STATUT_DEMANDE, \App\Models\AHeure::STATUT_PREMIERE_VALIDATION])) {
                 $name = '[En demande]  ' . $name;
             }
             $dateDebut = new \DateTime();
@@ -61,19 +61,17 @@ class Repos extends \App\Libraries\Calendrier\ACollection
             $dateFin->setTimestamp($heure['fin']);
             $statut = ' statut_' . $heure['statut'];
 
-            $title = 'Heure(s) de repos de ' . $nomComplet . ' le ' . $dateDebut->format('d/m/Y') . ' de ' . $dateDebut->format('H\:i') . ' à ' . $dateFin->format('H\:i');
-            $uid = uniqid('repos');
+            $title    = 'Heure(s) de repos de ' . $nomComplet . ' le ' . $dateDebut->format('d/m/Y') . ' de ' . $dateDebut->format('H\:i') . ' à ' . $dateFin->format('H\:i');
+            $uid      = uniqid('repos');
             $heures[] = new Evenement\Commun($uid, $dateDebut, $dateFin, $name, $title, $class);
         }
 
         return $heures;
     }
 
-
     /*
      * SQL
      */
-
 
     /**
      * Retourne la liste des id d'heures de repos satisfaisant aux critères
@@ -82,12 +80,12 @@ class Repos extends \App\Libraries\Calendrier\ACollection
      */
     private function getListeId()
     {
-        $ids = [];
+        $ids     = [];
         $etats[] = \App\Models\AHeure::STATUT_VALIDATION_FINALE;
         if ($this->canVoirEnTransit) {
             $etats = array_merge($etats, [
                 \App\Models\AHeure::STATUT_DEMANDE,
-                \App\Models\AHeure::STATUT_PREMIERE_VALIDATION
+                \App\Models\AHeure::STATUT_PREMIERE_VALIDATION,
             ]);
         }
         $req = 'SELECT id_heure AS id
@@ -120,7 +118,7 @@ class Repos extends \App\Libraries\Calendrier\ACollection
         }
 
         $listeId = array_map('intval', $listeId);
-        $req = 'SELECT *
+        $req     = 'SELECT *
                 FROM heure_repos HR
                     INNER JOIN conges_users CU ON (HR.login = CU.u_login)
                 WHERE id_heure IN (' . implode(',', $listeId) . ')

--- a/App/Libraries/Calendrier/Collection/Weekend.php
+++ b/App/Libraries/Calendrier/Collection/Weekend.php
@@ -41,12 +41,12 @@ class Weekend extends \App\Libraries\Calendrier\ACollection
         }
 
         $weekend = [];
-        $name = 'Week-end';
-        $title = null;
-        $class = 'weekend';
+        $name    = 'Week-end';
+        $title   = null;
+        $class   = 'weekend';
         foreach ($liste as $jour) {
-            $dateJour = new \DateTime($jour);
-            $uid = uniqid('weekend');
+            $dateJour  = new \DateTime($jour);
+            $uid       = uniqid('weekend');
             $weekend[] = new Evenement\Commun($uid, $dateJour, $dateJour, $name, $title, $class);
         }
 
@@ -83,7 +83,7 @@ class Weekend extends \App\Libraries\Calendrier\ACollection
     private function getListeJourSemaine($jourSemaine)
     {
         $debut = $this->dateDebut->getTimestamp();
-        $fin = $this->dateFin->getTimestamp();
+        $fin   = $this->dateFin->getTimestamp();
         if ($debut > $fin) {
             throw new \Exception('Date de début supérieure à date de fin');
         }
@@ -93,7 +93,7 @@ class Weekend extends \App\Libraries\Calendrier\ACollection
             /* Si on est sur le jour clé, on append la liste et on tape une semaine au dessus */
             if (date('w', $debut) == $jourSemaine) {
                 $listeJourSemaine[] = date('Y-m-d', $debut);
-                $debut = strtotime('+1 week', $debut);
+                $debut              = strtotime('+1 week', $debut);
             } else {
                 $debut = strtotime('+1 day', $debut);
             }
@@ -102,12 +102,10 @@ class Weekend extends \App\Libraries\Calendrier\ACollection
         return $listeJourSemaine;
     }
 
-
     /*
      * SQL
      * @TODO dégager lors de la mise en place de l'objet configuration
      */
-
 
     private function isSamediTravaille()
     {

--- a/App/Libraries/Calendrier/Evenement/Commun.php
+++ b/App/Libraries/Calendrier/Evenement/Commun.php
@@ -55,10 +55,10 @@ final class Commun implements EventInterface
      */
     public function __construct($uid, \DateTimeInterface $debut, \DateTimeInterface $fin, $name, $title, $class)
     {
-        $this->uid = (string) $uid;
+        $this->uid   = (string) $uid;
         $this->debut = clone $debut;
-        $this->fin = clone $fin;
-        $this->name = (string) $name;
+        $this->fin   = clone $fin;
+        $this->name  = (string) $name;
         $this->title = (string) $title;
         $this->class = (string) $class;
     }

--- a/App/Libraries/Calendrier/Fournisseur.php
+++ b/App/Libraries/Calendrier/Fournisseur.php
@@ -1,9 +1,9 @@
 <?php
 namespace App\Libraries\Calendrier;
 
+use \App\Libraries\Calendrier\BusinessCollection;
 use \CalendR\Event\EventInterface;
 use \CalendR\Event\Provider\ProviderInterface;
-use \App\Libraries\Calendrier\BusinessCollection;
 
 /**
  * Fournisseur d'événements pour le calendrier

--- a/App/Libraries/Notification/Additionnelle.php
+++ b/App/Libraries/Notification/Additionnelle.php
@@ -4,15 +4,17 @@ namespace App\Libraries\Notification;
 
 /**
  * Objet de gestion des notifications
- * 
- * 
+ *
+ *
  */
-Class Additionnelle extends \App\Libraries\ANotification {
+class Additionnelle extends \App\Libraries\ANotification
+{
 
     /**
      * {@inheritDoc}
      */
-    protected function getData($id) {
+    protected function getData($id)
+    {
 
         if (empty($id)) {
             return [];
@@ -23,11 +25,11 @@ Class Additionnelle extends \App\Libraries\ANotification {
                 WHERE id_heure =' . (int) $id;
 
         $data = $sql->query($req)->fetch_array();
-        
-        $data['jour']   = date('d/m/Y', $data['debut']);
-        $data['debut']  = date('H\:i', $data['debut']);
-        $data['fin']    = date('H\:i', $data['fin']);
-        $data['duree']    = \App\Helpers\Formatter::Timestamp2Duree($data['duree']);
+
+        $data['jour']  = date('d/m/Y', $data['debut']);
+        $data['debut'] = date('H\:i', $data['debut']);
+        $data['fin']   = date('H\:i', $data['fin']);
+        $data['duree'] = \App\Helpers\Formatter::Timestamp2Duree($data['duree']);
 
         return $data;
     }
@@ -35,19 +37,20 @@ Class Additionnelle extends \App\Libraries\ANotification {
     /**
      * {@inheritDoc}
      */
-    protected function getContenuDemande($data) {
+    protected function getContenuDemande($data)
+    {
 
         $return['sujet'] = "[CONGES] Demande d'heure additionnelle";
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
+        $infoUser        = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
 
         $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
-        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
-        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
+        $return['expediteur']['nom']  = $infoUser['u_nom'] . " " . $infoUser['u_prenom'];
+        $responsables                 = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " solicite une demande d'ajout d'heure additionnelle pour le ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] ." soit ". $data['duree'] ." heure(s). Vous devez traiter cette demande";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " solicite une demande d'ajout d'heure additionnelle pour le " . $data['jour'] . " de " . $data['debut'] . " à " . $data['fin'] . " soit " . $data['duree'] . " heure(s). Vous devez traiter cette demande";
 
         $return['config'] = 'mail_new_demande_alerte_resp';
         return $return;
@@ -56,15 +59,16 @@ Class Additionnelle extends \App\Libraries\ANotification {
     /**
      * {@inheritDoc}
      */
-    protected function getContenuEmployePremierValidation($data) {
+    protected function getContenuEmployePremierValidation($data)
+    {
 
-        $return['sujet'] = "[CONGES] Première validation d'heure additionnelle";
+        $return['sujet']              = "[CONGES] Première validation d'heure additionnelle";
         $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
-        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
+        $infoUser                     = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom']  = $infoUser['u_nom'] . " " . $infoUser['u_prenom'];
+        $return['destinataire'][]     = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé(e) votre demande d'heure additionnelle du  ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .". Il doit maintenant être traité en deuxième validation.";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé(e) votre demande d'heure additionnelle du  " . $data['jour'] . " de " . $data['debut'] . " à " . $data['fin'] . ". Il doit maintenant être traité en deuxième validation.";
 
         $return['config'] = 'mail_prem_valid_conges_alerte_user';
         return $return;
@@ -73,76 +77,80 @@ Class Additionnelle extends \App\Libraries\ANotification {
     /**
      * {@inheritDoc}
      */
-    protected function getContenuValidationFinale($data) {
+    protected function getContenuValidationFinale($data)
+    {
 
-        $return['sujet'] = "[CONGES] Demande d'heure additionnelle validée";
+        $return['sujet']              = "[CONGES] Demande d'heure additionnelle validée";
         $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
-        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
+        $infoUser                     = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom']  = $infoUser['u_nom'] . " " . $infoUser['u_prenom'];
+        $return['destinataire'][]     = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure additionnelle du ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure additionnelle du " . $data['jour'] . " de " . $data['debut'] . " à " . $data['fin'] . ".";
 
         $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
     }
-    
+
     /**
      * {@inheritDoc}
      */
-    protected function getContenuRefus($data) {
+    protected function getContenuRefus($data)
+    {
 
-        $return['sujet'] = "[CONGES] Demande d'heure additionnelle refusée";
+        $return['sujet']              = "[CONGES] Demande d'heure additionnelle refusée";
         $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
-        $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['expediteur']['nom'] = $infoResp['u_nom']." ".$infoResp['u_prenom'];
-        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
+        $infoResp                     = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom']  = $infoResp['u_nom'] . " " . $infoResp['u_prenom'];
+        $return['destinataire'][]     = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
-        $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure additionnelle du ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
+        $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure additionnelle du " . $data['jour'] . " de " . $data['debut'] . " à " . $data['fin'] . ".";
 
-        if(!is_null($data['comment_refus'])){
+        if (!is_null($data['comment_refus'])) {
             $return['message'] .= "\nCommentaire : " . $data['comment_refus'];
         }
-        
+
         $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
     }
-    
+
     /**
      * {@inheritDoc}
      */
-    protected function getContenuAnnulation($data) {
+    protected function getContenuAnnulation($data)
+    {
 
-        $return['sujet'] = "[CONGES] Demande d'heure additionnelle annulée";
+        $return['sujet']              = "[CONGES] Demande d'heure additionnelle annulée";
         $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
-        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
-        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
+        $responsables                 = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
+        $infoUser                     = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
+        $return['expediteur']['nom']  = $infoUser['u_nom'] . " " . $infoUser['u_prenom'];
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a annulé(e) la demande d'heure additionnelle du  ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a annulé(e) la demande d'heure additionnelle du  " . $data['jour'] . " de " . $data['debut'] . " à " . $data['fin'] . ".";
 
         $return['config'] = 'mail_supp_demande_alerte_resp';
         return $return;
     }
-    
+
     /**
      * {@inheritDoc}
      */
-    protected function getContenuGrandResponsablePremiereValidation($data) {
-        $return['sujet'] = "[CONGES] Demande d'heure additionnelle";
+    protected function getContenuGrandResponsablePremiereValidation($data)
+    {
+        $return['sujet']              = "[CONGES] Demande d'heure additionnelle";
         $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
-        $grandResponsables = \App\ProtoControllers\Responsable::getLoginGrandResponsableUtilisateur($data['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
-        $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['expediteur']['nom'] = $infoResp['u_nom']." ".$infoResp['u_prenom'];
+        $grandResponsables            = \App\ProtoControllers\Responsable::getLoginGrandResponsableUtilisateur($data['login']);
+        $infoUser                     = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
+        $infoResp                     = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom']  = $infoResp['u_nom'] . " " . $infoResp['u_prenom'];
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-    $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a validé(e) la demande d'ajout d'heure additionnelle de ".$infoUser['u_prenom']." ".$infoUser['u_nom']." pour le ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] ." soit ". $data['duree'] ." heure(s). Vous devez traiter cette demande";
+        $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a validé(e) la demande d'ajout d'heure additionnelle de " . $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " pour le " . $data['jour'] . " de " . $data['debut'] . " à " . $data['fin'] . " soit " . $data['duree'] . " heure(s). Vous devez traiter cette demande";
 
         $return['config'] = 'mail_new_demande_alerte_resp';
         return $return;

--- a/App/Libraries/Notification/Repos.php
+++ b/App/Libraries/Notification/Repos.php
@@ -4,16 +4,17 @@ namespace App\Libraries\Notification;
 
 /**
  * Objet de gestion des notifications
- * 
- * 
+ *
+ *
  */
-Class Repos extends \App\Libraries\ANotification {
-
+class Repos extends \App\Libraries\ANotification
+{
 
     /**
      * {@inheritDoc}
      */
-    protected function getData($id) {
+    protected function getData($id)
+    {
 
         if (empty($id)) {
             return [];
@@ -24,11 +25,11 @@ Class Repos extends \App\Libraries\ANotification {
                 WHERE id_heure =' . (int) $id;
 
         $data = $sql->query($req)->fetch_array();
-        
-        $data['jour']   = date('d/m/Y', $data['debut']);
-        $data['debut']  = date('H\:i', $data['debut']);
-        $data['fin']    = date('H\:i', $data['fin']);
-        $data['duree']    = \App\Helpers\Formatter::Timestamp2Duree($data['duree']);
+
+        $data['jour']  = date('d/m/Y', $data['debut']);
+        $data['debut'] = date('H\:i', $data['debut']);
+        $data['fin']   = date('H\:i', $data['fin']);
+        $data['duree'] = \App\Helpers\Formatter::Timestamp2Duree($data['duree']);
 
         return $data;
     }
@@ -36,19 +37,20 @@ Class Repos extends \App\Libraries\ANotification {
     /**
      * {@inheritDoc}
      */
-    protected function getContenuDemande($data) {
+    protected function getContenuDemande($data)
+    {
 
-        $return['sujet'] = "[CONGES] Demande d'heure de repos";
+        $return['sujet']              = "[CONGES] Demande d'heure de repos";
         $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
-        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
-        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
+        $responsables                 = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
+        $infoUser                     = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
+        $return['expediteur']['nom']  = $infoUser['u_nom'] . " " . $infoUser['u_prenom'];
 
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " solicite une demande d'ajout d'heure de repos pour le ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] ." soit ". $data['duree'] ." heure(s). Vous devez traiter cette demande";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " solicite une demande d'ajout d'heure de repos pour le " . $data['jour'] . " de " . $data['debut'] . " à " . $data['fin'] . " soit " . $data['duree'] . " heure(s). Vous devez traiter cette demande";
 
         $return['config'] = 'mail_new_demande_alerte_resp';
         return $return;
@@ -57,95 +59,100 @@ Class Repos extends \App\Libraries\ANotification {
     /**
      * {@inheritDoc}
      */
-    protected function getContenuEmployePremierValidation($data) {
+    protected function getContenuEmployePremierValidation($data)
+    {
 
-        $return['sujet'] = "[CONGES] Première validation d'heure de repos";
+        $return['sujet']              = "[CONGES] Première validation d'heure de repos";
         $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
+        $infoUser                     = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom']  = $infoUser['u_nom'] . " " . $infoUser['u_prenom'];
 
         $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé(e) votre demande d'heure de repos du  ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .". Il doit maintenant être traité en deuxième validation.";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a validé(e) votre demande d'heure de repos du  " . $data['jour'] . " de " . $data['debut'] . " à " . $data['fin'] . ". Il doit maintenant être traité en deuxième validation.";
 
         $return['config'] = 'mail_prem_valid_conges_alerte_user';
         return $return;
     }
-    
+
     /**
      * {@inheritDoc}
      */
-    protected function getContenuValidationFinale($data) {
+    protected function getContenuValidationFinale($data)
+    {
 
-        $return['sujet'] = "[CONGES] Demande d'heure de repos validée";
+        $return['sujet']              = "[CONGES] Demande d'heure de repos validée";
         $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
-        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
+        $infoUser                     = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom']  = $infoUser['u_nom'] . " " . $infoUser['u_prenom'];
+        $return['destinataire'][]     = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure de repos du ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a accepté la demande d'heure de repos du " . $data['jour'] . " de " . $data['debut'] . " à " . $data['fin'] . ".";
 
         $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
     }
-    
+
     /**
      * {@inheritDoc}
      */
-    protected function getContenuRefus($data) {
+    protected function getContenuRefus($data)
+    {
 
-        $return['sujet'] = "[CONGES] Demande d'heure de repos refusée";
+        $return['sujet']              = "[CONGES] Demande d'heure de repos refusée";
         $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
-        $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['expediteur']['nom'] = $infoResp['u_nom']." ".$infoResp['u_prenom'];
-        $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
+        $infoResp                     = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom']  = $infoResp['u_nom'] . " " . $infoResp['u_prenom'];
+        $return['destinataire'][]     = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
 
-        $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure de repos du ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
+        $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a refusé(e) votre demande d'heure de repos du " . $data['jour'] . " de " . $data['debut'] . " à " . $data['fin'] . ".";
 
-        if(!is_null($data['comment_refus'])){
+        if (!is_null($data['comment_refus'])) {
             $return['message'] .= "\nCommentaire : " . $data['comment_refus'];
         }
-        
+
         $return['config'] = 'mail_valid_conges_alerte_user';
         return $return;
     }
-    
+
     /**
      * {@inheritDoc}
      */
-    protected function getContenuAnnulation($data) {
+    protected function getContenuAnnulation($data)
+    {
 
-        $return['sujet'] = "[CONGES] Demande d'heure de repos annulée";
+        $return['sujet']              = "[CONGES] Demande d'heure de repos annulée";
         $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($data['login']);
-        $responsables = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
-        $return['expediteur']['nom'] = $infoUser['u_nom']." ".$infoUser['u_prenom'];
+        $responsables                 = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($data['login']);
+        $infoUser                     = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
+        $return['expediteur']['nom']  = $infoUser['u_nom'] . " " . $infoUser['u_prenom'];
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a annulé(e) la demande d'heure de repos du  ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] .".";
+        $return['message'] = $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " a annulé(e) la demande d'heure de repos du  " . $data['jour'] . " de " . $data['debut'] . " à " . $data['fin'] . ".";
 
         $return['config'] = 'mail_supp_demande_alerte_resp';
         return $return;
     }
-    
+
     /**
      * {@inheritDoc}
      */
-    protected function getContenuGrandResponsablePremiereValidation($data) {
-        $return['sujet'] = "[CONGES] Demande d'heure de repos";
+    protected function getContenuGrandResponsablePremiereValidation($data)
+    {
+        $return['sujet']              = "[CONGES] Demande d'heure de repos";
         $return['expediteur']['mail'] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($_SESSION['userlogin']);
-        $grandResponsables = \App\ProtoControllers\Responsable::getLoginGrandResponsableUtilisateur($data['login']);
-        $infoUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
-        $infoResp = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
-        $return['expediteur']['nom'] = $infoResp['u_nom']." ".$infoResp['u_prenom'];
+        $grandResponsables            = \App\ProtoControllers\Responsable::getLoginGrandResponsableUtilisateur($data['login']);
+        $infoUser                     = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($data['login']);
+        $infoResp                     = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($_SESSION['userlogin']);
+        $return['expediteur']['nom']  = $infoResp['u_nom'] . " " . $infoResp['u_prenom'];
 
         foreach ($responsables as $responsable) {
             $return['destinataire'][] = \App\ProtoControllers\Utilisateur::getEmailUtilisateur($responsable);
         }
 
-    $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a validé(e) la demande d'ajout d'heure de repos de ".$infoUser['u_prenom']." ".$infoUser['u_nom']." pour le ". $data['jour'] ." de ". $data['debut'] ." à ". $data['fin'] ." soit ". $data['duree'] ." heure(s). Vous devez traiter cette demande";
+        $return['message'] = $infoResp['u_prenom'] . " " . $infoResp['u_nom'] . " a validé(e) la demande d'ajout d'heure de repos de " . $infoUser['u_prenom'] . " " . $infoUser['u_nom'] . " pour le " . $data['jour'] . " de " . $data['debut'] . " à " . $data['fin'] . " soit " . $data['duree'] . " heure(s). Vous devez traiter cette demande";
 
         $return['config'] = 'mail_new_demande_alerte_resp';
         return $return;

--- a/App/Libraries/Structure/HtmlElement.php
+++ b/App/Libraries/Structure/HtmlElement.php
@@ -103,7 +103,7 @@ abstract class HtmlElement implements Interfaces\IHtmlElement
      * @inheritdoc
      * @see Interfaces\IRenderable
      */
-    public abstract function render();
+    abstract public function render();
 
     /**
      * Render les classes de l'élément

--- a/App/Libraries/Structure/Table.php
+++ b/App/Libraries/Structure/Table.php
@@ -27,12 +27,12 @@ class Table extends HtmlElement implements Interfaces\IHeritable
      */
     public function render()
     {
-        echo '<table id="' .  $this->getId() . '"';
+        echo '<table id="' . $this->getId() . '"';
         $this->renderClasses();
         $this->renderAttributes();
         echo '>';
         foreach ($this->children as $child) {
-            if ($child instanceOf Interfaces\IRenderable) {
+            if ($child instanceof Interfaces\IRenderable) {
                 $child->render();
             } else {
                 /* 1.9 TODO: On peut ajouter n'importe quel fils quitte à faire n'importe quoi,

--- a/App/Models/AHeure.php
+++ b/App/Models/AHeure.php
@@ -1,5 +1,6 @@
 <?php
 namespace App\Models;
+
 /**
  * Modèle d'heures
  *
@@ -19,32 +20,32 @@ abstract class AHeure
      * Constante de statut de première validation
      * @var string
      */
-    const STATUT_PREMIERE_VALIDATION  = 2;
+    const STATUT_PREMIERE_VALIDATION = 2;
 
     /**
      * Constante de statut de seconde validation
      * @var string
      */
-    const STATUT_VALIDATION_FINALE      = 3;
+    const STATUT_VALIDATION_FINALE = 3;
 
     /**
      * Constante de refus par l'un des validateurs
      * @var string
      */
-    const STATUT_REFUS   = 4;
+    const STATUT_REFUS = 4;
 
     /**
      * Constante d'annulation par l'employé
      * @var string
      */
-    const STATUT_ANNUL   = 5;
+    const STATUT_ANNUL = 5;
 
     /**
      * Constantes du formulaire de traitement des demandes
      * à terme, vu que c'est une logique métier qui dépend de plusieurs modèles, à mettre dans un service ou une spécification
      */
-    const ACCEPTE       = '1';
-    const REFUSE        = '2';
+    const ACCEPTE = '1';
+    const REFUSE  = '2';
 
     /**
      * Retourne les options de select des statuts
@@ -58,7 +59,7 @@ abstract class AHeure
             static::STATUT_PREMIERE_VALIDATION,
             static::STATUT_VALIDATION_FINALE,
             static::STATUT_REFUS,
-            static::STATUT_ANNUL
+            static::STATUT_ANNUL,
         ];
         $options = [];
         foreach ($statuts as $value) {

--- a/App/Models/Conge.php
+++ b/App/Models/Conge.php
@@ -50,8 +50,8 @@ class Conge
      * Constantes du formulaire de traitement des demandes
      * à terme, vu que c'est une logique métier qui dépend de plusieurs modèles, à mettre dans un service ou une spécification
      */
-    const ACCEPTE       = '1';
-    const REFUSE        = '2';
+    const ACCEPTE = '1';
+    const REFUSE  = '2';
 
     /**
      * Retourne les options de select des statuts
@@ -65,7 +65,7 @@ class Conge
             static::STATUT_PREMIERE_VALIDATION,
             static::STATUT_VALIDATION_FINALE,
             static::STATUT_REFUS,
-            static::STATUT_ANNUL
+            static::STATUT_ANNUL,
         ];
         $options = [];
         foreach ($statuts as $value) {

--- a/App/Models/Heure/Additionnelle.php
+++ b/App/Models/Heure/Additionnelle.php
@@ -12,7 +12,7 @@ dans un but spécifique. Reportez-vous à la Licence Publique Générale GNU pou
 Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps
 que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation,
 Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, États-Unis.
-*************************************************************************************************
+ *************************************************************************************************
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU General Public License as published by the Free Software Foundation; either
 version 2 of the License, or any later version.
@@ -22,7 +22,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-*************************************************************************************************/
+ *************************************************************************************************/
 namespace App\Models\Heure;
 
 /**

--- a/App/Models/Heure/Repos.php
+++ b/App/Models/Heure/Repos.php
@@ -12,7 +12,7 @@ dans un but spécifique. Reportez-vous à la Licence Publique Générale GNU pou
 Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps
 que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation,
 Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, États-Unis.
-*************************************************************************************************
+ *************************************************************************************************
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU General Public License as published by the Free Software Foundation; either
 version 2 of the License, or any later version.
@@ -22,7 +22,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-*************************************************************************************************/
+ *************************************************************************************************/
 namespace App\Models\Heure;
 
 /**

--- a/App/Models/Planning.php
+++ b/App/Models/Planning.php
@@ -13,7 +13,7 @@ dans un but spécifique. Reportez-vous à la Licence Publique Générale GNU pou
 Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps
 que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation,
 Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, États-Unis.
-*************************************************************************************************
+ *************************************************************************************************
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU General Public License as published by the Free Software Foundation; either
 version 2 of the License, or any later version.
@@ -23,7 +23,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-*************************************************************************************************/
+ *************************************************************************************************/
 namespace App\Models;
 
 /**
@@ -39,6 +39,6 @@ class Planning
      *
      * @var int
      */
-    const STATUS_ACTIVE = STATUS_ACTIVE;
+    const STATUS_ACTIVE  = STATUS_ACTIVE;
     const STATUS_DELETED = STATUS_DELETED;
 }

--- a/App/Models/Planning/Creneau.php
+++ b/App/Models/Planning/Creneau.php
@@ -19,14 +19,14 @@ class Creneau
     /**
      * @var int Types d'heures
      */
-    const TYPE_HEURE_DEBUT     = 1;
-    const TYPE_HEURE_FIN       = 2;
+    const TYPE_HEURE_DEBUT = 1;
+    const TYPE_HEURE_FIN   = 2;
 
     /**
      * @var int Types de périodes
      */
-    const TYPE_PERIODE_MATIN      = 1;
-    const TYPE_PERIODE_APRES_MIDI = 2;
+    const TYPE_PERIODE_MATIN            = 1;
+    const TYPE_PERIODE_APRES_MIDI       = 2;
     const TYPE_PERIODE_MATIN_APRES_MIDI = 3;
 
     public static function getListeTypePeriode()

--- a/App/ProtoControllers/APlanning.php
+++ b/App/ProtoControllers/APlanning.php
@@ -27,9 +27,9 @@ class APlanning
         $utilisateursAssocies = array_map(
             function ($utilisateur) {
                 return [
-                    'login' => $utilisateur['u_login'],
-                    'nom' => $utilisateur['u_nom'],
-                    'prenom' => $utilisateur['u_prenom'],
+                    'login'      => $utilisateur['u_login'],
+                    'nom'        => $utilisateur['u_nom'],
+                    'prenom'     => $utilisateur['u_prenom'],
                     'planningId' => (int) $utilisateur['planning_id'],
                 ];
             },

--- a/App/ProtoControllers/Calendrier.php
+++ b/App/ProtoControllers/Calendrier.php
@@ -69,13 +69,13 @@ final class Calendrier
 
     public function __construct()
     {
-        $this->session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
+        $this->session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-        if(substr($this->session, 0, 9)!="phpconges") {
+        if (substr($this->session, 0, 9) != "phpconges") {
             session_start();
-            $_SESSION['config']=init_config_tab();
-            if(empty($_SESSION['userlogin'])) {
-                redirect( ROOT_PATH . 'index.php' );
+            $_SESSION['config'] = init_config_tab();
+            if (empty($_SESSION['userlogin'])) {
+                redirect(ROOT_PATH . 'index.php');
             }
         } else {
             include_once INCLUDE_PATH . 'session.php';
@@ -134,7 +134,7 @@ final class Calendrier
             $this->dateFinMaintenant = $this->dateDebutMaintenant->modify('+1 week');
         } else {
             $this->dateDebutMaintenant = new \DateTimeImmutable(date('Y') . '-' . date('m') . '-01');
-            $this->dateFinMaintenant = $this->dateDebutMaintenant->modify('+1 month');
+            $this->dateFinMaintenant   = $this->dateDebutMaintenant->modify('+1 month');
         }
     }
 
@@ -163,21 +163,21 @@ final class Calendrier
 
         foreach ($this->getOptionsVue() as $valeur => $label) {
             $selected = ($valeur === $this->vue)
-                ? 'selected="selected"'
-                : '';
+            ? 'selected="selected"'
+            : '';
             $form .= '<option value="' . $valeur . '" ' . $selected . '>' . _($label) . '</option>';
         }
         $form .= '</select></div></div>';
-        if($_SESSION['config']['gestion_groupes']) {
+        if ($_SESSION['config']['gestion_groupes']) {
             $form .= '<div class="form-group col-md-4 col-sm-5">
             <label class="control-label col-md-3 col-sm-3" for="groupe">Groupe&nbsp;:</label>
             <div class="col-md-8 col-sm-8"><select class="form-control" name="search[groupe]" id="groupe">';
             $form .= '<option value="' . NIL_INT . '">Tous</option>';
 
             foreach (\App\ProtoControllers\Groupe::getOptions() as $id => $groupe) {
-                $selected = ($id ===  $this->idGroupe)
-                    ? 'selected="selected"'
-                    : '';
+                $selected = ($id === $this->idGroupe)
+                ? 'selected="selected"'
+                : '';
                 $form .= '<option value="' . $id . '" ' . $selected . '>' . $groupe['nom'] . '</option>';
             }
             $form .= '</select></div></div>';
@@ -199,7 +199,7 @@ final class Calendrier
     private function getOptionsVue()
     {
         return [
-            static::VUE_MOIS => 'vue_mois',
+            static::VUE_MOIS    => 'vue_mois',
             static::VUE_SEMAINE => 'vue_semaine',
         ];
     }
@@ -220,7 +220,7 @@ final class Calendrier
             $this->idGroupe
         );
         $fournisseur = new \App\Libraries\Calendrier\Fournisseur($businessCollection);
-        $calendar = new \CalendR\Calendar();
+        $calendar    = new \CalendR\Calendar();
         $calendar->getEventManager()->addProvider('provider', $fournisseur);
         /* Suis pas fan de la répartition par if, mais ça a l'air de faire le job */
         if (static::VUE_SEMAINE === $this->vue) {
@@ -249,8 +249,8 @@ final class Calendrier
     private function setPeriodesSemaine()
     {
         $this->dateDebutPrecedente = $this->dateDebut->modify('-1 week');
-        $this->dateFin = $this->dateDebut->modify('+1 week');
-        $this->dateFinSuivante = $this->dateFin->modify('+1 week');
+        $this->dateFin             = $this->dateDebut->modify('+1 week');
+        $this->dateFinSuivante     = $this->dateFin->modify('+1 week');
     }
 
     /**
@@ -259,7 +259,7 @@ final class Calendrier
     private function setPeriodesMois()
     {
         $this->dateDebutPrecedente = $this->dateDebut->modify('-1 month');
-        $this->dateFinSuivante = $this->dateFin->modify('+1 month');
+        $this->dateFinSuivante     = $this->dateFin->modify('+1 month');
     }
 
     /**
@@ -272,7 +272,7 @@ final class Calendrier
     private function getCalendrierSemaine(\CalendR\Calendar $calendar)
     {
         /* TODO: La lib ne gère pas les immutables, faire une PR */
-        $week = $calendar->getWeek(new \DateTime($this->dateDebut->format('Y-m-d')));
+        $week            = $calendar->getWeek(new \DateTime($this->dateDebut->format('Y-m-d')));
         $eventCollection = $calendar->getEvents($week);
 
         $return = '<h2>Semaine ' . $week->getBegin()->format('W – Y') . '</h2>';
@@ -295,8 +295,8 @@ final class Calendrier
             foreach ($eventCollection->find($day) as $event) {
                 /* Suppression des événements qui sont plus fins que la journée */
                 if ($event->getBegin() <= $day->getBegin()) {
-                    $title = $event->getTitle();
-                    $avecTitle = (!empty($title)) ? 'evenement-avec-title': '';
+                    $title     = $event->getTitle();
+                    $avecTitle = (!empty($title)) ? 'evenement-avec-title' : '';
                     $return .= '<div class="' . $avecTitle . ' ' . $event->getClass() . '"
                     title="' . $title . '"><div class="contenu">' . $event->getName() . '</div>';
                     /* Un événement qui se termine est forcément avant la fin de la journée */
@@ -317,8 +317,8 @@ final class Calendrier
                             if ($event->getBegin() > $day->getBegin()
                                 && $event->containsPeriod($minute)
                             ) {
-                                $title = $event->getTitle();
-                                $avecTitle = (!empty($title)) ? 'evenement-avec-title': '';
+                                $title               = $event->getTitle();
+                                $avecTitle           = (!empty($title)) ? 'evenement-avec-title' : '';
                                 $evenementsPeriode[] = '<div class="' . $avecTitle . ' ' . $event->getClass() . '"
                                 title="' . $title . '"><div class="contenu">' . $event->getName() . '</div>';
                                 /* Un événement qui se termine est forcément avant la fin de la période */
@@ -332,8 +332,8 @@ final class Calendrier
                             $inflated[$minute->format('H\:i')] = true;
                         }
                         $toInflate = (isset($inflated[$minute->format('H\:i')]) && $inflated[$minute->format('H\:i')])
-                            ? 'inflate'
-                            : '';
+                        ? 'inflate'
+                        : '';
                         $return .= '<div class="celluleMinute ' . $toInflate . '">' . implode('', $evenementsPeriode) . '</div>';
                     }
                 }
@@ -347,8 +347,8 @@ final class Calendrier
                 foreach ($hour as $minute) {
                     if (0 === $minute->format('i') % 30) {
                         $toInflate = (isset($inflated[$minute->format('H\:i')]) && $inflated[$minute->format('H\:i')])
-                            ? 'inflate'
-                            : '';
+                        ? 'inflate'
+                        : '';
                         $return .= '<div class="celluleMinute ' . $toInflate . '">' . $minute->format('H\:i') . '</div>';
                     }
                 }
@@ -371,7 +371,7 @@ final class Calendrier
     private function getCalendrierMois(\CalendR\Calendar $calendar)
     {
         /* TODO: La lib ne gère pas les immutables, faire une PR */
-        $month = $calendar->getMonth(new \DateTime($this->dateDebut->format('Y-m-d')));
+        $month           = $calendar->getMonth(new \DateTime($this->dateDebut->format('Y-m-d')));
         $eventCollection = $calendar->getEvents($month);
 
         $return = '<h2>' . strftime('%B %G', $month->getBegin()->getTimestamp()) . '</h2>';
@@ -396,8 +396,8 @@ final class Calendrier
                 $return .= '<div class="jourId ' . $today . '">' . $day->getBegin()->format('j') . '</div>';
                 /* Tous les événements qui sont contenus dans des jours */
                 foreach ($eventCollection->find($day) as $event) {
-                    $title = $event->getTitle();
-                    $avecTitle = (!empty($title)) ? 'evenement-avec-title': '';
+                    $title     = $event->getTitle();
+                    $avecTitle = (!empty($title)) ? 'evenement-avec-title' : '';
                     $return .= '<div class="' . $avecTitle . ' ' . $event->getClass() . '"
                     title="' . $title . '"><div class="contenu">' . $event->getName() . '</div>';
                     /* Un événement qui se termine est forcément avant la fin de la journée */
@@ -421,9 +421,9 @@ final class Calendrier
     private function getNavigation()
     {
         $urlCalendrier = ROOT_PATH . 'calendrier.php';
-        $queryBase = [
-            'session' => $this->session,
-            'search[vue]' => $this->vue,
+        $queryBase     = [
+            'session'        => $this->session,
+            'search[vue]'    => $this->vue,
             'search[groupe]' => $this->idGroupe,
         ];
         $queryPrec = [

--- a/App/ProtoControllers/Conge.php
+++ b/App/ProtoControllers/Conge.php
@@ -17,15 +17,15 @@ class Conge
      */
     public function getListe()
     {
-        $return = '';
-        $errorsLst=[];
-        if($_SESSION['config']['where_to_find_user_email']=="ldap"){
-            include_once CONFIG_PATH .'config_ldap.php';
+        $return    = '';
+        $errorsLst = [];
+        if ($_SESSION['config']['where_to_find_user_email'] == "ldap") {
+            include_once CONFIG_PATH . 'config_ldap.php';
         }
 
-        if(!empty($_POST) && !$this->isSearch($_POST)) {
+        if (!empty($_POST) && !$this->isSearch($_POST)) {
             if (0 < (int) \utilisateur\Fonctions::postDemandeCongesHeure($_POST, $errorsLst)) {
-                $return .= '<div class="alert alert-info">'._('suppr_succes').'</div>';
+                $return .= '<div class="alert alert-info">' . _('suppr_succes') . '</div>';
             }
         }
         // on initialise le tableau global des jours fériés s'il ne l'est pas déjà :
@@ -40,7 +40,7 @@ class Conge
             $champsRecherche = [
                 'type' => 'cp',
             ];
-            $champsSql       = [];
+            $champsSql = [];
         }
         $params = $champsSql + [
             'p_login' => $_SESSION['userlogin'],
@@ -48,7 +48,7 @@ class Conge
             'p_etat'  => 'demande',
         ]; // champs par défaut écrasés par postés
 
-        $return.= $this->getFormulaireRecherche($champsRecherche);
+        $return .= $this->getFormulaireRecherche($champsRecherche);
 
         $table = new \App\Libraries\Structure\Table();
         $table->addClasses([
@@ -58,19 +58,19 @@ class Conge
             'table-condensed',
             'table-striped',
         ]);
-        $childTable = '<thead><tr><th>' . _('divers_debut_maj_1') . '</th><th>'. _('divers_fin_maj_1') .'</th><th>'. _('divers_type_maj_1') .'</th><th>'. _('divers_nb_jours_pris_maj_1') .'</th><th>Statut</th><th></th><th></th>';
+        $childTable = '<thead><tr><th>' . _('divers_debut_maj_1') . '</th><th>' . _('divers_fin_maj_1') . '</th><th>' . _('divers_type_maj_1') . '</th><th>' . _('divers_nb_jours_pris_maj_1') . '</th><th>Statut</th><th></th><th></th>';
         $childTable .= '</tr>';
         $childTable .= '</thead><tbody>';
-        $listId = $this->getListeId($params);
+        $listId  = $this->getListeId($params);
         $session = session_id();
         if (empty($listId)) {
             $colonnes = 8;
-            $childTable .= '<tr><td colspan="' . $colonnes . '"><center>' . _('aucun_resultat') .'</center></td></tr>';
+            $childTable .= '<tr><td colspan="' . $colonnes . '"><center>' . _('aucun_resultat') . '</center></td></tr>';
         } else {
-            $i = true;
-            $listeConges = $this->getListeSQL($listId);
+            $i                        = true;
+            $listeConges              = $this->getListeSQL($listId);
             $interdictionModification = $_SESSION['config']['interdit_modif_demande'];
-            $affichageDateTraitement = $_SESSION['config']['affiche_date_traitement'];
+            $affichageDateTraitement  = $_SESSION['config']['affiche_date_traitement'];
             foreach ($listeConges as $conges) {
                 /** Dates demande / traitement */
                 $dateDemande = '';
@@ -78,11 +78,11 @@ class Conge
                 if ($affichageDateTraitement) {
                     if (!empty($conges["p_date_demande"])) {
                         list($date, $heure) = explode(' ', $conges["p_date_demande"]);
-                        $dateDemande = '(' . \App\Helpers\Formatter::dateIso2Fr($date) . ' ' . $heure . ') ';
+                        $dateDemande        = '(' . \App\Helpers\Formatter::dateIso2Fr($date) . ' ' . $heure . ') ';
                     }
-                    if(null != $conges["p_date_traitement"]) {
+                    if (null != $conges["p_date_traitement"]) {
                         list($date, $heure) = explode(' ', $conges["p_date_traitement"]);
-                        $dateReponse = '(' . \App\Helpers\Formatter::dateIso2Fr($date) . ' ' . $heure . ') ';
+                        $dateReponse        = '(' . \App\Helpers\Formatter::dateIso2Fr($date) . ' ' . $heure . ') ';
                     }
                 }
 
@@ -98,33 +98,33 @@ class Conge
                     $messageReponse = '';
                 }
 
-                $demi_j_deb = ($conges["p_demi_jour_deb"]=="am") ? 'matin' : 'après-midi';
+                $demi_j_deb = ($conges["p_demi_jour_deb"] == "am") ? 'matin' : 'après-midi';
 
-                $demi_j_fin = ($conges["p_demi_jour_fin"] =="am") ? 'matin' : 'après-midi';
-                $user_modif_demande="&nbsp;";
+                $demi_j_fin         = ($conges["p_demi_jour_fin"] == "am") ? 'matin' : 'après-midi';
+                $user_modif_demande = "&nbsp;";
 
                 // si on peut modifier une demande :on defini le lien à afficher
-                if( !$interdictionModification && $conges["p_etat"] != "valid") {
+                if (!$interdictionModification && $conges["p_etat"] != "valid") {
                     //on ne peut pas modifier une demande qui a déja été validé une fois (si on utilise la double validation)
-                    $user_modif_demande = '<a href="user_index.php?session=' . $session . '&p_num=' . $conges['p_num'] . '&onglet=modif_demande">' . _('form_modif') . '</a>' ;
+                    $user_modif_demande = '<a href="user_index.php?session=' . $session . '&p_num=' . $conges['p_num'] . '&onglet=modif_demande">' . _('form_modif') . '</a>';
                 }
                 $user_suppr_demande = '<a href="user_index.php?session=' . $session . '&p_num=' . $conges['p_num'] . '&onglet=suppr_demande">' . _('form_supprim') . '</a>';
-                $childTable .= '<tr class="'.($i?'i':'p').'">';
+                $childTable .= '<tr class="' . ($i ? 'i' : 'p') . '">';
                 $childTable .= '<td class="histo">' . \App\Helpers\Formatter::dateIso2Fr($conges["p_date_deb"]) . ' <span class="demi">' . schars($demi_j_deb) . '</span></td>';
-                $childTable .= '<td class="histo">' . \App\Helpers\Formatter::dateIso2Fr($conges["p_date_fin"]) . ' <span class="demi">' . schars($demi_j_fin) . '</span></td>' ;
-                $childTable .= '<td class="histo">'.schars($conges["ta_libelle"]).'</td>' ;
-                $childTable .= '<td class="histo">'.affiche_decimal($conges["p_nb_jours"]).'</td>' ;
+                $childTable .= '<td class="histo">' . \App\Helpers\Formatter::dateIso2Fr($conges["p_date_fin"]) . ' <span class="demi">' . schars($demi_j_fin) . '</span></td>';
+                $childTable .= '<td class="histo">' . schars($conges["ta_libelle"]) . '</td>';
+                $childTable .= '<td class="histo">' . affiche_decimal($conges["p_nb_jours"]) . '</td>';
                 $childTable .= '<td>' . \App\Models\Conge::statusText($conges["p_etat"]) . '</td>';
                 $childTable .= '<td class="histo">';
                 if (!empty($messageDemande) || !empty($messageReponse)) {
                     $childTable .= '<i class="fa fa-comments" aria-hidden="true" title="' . $messageDemande . "\n\n" . $messageReponse . '"></i>';
                 }
-                $childTable .= '</td>' ;
+                $childTable .= '</td>';
                 $childTable .= '<td class="histo">';
-                if(!$interdictionModification) {
+                if (!$interdictionModification) {
                     $childTable .= $user_modif_demande . '&nbsp;&nbsp;';
                 }
-                $childTable .= ($user_suppr_demande) . '</td>'."\n" ;
+                $childTable .= ($user_suppr_demande) . '</td>' . "\n";
                 $childTable .= '</tr>';
                 $i = !$i;
             }
@@ -160,32 +160,32 @@ class Conge
     protected function getFormulaireRecherche(array $champs)
     {
         $session = session_id();
-        $form = '';
-        $form = '<form method="post" action="" class="form-inline search" role="form">';
+        $form    = '';
+        $form    = '<form method="post" action="" class="form-inline search" role="form">';
         $form .= '<div class="form-group"><label class="control-label col-md-4" for="statut">Statut&nbsp;:</label><div class="col-md-8"><select class="form-control" name="search[p_etat]" id="statut">';
         foreach (\App\Models\Conge::getOptionsStatuts() as $key => $value) {
             $selected = (isset($champs['p_etat']) && $key == $champs['p_etat'])
-                ? 'selected="selected"'
-                : '';
+            ? 'selected="selected"'
+            : '';
             $form .= '<option value="' . $key . '" ' . $selected . '>' . $value . '</option>';
         }
         $form .= '</select></div></div>';
         $form .= '<div class="form-group "><label class="control-label col-md-4" for="type">Type&nbsp;:</label><div class="col-md-8"><select class="form-control" name="search[type]" id="type">';
         foreach (\utilisateur\Fonctions::getOptionsTypeConges() as $key => $value) {
             $selected = (isset($champs['type']) && $key == $champs['type'])
-                ? 'selected="selected"'
-                : '';
+            ? 'selected="selected"'
+            : '';
             $form .= '<option value="' . $key . '" ' . $selected . '>' . $value . '</option>';
         }
         $form .= '</select></div></div>';
         $form .= '<div class="form-group"><label class="control-label col-md-4" for="annee">Année&nbsp;:</label><div class="col-md-8"><select class="form-control" name="search[annee]" id="sel1">';
         foreach (\utilisateur\Fonctions::getOptionsAnnees() as $key => $value) {
             $selected = (isset($champs['annee']) && $key == $champs['annee'])
-                ? 'selected="selected"'
-                : '';
+            ? 'selected="selected"'
+            : '';
             $form .= '<option value="' . $key . '" ' . $selected . '>' . $value . '</option>';
         }
-        $form .= '</select></div></div><div class="form-group"><div class="input-group"><button type="submit" class="btn btn-default"><i class="fa fa-search" aria-hidden="true"></i></button>&nbsp;<a href="' . ROOT_PATH . 'utilisateur/user_index.php?session='. $session . '&onglet=liste_conge" type="reset" class="btn btn-default">Reset</a></div></div></form>';
+        $form .= '</select></div></div><div class="form-group"><div class="input-group"><button type="submit" class="btn btn-default"><i class="fa fa-search" aria-hidden="true"></i></button>&nbsp;<a href="' . ROOT_PATH . 'utilisateur/user_index.php?session=' . $session . '&onglet=liste_conge" type="reset" class="btn btn-default">Reset</a></div></div></form>';
 
         return $form;
     }
@@ -217,13 +217,13 @@ class Conge
      * SQL
      */
 
-     /**
-      * Retourne une liste d'id de congés
-      *
-      * @param array $params Paramètres de recherche
-      *
-      * @return array
-      */
+    /**
+     * Retourne une liste d'id de congés
+     *
+     * @param array $params Paramètres de recherche
+     *
+     * @return array
+     */
     protected function getListeId(array $params)
     {
         if (!empty($params)) {
@@ -250,7 +250,7 @@ class Conge
         $req = 'SELECT p_num AS id
                 FROM conges_periode CP
                     INNER JOIN conges_type_absence CTA ON (CP.p_type = CTA.ta_id) '
-                . ((!empty($where)) ? ' WHERE ' . implode(' AND ', $where) : '');
+            . ((!empty($where)) ? ' WHERE ' . implode(' AND ', $where) : '');
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {
             $ids[] = (int) $data['id'];

--- a/App/ProtoControllers/Employe/Conge.php
+++ b/App/ProtoControllers/Employe/Conge.php
@@ -20,15 +20,15 @@ class Conge
      */
     public function getListe()
     {
-        $return = '';
-        $errorsLst=[];
-        if($_SESSION['config']['where_to_find_user_email']=="ldap"){
-            include_once CONFIG_PATH .'config_ldap.php';
+        $return    = '';
+        $errorsLst = [];
+        if ($_SESSION['config']['where_to_find_user_email'] == "ldap") {
+            include_once CONFIG_PATH . 'config_ldap.php';
         }
 
-        if(!empty($_POST) && !$this->isSearch($_POST)) {
+        if (!empty($_POST) && !$this->isSearch($_POST)) {
             if (0 < (int) \utilisateur\Fonctions::postDemandeCongesHeure($_POST, $errorsLst)) {
-                $return .= '<div class="alert alert-info">'._('suppr_succes').'</div>';
+                $return .= '<div class="alert alert-info">' . _('suppr_succes') . '</div>';
             }
         }
         // on initialise le tableau global des jours fériés s'il ne l'est pas déjà :
@@ -43,7 +43,7 @@ class Conge
             $champsRecherche = [
                 'type' => 'cp',
             ];
-            $champsSql       = [];
+            $champsSql = [];
         }
         $params = $champsSql + [
             'p_login' => $_SESSION['userlogin'],
@@ -51,7 +51,7 @@ class Conge
             'p_etat'  => 'demande',
         ]; // champs par défaut écrasés par postés
 
-        $return.= $this->getFormulaireRecherche($champsRecherche);
+        $return .= $this->getFormulaireRecherche($champsRecherche);
 
         $table = new \App\Libraries\Structure\Table();
         $table->addClasses([
@@ -61,19 +61,19 @@ class Conge
             'table-condensed',
             'table-striped',
         ]);
-        $childTable = '<thead><tr><th>' . _('divers_debut_maj_1') . '</th><th>'. _('divers_fin_maj_1') .'</th><th>'. _('divers_type_maj_1') .'</th><th>'. _('divers_nb_jours_pris_maj_1') .'</th><th>Statut</th><th></th><th></th>';
+        $childTable = '<thead><tr><th>' . _('divers_debut_maj_1') . '</th><th>' . _('divers_fin_maj_1') . '</th><th>' . _('divers_type_maj_1') . '</th><th>' . _('divers_nb_jours_pris_maj_1') . '</th><th>Statut</th><th></th><th></th>';
         $childTable .= '</tr>';
         $childTable .= '</thead><tbody>';
-        $listId = $this->getListeId($params);
+        $listId  = $this->getListeId($params);
         $session = session_id();
         if (empty($listId)) {
             $colonnes = 8;
-            $childTable .= '<tr><td colspan="' . $colonnes . '"><center>' . _('aucun_resultat') .'</center></td></tr>';
+            $childTable .= '<tr><td colspan="' . $colonnes . '"><center>' . _('aucun_resultat') . '</center></td></tr>';
         } else {
-            $i = true;
-            $listeConges = $this->getListeSQL($listId);
+            $i                        = true;
+            $listeConges              = $this->getListeSQL($listId);
             $interdictionModification = $_SESSION['config']['interdit_modif_demande'];
-            $affichageDateTraitement = $_SESSION['config']['affiche_date_traitement'];
+            $affichageDateTraitement  = $_SESSION['config']['affiche_date_traitement'];
             foreach ($listeConges as $conges) {
                 /** Dates demande / traitement */
                 $dateDemande = '';
@@ -81,11 +81,11 @@ class Conge
                 if ($affichageDateTraitement) {
                     if (!empty($conges["p_date_demande"])) {
                         list($date, $heure) = explode(' ', $conges["p_date_demande"]);
-                        $dateDemande = '(' . \App\Helpers\Formatter::dateIso2Fr($date) . ' ' . $heure . ') ';
+                        $dateDemande        = '(' . \App\Helpers\Formatter::dateIso2Fr($date) . ' ' . $heure . ') ';
                     }
-                    if(null != $conges["p_date_traitement"]) {
+                    if (null != $conges["p_date_traitement"]) {
                         list($date, $heure) = explode(' ', $conges["p_date_traitement"]);
-                        $dateReponse = '(' . \App\Helpers\Formatter::dateIso2Fr($date) . ' ' . $heure . ') ';
+                        $dateReponse        = '(' . \App\Helpers\Formatter::dateIso2Fr($date) . ' ' . $heure . ') ';
                     }
                 }
 
@@ -101,38 +101,38 @@ class Conge
                     $messageReponse = '';
                 }
 
-                $demi_j_deb = ($conges["p_demi_jour_deb"]=="am") ? 'matin' : 'après-midi';
+                $demi_j_deb = ($conges["p_demi_jour_deb"] == "am") ? 'matin' : 'après-midi';
 
-                $demi_j_fin = ($conges["p_demi_jour_fin"] =="am") ? 'matin' : 'après-midi';
+                $demi_j_fin = ($conges["p_demi_jour_fin"] == "am") ? 'matin' : 'après-midi';
 
-                $childTable .= '<tr class="'.($i?'i':'p').'">';
+                $childTable .= '<tr class="' . ($i ? 'i' : 'p') . '">';
                 $childTable .= '<td class="histo">' . \App\Helpers\Formatter::dateIso2Fr($conges["p_date_deb"]) . ' <span class="demi">' . schars($demi_j_deb) . '</span></td>';
-                $childTable .= '<td class="histo">' . \App\Helpers\Formatter::dateIso2Fr($conges["p_date_fin"]) . ' <span class="demi">' . schars($demi_j_fin) . '</span></td>' ;
-                $childTable .= '<td class="histo">'.schars($conges["ta_libelle"]).'</td>' ;
-                $childTable .= '<td class="histo">'.affiche_decimal($conges["p_nb_jours"]).'</td>' ;
+                $childTable .= '<td class="histo">' . \App\Helpers\Formatter::dateIso2Fr($conges["p_date_fin"]) . ' <span class="demi">' . schars($demi_j_fin) . '</span></td>';
+                $childTable .= '<td class="histo">' . schars($conges["ta_libelle"]) . '</td>';
+                $childTable .= '<td class="histo">' . affiche_decimal($conges["p_nb_jours"]) . '</td>';
                 $childTable .= '<td>' . \App\Models\Conge::statusText($conges["p_etat"]) . '</td>';
                 $childTable .= '<td class="histo">';
                 if (!empty($messageDemande) || !empty($messageReponse)) {
                     $childTable .= '<i class="fa fa-comments" aria-hidden="true" title="' . $messageDemande . "\n\n" . $messageReponse . '"></i>';
                 }
-                $childTable .= '</td>' ;
+                $childTable .= '</td>';
                 $childTable .= '<td class="histo">';
 
                 $user_modif_demande = '<i class="fa fa-pencil disabled"></i>';
                 $user_suppr_demande = '<i class="fa fa-times-circle disabled"></i>';
 
                 // si on peut modifier une demande on defini le lien à afficher
-                if($conges["p_etat"] == \App\Models\Conge::STATUT_DEMANDE) {
-                    if(!$interdictionModification){
-                        $user_modif_demande = '<a href="user_index.php?session=' . $session . '&p_num=' . $conges['p_num'] . '&onglet=modif_demande"><i class="fa fa-pencil"></i></a>' ;
+                if ($conges["p_etat"] == \App\Models\Conge::STATUT_DEMANDE) {
+                    if (!$interdictionModification) {
+                        $user_modif_demande = '<a href="user_index.php?session=' . $session . '&p_num=' . $conges['p_num'] . '&onglet=modif_demande"><i class="fa fa-pencil"></i></a>';
                     }
                     $user_suppr_demande = '<a href="user_index.php?session=' . $session . '&p_num=' . $conges['p_num'] . '&onglet=suppr_demande"><i class="fa fa-times-circle"></i></a>';
                 }
-                
-                if(!$interdictionModification) {
+
+                if (!$interdictionModification) {
                     $childTable .= $user_modif_demande . '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;';
                 }
-                $childTable .= ($user_suppr_demande) . '</td>'."\n" ;
+                $childTable .= ($user_suppr_demande) . '</td>' . "\n";
                 $childTable .= '</tr>';
                 $i = !$i;
             }
@@ -168,32 +168,32 @@ class Conge
     protected function getFormulaireRecherche(array $champs)
     {
         $session = session_id();
-        $form = '';
-        $form = '<form method="post" action="" class="form-inline search" role="form">';
+        $form    = '';
+        $form    = '<form method="post" action="" class="form-inline search" role="form">';
         $form .= '<div class="form-group"><label class="control-label col-md-4" for="statut">Statut&nbsp;:</label><div class="col-md-8"><select class="form-control" name="search[p_etat]" id="statut">';
         foreach (\App\Models\Conge::getOptionsStatuts() as $key => $value) {
             $selected = (isset($champs['p_etat']) && $key == $champs['p_etat'])
-                ? 'selected="selected"'
-                : '';
+            ? 'selected="selected"'
+            : '';
             $form .= '<option value="' . $key . '" ' . $selected . '>' . $value . '</option>';
         }
         $form .= '</select></div></div>';
         $form .= '<div class="form-group "><label class="control-label col-md-4" for="type">Type&nbsp;:</label><div class="col-md-8"><select class="form-control" name="search[type]" id="type">';
         foreach (\utilisateur\Fonctions::getOptionsTypeConges() as $key => $value) {
             $selected = (isset($champs['type']) && $key == $champs['type'])
-                ? 'selected="selected"'
-                : '';
+            ? 'selected="selected"'
+            : '';
             $form .= '<option value="' . $key . '" ' . $selected . '>' . $value . '</option>';
         }
         $form .= '</select></div></div>';
         $form .= '<div class="form-group"><label class="control-label col-md-4" for="annee">Année&nbsp;:</label><div class="col-md-8"><select class="form-control" name="search[annee]" id="sel1">';
         foreach (\utilisateur\Fonctions::getOptionsAnnees() as $key => $value) {
             $selected = (isset($champs['annee']) && $key == $champs['annee'])
-                ? 'selected="selected"'
-                : '';
+            ? 'selected="selected"'
+            : '';
             $form .= '<option value="' . $key . '" ' . $selected . '>' . $value . '</option>';
         }
-        $form .= '</select></div></div><div class="form-group"><div class="input-group"><button type="submit" class="btn btn-default"><i class="fa fa-search" aria-hidden="true"></i></button>&nbsp;<a href="' . ROOT_PATH . 'utilisateur/user_index.php?session='. $session . '&onglet=liste_conge" type="reset" class="btn btn-default">Reset</a></div></div></form>';
+        $form .= '</select></div></div><div class="form-group"><div class="input-group"><button type="submit" class="btn btn-default"><i class="fa fa-search" aria-hidden="true"></i></button>&nbsp;<a href="' . ROOT_PATH . 'utilisateur/user_index.php?session=' . $session . '&onglet=liste_conge" type="reset" class="btn btn-default">Reset</a></div></div></form>';
 
         return $form;
     }
@@ -225,13 +225,13 @@ class Conge
      * SQL
      */
 
-     /**
-      * Retourne une liste d'id de congés
-      *
-      * @param array $params Paramètres de recherche
-      *
-      * @return array
-      */
+    /**
+     * Retourne une liste d'id de congés
+     *
+     * @param array $params Paramètres de recherche
+     *
+     * @return array
+     */
     protected function getListeId(array $params)
     {
         $sql = \includes\SQL::singleton();
@@ -259,7 +259,7 @@ class Conge
         $req = 'SELECT p_num AS id
                 FROM conges_periode CP
                     INNER JOIN conges_type_absence CTA ON (CP.p_type = CTA.ta_id) '
-                . ((!empty($where)) ? ' WHERE ' . implode(' AND ', $where) : '');
+            . ((!empty($where)) ? ' WHERE ' . implode(' AND ', $where) : '');
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {
             $ids[] = (int) $data['id'];
@@ -294,14 +294,15 @@ class Conge
      * Retourne les demandes d'un employé
      *
      */
-    public static function getIdDemandesUtilisateur($user) {
+    public static function getIdDemandesUtilisateur($user)
+    {
 
         $ids = [];
         $sql = \includes\SQL::singleton();
         $req = 'SELECT p_num AS id
                 FROM conges_periode
                 WHERE p_login = \'' . $sql->quote($user) . '\'
-                AND p_etat = \''. \App\Models\Conge::STATUT_DEMANDE.'\'';
+                AND p_etat = \'' . \App\Models\Conge::STATUT_DEMANDE . '\'';
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {
             $ids[] = (int) $data['id'];
@@ -309,7 +310,6 @@ class Conge
 
         return $ids;
     }
-
 
     /**
      * Vérifie l'existence de congé basée sur les critères fournis
@@ -351,7 +351,7 @@ class Conge
     public function isChevauchement($user, $dateDebut, $typeCreneauDebut, $dateFin, $typeCreneauFin)
     {
         return $this->isChevauchementHeuresRepos($user, $dateDebut, $typeCreneauDebut, $dateFin, $typeCreneauFin)
-            || $this->isChevauchementHeuresAdditionnelles($user, $dateDebut, $typeCreneauDebut, $dateFin, $typeCreneauFin);
+        || $this->isChevauchementHeuresAdditionnelles($user, $dateDebut, $typeCreneauDebut, $dateFin, $typeCreneauFin);
     }
 
     /**
@@ -400,16 +400,16 @@ class Conge
      */
     private function isChevauchementHeures($user, $dateDebut, $typeCreneauDebut, $dateFin, $typeCreneauFin, $typeHeure)
     {
-        $sql = \includes\SQL::singleton();
+        $sql            = \includes\SQL::singleton();
         $filtresDates[] = '(dateDebutHeure > "' . $dateDebut . '" AND dateDebutHeure < "' . $dateFin . '")';
         if (Creneau::TYPE_PERIODE_MATIN_APRES_MIDI
- === $typeCreneauDebut) {
+            === $typeCreneauDebut) {
             $filtresDates[] = '(dateDebutHeure = "' . $dateDebut . '")';
         } else {
             $filtresDates[] = '(dateDebutHeure = "' . $dateDebut . '" AND type_periode IN (' . $typeCreneauDebut . ',' . Creneau::TYPE_PERIODE_MATIN_APRES_MIDI . '))';
         }
         if (Creneau::TYPE_PERIODE_MATIN_APRES_MIDI
- === $typeCreneauFin) {
+            === $typeCreneauFin) {
             $filtresDates[] = '(dateDebutHeure = "' . $dateFin . '")';
         } else {
             $filtresDates[] = '(dateDebutHeure = "' . $dateFin . '" AND type_periode IN (' . $typeCreneauFin . ',' . Creneau::TYPE_PERIODE_MATIN_APRES_MIDI . '))';
@@ -424,7 +424,7 @@ class Conge
             SELECT *
             FROM
                 (SELECT *, DATE_FORMAT(FROM_UNIXTIME(debut), "%Y-%m-%d") AS dateDebutHeure
-            FROM ' .  $typeHeure . ') tmp
+            FROM ' . $typeHeure . ') tmp
             WHERE statut IN ("' . implode('","', $etats) . '")
                 AND login = "' . $sql->quote($user) . '"
                 AND (' . implode(' OR ', $filtresDates) . ')

--- a/App/ProtoControllers/Employe/Heure/Additionnelle.php
+++ b/App/ProtoControllers/Employe/Heure/Additionnelle.php
@@ -1,8 +1,8 @@
 <?php
 namespace App\ProtoControllers\Employe\Heure;
 
-use \App\Models\AHeure;
 use App\Models\Planning\Creneau;
+use \App\Models\AHeure;
 
 /**
  * ProtoContrôleur d'heures additionnelles, en attendant la migration vers le MVC REST
@@ -23,8 +23,8 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
         $valueJour  = date('d/m/Y');
         $valueDebut = '';
         $valueFin   = '';
-        $notice = '';
-        $comment = '';
+        $notice     = '';
+        $comment    = '';
 
         if (!empty($_POST)) {
             if (0 >= (int) $this->postHtmlCommon($_POST, $errorsLst, $notice)) {
@@ -44,7 +44,7 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
                 $comment    = \includes\SQL::quote($_POST['comment']);
             } else {
                 log_action(0, 'demande', '', 'Nouvelle demande d\'heure additionnelle enregistrée');
-                redirect(ROOT_PATH . 'utilisateur/user_index.php?session='. session_id() . '&onglet=liste_heure_additionnelle', false);
+                redirect(ROOT_PATH . 'utilisateur/user_index.php?session=' . session_id() . '&onglet=liste_heure_additionnelle', false);
             }
         }
 
@@ -58,7 +58,7 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
         $daysOfWeekDisabled = \utilisateur\Fonctions::getDatePickerDaysOfWeekDisabled();
         $datesFeries        = \utilisateur\Fonctions::getDatePickerJoursFeries();
         $datesFerme         = \utilisateur\Fonctions::getDatePickerFermeture();
-        $datesDisabled      = array_merge($datesFeries,$datesFerme);
+        $datesDisabled      = array_merge($datesFeries, $datesFerme);
         $startDate          = \utilisateur\Fonctions::getDatePickerStartDate();
 
         $datePickerOpts = [
@@ -74,15 +74,15 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
 
         $childTable = '';
 
         if (NIL_INT !== $id) {
-            $sql   = 'SELECT * FROM heure_additionnelle WHERE id_heure = ' . $id;
-            $query = \includes\SQL::query($sql);
-            $data = $query->fetch_array();
+            $sql        = 'SELECT * FROM heure_additionnelle WHERE id_heure = ' . $id;
+            $query      = \includes\SQL::query($sql);
+            $data       = $query->fetch_array();
             $valueJour  = date('d/m/Y', $data['debut']);
             $valueDebut = date('H\:i', $data['debut']);
             $valueFin   = date('H\:i', $data['fin']);
@@ -96,7 +96,7 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
 
         $childTable .= '<thead><tr><th width="20%">' . _('Jour') . '</th><th>' . _('creneau') . '</th><th>' . _('divers_comment_maj_1') . '</th></tr></thead><tbody>';
         $childTable .= '<tr><td><div class="form-inline col-xs-12 col-sm-10 col-lg-8"><input class="form-control date" type="text" value="' . $valueJour . '" name="jour"></div></td>';
-        $childTable .= '<td><div class="form-inline col-xs-10 col-sm-6 col-lg-4"><input class="form-control" style="width:45%" type="text" id="' . $debutId . '"  value="' . $valueDebut . '" name="debut_heure">&nbsp;<i class="fa fa-caret-right"></i>&nbsp;<input class="form-control" style="width:45%" type="text" id="' . $finId . '"  value="' . $valueFin . '" name="fin_heure"></div></td><td><input class="form-control" type="text" name="comment" value="'.$comment.'" size="20" maxlength="100"></td></tr>';
+        $childTable .= '<td><div class="form-inline col-xs-10 col-sm-6 col-lg-4"><input class="form-control" style="width:45%" type="text" id="' . $debutId . '"  value="' . $valueDebut . '" name="debut_heure">&nbsp;<i class="fa fa-caret-right"></i>&nbsp;<input class="form-control" style="width:45%" type="text" id="' . $finId . '"  value="' . $valueFin . '" name="fin_heure"></div></td><td><input class="form-control" type="text" name="comment" value="' . $comment . '" size="20" maxlength="100"></td></tr>';
         $childTable .= '</tbody>';
         $childTable .= '<script type="text/javascript">generateTimePicker("' . $debutId . '");generateTimePicker("' . $finId . '");</script>';
 
@@ -105,7 +105,7 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
         $table->render();
         $return .= ob_get_clean();
         $return .= '<div class="form-group"><input type="submit" class="btn btn-success" value="' . _('form_submit') . '" /></div>';
-        $return .='</form>';
+        $return .= '</form>';
 
         return $return;
     }
@@ -120,11 +120,11 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
             log_action($id, 'annul', '', 'Annulation de la demande d\'heure additionnelle ' . $id);
             $notice = _('heure_additionnelle_annulee');
             $return = $id;
-            
+
             $notif = new \App\Libraries\Notification\Additionnelle($id);
-            if(!$notif->send()) {
+            if (!$notif->send()) {
                 $errorsLst['email'] = _('erreur_envoi_mail');
-                $return = NIL_INT;
+                $return             = NIL_INT;
             }
         }
         return $return;
@@ -140,7 +140,7 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
             $data = $this->dataModel2Db($put, $user);
             $id   = $this->update($data, $user, $idHeure);
             log_action($idHeure, 'modif', '', 'Modification demande d\'heure additionnelle ' . $idHeure);
-            
+
             return $id;
         }
 
@@ -158,15 +158,15 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
             $id   = $this->insert($data, $user);
             log_action($id, 'demande', '', 'demande d\'heure additionnelle ' . $id);
             $return = $id;
-            $notif = new \App\Libraries\Notification\Additionnelle($id);
+            $notif  = new \App\Libraries\Notification\Additionnelle($id);
             if (!$notif->send()) {
                 $errorsLst['email'] = _('erreur_envoi_mail');
-                $return = NIL_INT;
+                $return             = NIL_INT;
             }
         }
         return NIL_INT;
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -176,9 +176,9 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
          * Comme pour le moment on ne peut prendre une heure de repos que sur un jour,
          * on prend arbitrairement le début...
          */
-        $numeroSemaine = date('W', $debut);
-        $dureeTotale   = $fin - $debut;
-        $typeSemaineReel  = \utilisateur\Fonctions::getRealWeekType($planning, $numeroSemaine);
+        $numeroSemaine   = date('W', $debut);
+        $dureeTotale     = $fin - $debut;
+        $typeSemaineReel = \utilisateur\Fonctions::getRealWeekType($planning, $numeroSemaine);
         /* Si la semaine n'est pas travaillée */
         if (NIL_INT === $typeSemaineReel) {
             return $dureeTotale;
@@ -187,7 +187,7 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
              * ... Pareil pour le jour
              */
             $planningSemaine = $planning[$typeSemaineReel];
-            $jourId = date('N', $debut);
+            $jourId          = date('N', $debut);
             /* Si le jour n'est pas travaillé */
             if (!\utilisateur\Fonctions::isWorkingDay($planningSemaine, $jourId)) {
                 return $dureeTotale;
@@ -265,15 +265,15 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
                     $message = '<div class="alert alert-danger">' . _('erreur_recommencer') . ' :<ul>' . $errors . '</ul></div>';
                 }
             } elseif ('DELETE' === $_POST['_METHOD'] && !empty($notice)) {
-                $message = '<div class="alert alert-info">' .  $notice . '.</div>';
+                $message = '<div class="alert alert-info">' . $notice . '.</div>';
             } else {
                 log_action(0, '', '', 'Récupération de l\'heure additionnelle ' . $_POST['id_heure']);
-                redirect(ROOT_PATH . 'utilisateur/user_index.php?session='. session_id() . '&onglet=liste_heure_additionnelle', false);
+                redirect(ROOT_PATH . 'utilisateur/user_index.php?session=' . session_id() . '&onglet=liste_heure_additionnelle', false);
             }
         }
         $champsRecherche = (!empty($_POST) && $this->isSearch($_POST))
-            ? $this->transformChampsRecherche($_POST)
-            : ['statut' => AHeure::STATUT_DEMANDE];
+        ? $this->transformChampsRecherche($_POST)
+        : ['statut' => AHeure::STATUT_DEMANDE];
         $params = $champsRecherche + [
             'login' => $_SESSION['userlogin'],
         ];
@@ -290,24 +290,24 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
             'table-striped',
         ]);
         $childTable = '<thead><tr><th>' . _('jour') . '</th><th>' . _('divers_debut_maj_1') . '</th><th>' . _('divers_fin_maj_1') . '</th><th>' . _('duree') . '</th><th>' . _('statut') . '</th><th>' . _('commentaire') . '</th><th></th></tr></thead><tbody>';
-        $session = session_id();
-        $listId = $this->getListeId($params);
+        $session    = session_id();
+        $listId     = $this->getListeId($params);
         if (empty($listId)) {
             $childTable .= '<tr><td colspan="6"><center>' . _('aucun_resultat') . '</center></td></tr>';
         } else {
             $listeAdditionelle = $this->getListeSQL($listId);
             foreach ($listeAdditionelle as $additionnelle) {
-                $jour   = date('d/m/Y', $additionnelle['debut']);
-                $debut  = date('H\:i', $additionnelle['debut']);
-                $fin    = date('H\:i', $additionnelle['fin']);
-                $duree  = \App\Helpers\Formatter::Timestamp2Duree($additionnelle['duree']);
-                $statut = AHeure::statusText($additionnelle['statut']);
+                $jour    = date('d/m/Y', $additionnelle['debut']);
+                $debut   = date('H\:i', $additionnelle['debut']);
+                $fin     = date('H\:i', $additionnelle['fin']);
+                $duree   = \App\Helpers\Formatter::Timestamp2Duree($additionnelle['duree']);
+                $statut  = AHeure::statusText($additionnelle['statut']);
                 $comment = \includes\SQL::quote($additionnelle['comment']);
                 if (AHeure::STATUT_DEMANDE == $additionnelle['statut']) {
                     $modification = '<a title="' . _('form_modif') . '" href="user_index.php?onglet=modif_heure_additionnelle&id=' . $additionnelle['id_heure'] . '&session=' . $session . '"><i class="fa fa-pencil"></i></a>';
                     $annulation   = '<input type="hidden" name="id_heure" value="' . $additionnelle['id_heure'] . '" /><input type="hidden" name="_METHOD" value="DELETE" /><button type="submit" class="btn btn-link" title="' . _('Annuler') . '"><i class="fa fa-times-circle"></i></button>';
                 } else {
-                    $modification = '<i class="fa fa-pencil disabled" title="'  . _('heure_non_modifiable') . '"></i>';
+                    $modification = '<i class="fa fa-pencil disabled" title="' . _('heure_non_modifiable') . '"></i>';
                     $annulation   = '<button title="' . _('heure_non_supprimable') . '" type="button" class="btn btn-link disabled"><i class="fa fa-times-circle"></i></button>';
                 }
                 $childTable .= '<tr><td>' . $jour . '</td><td>' . $debut . '</td><td>' . $fin . '</td><td>' . $duree . '</td><td>' . $statut . '</td><td>' . $comment . '</td><td><form action="" method="post" accept-charset="UTF-8"
@@ -331,18 +331,18 @@ enctype="application/x-www-form-urlencoded">' . $modification . '&nbsp;&nbsp;' .
         $form = '<form method="post" action="" class="form-inline search" role="form"><div class="form-group"><label class="control-label col-md-4" for="statut">Statut&nbsp;:</label><div class="col-md-8"><select class="form-control" name="search[statut]" id="statut">';
         foreach (\App\Models\AHeure::getOptionsStatuts() as $key => $value) {
             $selected = (isset($champs['statut']) && $key === $champs['statut'])
-                ? 'selected="selected"'
-                : '';
+            ? 'selected="selected"'
+            : '';
             $form .= '<option value="' . $key . '" ' . $selected . '>' . $value . '</option>';
         }
         $form .= '</select></div></div><div class="form-group"><label class="control-label col-md-4" for="annee">Année&nbsp;:</label><div class="col-md-8"><select class="form-control" name="search[annee]" id="sel1">';
         foreach (\utilisateur\Fonctions::getOptionsAnnees() as $key => $value) {
             $selected = (isset($champs['annee']) && $key === $champs['annee'])
-                ? 'selected="selected"'
-                : '';
+            ? 'selected="selected"'
+            : '';
             $form .= '<option value="' . $key . '" ' . $selected . '>' . $value . '</option>';
         }
-        $form .= '</select></div></div><div class="form-group"><div class="input-group"><button type="submit" class="btn btn-default"><i class="fa fa-search" aria-hidden="true"></i></button>&nbsp;<a href="' . ROOT_PATH . 'utilisateur/user_index.php?session='. session_id() . '&onglet=liste_heure_additionnelle" type="reset" class="btn btn-default">Reset</a></div></div></form>';
+        $form .= '</select></div></div><div class="form-group"><div class="input-group"><button type="submit" class="btn btn-default"><i class="fa fa-search" aria-hidden="true"></i></button>&nbsp;<a href="' . ROOT_PATH . 'utilisateur/user_index.php?session=' . session_id() . '&onglet=liste_heure_additionnelle" type="reset" class="btn btn-default">Reset</a></div></div></form>';
 
         return $form;
     }
@@ -376,7 +376,7 @@ enctype="application/x-www-form-urlencoded">' . $modification . '&nbsp;&nbsp;' .
         $sql = \includes\SQL::singleton();
         $req = 'SELECT id_heure AS id
                 FROM heure_additionnelle '
-                . ((!empty($where)) ? ' WHERE ' . implode(' AND ', $where) : '');
+            . ((!empty($where)) ? ' WHERE ' . implode(' AND ', $where) : '');
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {
             $ids[] = (int) $data['id'];
@@ -385,22 +385,22 @@ enctype="application/x-www-form-urlencoded">' . $modification . '&nbsp;&nbsp;' .
         return $ids;
     }
 
-     /**
-      * {@inheritDoc}
-      */
-     protected function getListeSQL(array $listId)
-     {
-         if (empty($listId)) {
-             return [];
-         }
-         $sql = \includes\SQL::singleton();
-         $req = 'SELECT *
+    /**
+     * {@inheritDoc}
+     */
+    protected function getListeSQL(array $listId)
+    {
+        if (empty($listId)) {
+            return [];
+        }
+        $sql = \includes\SQL::singleton();
+        $req = 'SELECT *
                  FROM heure_additionnelle
                  WHERE id_heure IN (' . implode(',', $listId) . ')
                  ORDER BY debut DESC, statut ASC';
 
-         return $sql->query($req)->fetch_all(MYSQLI_ASSOC);
-     }
+        return $sql->query($req)->fetch_all(MYSQLI_ASSOC);
+    }
 
     /**
      * {@inheritDoc}
@@ -408,8 +408,8 @@ enctype="application/x-www-form-urlencoded">' . $modification . '&nbsp;&nbsp;' .
     protected function isChevauchement($jour, $heureDebut, $heureFin, $user, $id)
     {
         return $this->isChevauchementHeureAdditionnelle($jour, $heureDebut, $heureFin, $user, $id)
-            || $this->isChevauchementHeureRepos($jour, $heureDebut, $heureFin, $user)
-            || $this->isChevauchementConges($jour, $heureDebut, $heureFin, $user)
+        || $this->isChevauchementHeureRepos($jour, $heureDebut, $heureFin, $user)
+        || $this->isChevauchementConges($jour, $heureDebut, $heureFin, $user)
         ;
     }
 
@@ -432,11 +432,11 @@ enctype="application/x-www-form-urlencoded">' . $modification . '&nbsp;&nbsp;' .
             NULL,
             "' . $user . '",
             ' . (int) $data['debut'] . ',
-            '. (int) $data['fin'] .',
-            '. (int) $data['duree'] . ',
+            ' . (int) $data['fin'] . ',
+            ' . (int) $data['duree'] . ',
             ' . (int) $data['typePeriode'] . ',
             ' . (int) $data['statut'] . ',
-            "'. \includes\SQL::quote($data['comment']) .'"
+            "' . \includes\SQL::quote($data['comment']) . '"
         )';
         $query = $sql->query($req);
 
@@ -448,14 +448,14 @@ enctype="application/x-www-form-urlencoded">' . $modification . '&nbsp;&nbsp;' .
      */
     protected function update(array $data, $user, $id)
     {
-        $sql   = \includes\SQL::singleton();
-        $req   = 'UPDATE heure_additionnelle
+        $sql = \includes\SQL::singleton();
+        $req = 'UPDATE heure_additionnelle
                 SET debut = ' . (int) $data['debut'] . ',
                     fin = ' . (int) $data['fin'] . ',
                     duree = ' . (int) $data['duree'] . ',
                     type_periode = ' . (int) $data['typePeriode'] . ',
                     comment = \'' . $data['comment'] . '\'
-                WHERE id_heure = '. (int) $id . '
+                WHERE id_heure = ' . (int) $id . '
                 AND login = "' . $user . '"';
         $query = $sql->query($req);
 
@@ -513,29 +513,28 @@ enctype="application/x-www-form-urlencoded">' . $modification . '&nbsp;&nbsp;' .
         return 0 < (int) $query->fetch_array()[0];
     }
 
+    /**
+     * Vérifie l'existence de congé basée sur les critères fournis
+     *
+     * @param array $params
+     *
+     * @return bool
+     * @TODO: à terme, à baser sur le getList()
+     */
+    public function exists(array $params)
+    {
+        $sql = \includes\SQL::singleton();
 
-        /**
-         * Vérifie l'existence de congé basée sur les critères fournis
-         *
-         * @param array $params
-         *
-         * @return bool
-         * @TODO: à terme, à baser sur le getList()
-         */
-        public function exists(array $params)
-        {
-            $sql = \includes\SQL::singleton();
-
-            $where = [];
-            foreach ($params as $key => $value) {
-                $where[] = $key . ' = "' . $sql->quote($value) . '"';
-            }
-            $req = 'SELECT EXISTS (
+        $where = [];
+        foreach ($params as $key => $value) {
+            $where[] = $key . ' = "' . $sql->quote($value) . '"';
+        }
+        $req = 'SELECT EXISTS (
                         SELECT *
                         FROM heure_additionnelle
                         WHERE ' . implode(' AND ', $where) . '
             )';
 
-            return 0 < (int) $sql->query($req)->fetch_array()[0];
-        }
+        return 0 < (int) $sql->query($req)->fetch_array()[0];
+    }
 }

--- a/App/ProtoControllers/Employe/Heure/Repos.php
+++ b/App/ProtoControllers/Employe/Heure/Repos.php
@@ -1,8 +1,8 @@
 <?php
 namespace App\ProtoControllers\Employe\Heure;
 
-use \App\Models\AHeure;
 use App\Models\Planning\Creneau;
+use \App\Models\AHeure;
 
 /**
  * ProtoContrôleur d'heures de repos, en attendant la migration vers le MVC REST
@@ -23,7 +23,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
         $valueJour  = date('d/m/Y');
         $valueDebut = '';
         $valueFin   = '';
-        $notice = '';
+        $notice     = '';
         $comment    = '';
 
         if (!empty($_POST)) {
@@ -44,7 +44,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
                 $comment    = \includes\SQL::quote($_POST['comment']);
             } else {
                 log_action(0, 'demande', '', 'Nouvelle demande d\'heure de repos enregistrée');
-                redirect(ROOT_PATH . 'utilisateur/user_index.php?session='. session_id() . '&onglet=liste_heure_repos', false);
+                redirect(ROOT_PATH . 'utilisateur/user_index.php?session=' . session_id() . '&onglet=liste_heure_repos', false);
             }
         }
 
@@ -58,7 +58,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
         $daysOfWeekDisabled = \utilisateur\Fonctions::getDatePickerDaysOfWeekDisabled();
         $datesFeries        = \utilisateur\Fonctions::getDatePickerJoursFeries();
         $datesFerme         = \utilisateur\Fonctions::getDatePickerFermeture();
-        $datesDisabled      = array_merge($datesFeries,$datesFerme);
+        $datesDisabled      = array_merge($datesFeries, $datesFerme);
         $startDate          = \utilisateur\Fonctions::getDatePickerStartDate();
 
         $datePickerOpts = [
@@ -74,15 +74,15 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
 
         $childTable = '';
 
         if (NIL_INT !== $id) {
-            $sql   = 'SELECT * FROM heure_repos WHERE id_heure = ' . $id;
-            $query = \includes\SQL::query($sql);
-            $data = $query->fetch_array();
+            $sql        = 'SELECT * FROM heure_repos WHERE id_heure = ' . $id;
+            $query      = \includes\SQL::query($sql);
+            $data       = $query->fetch_array();
             $valueJour  = date('d/m/Y', $data['debut']);
             $valueDebut = date('H\:i', $data['debut']);
             $valueFin   = date('H\:i', $data['fin']);
@@ -101,7 +101,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
         $childTable .= '<td><div class="form-inline col-xs-10 col-sm-6 col-lg-4">
         <input class="form-control" style="width:45%" type="text" id="' . $debutId . '"  value="' . $valueDebut . '" name="debut_heure">
         &nbsp;<i class="fa fa-caret-right"></i>&nbsp;
-        <input class="form-control" style="width:45%" type="text" id="' . $finId . '"  value="' . $valueFin . '" name="fin_heure"></div></td><td><input class="form-control" type="text" name="comment" value="'.$comment.'" size="20" maxlength="100"></td></tr>';
+        <input class="form-control" style="width:45%" type="text" id="' . $finId . '"  value="' . $valueFin . '" name="fin_heure"></div></td><td><input class="form-control" type="text" name="comment" value="' . $comment . '" size="20" maxlength="100"></td></tr>';
         $childTable .= '</tbody>';
         $childTable .= '<script type="text/javascript">generateTimePicker("' . $debutId . '");generateTimePicker("' . $finId . '");</script>';
         $table->addChild($childTable);
@@ -109,7 +109,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
         $table->render();
         $return .= ob_get_clean();
         $return .= '<div class="form-group"><input type="submit" class="btn btn-success" value="' . _('form_submit') . '" /></div>';
-        $return .='</form>';
+        $return .= '</form>';
 
         return $return;
     }
@@ -130,14 +130,13 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
 
         return NIL_INT;
     }
-    
-    
+
     /**
      * {@inheritDoc}
      */
     protected function post(array $post, array &$errorsLst, $user)
     {
-        $return =NIL_INT;
+        $return = NIL_INT;
         if (!$this->hasErreurs($post, $user, $errorsLst)) {
             $data = $this->dataModel2Db($post, $user);
             $id   = $this->insert($data, $user);
@@ -147,7 +146,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
             $notif = new \App\Libraries\Notification\Repos($id);
             if (!$notif->send()) {
                 $errorsLst['email'] = _('erreur_envoi_mail');
-                $return = NIL_INT;
+                $return             = NIL_INT;
             }
         }
         return $return;
@@ -170,7 +169,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
         } else {
             /* … Pareil pour le jour */
             $planningWeek = $planning[$realWeekType];
-            $jourId = date('N', $debut);
+            $jourId       = date('N', $debut);
             /* Si le jour n'est pas travaillé */
             if (!\utilisateur\Fonctions::isWorkingDay($planningWeek, $jourId)) {
                 return 0;
@@ -204,7 +203,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
                 if ($horodateDebut <= $creneauDebut) {
                     if ($horodateFin <= $creneauDebut) {
                         // On ne cumule rien
-                        
+
                         break;
                     } elseif ($horodateFin > $creneauDebut && $horodateFin <= $creneauFin) {
                         $reelleDuree += $horodateFin - $creneauDebut;
@@ -240,7 +239,7 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
             $notif = new \App\Libraries\Notification\Repos($id);
             if (!$notif->send()) {
                 $errorsLst['email'] = _('erreur_envoi_mail');
-                $return = NIL_INT;
+                $return             = NIL_INT;
             }
         }
         return $return;
@@ -264,15 +263,15 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
                     $message = '<div class="alert alert-danger">' . _('erreur_recommencer') . ' :<ul>' . $errors . '</ul></div>';
                 }
             } elseif ('DELETE' === $_POST['_METHOD'] && !empty($notice)) {
-                $message = '<div class="alert alert-info">' .  $notice . '.</div>';
+                $message = '<div class="alert alert-info">' . $notice . '.</div>';
             } else {
                 log_action(0, '', '', 'Récupération de l\'heure de repos ' . $_POST['id_heure']);
-                redirect(ROOT_PATH . 'utilisateur/user_index.php?session='. session_id() . '&onglet=liste_heure_repos', false);
+                redirect(ROOT_PATH . 'utilisateur/user_index.php?session=' . session_id() . '&onglet=liste_heure_repos', false);
             }
         }
         $champsRecherche = (!empty($_POST) && $this->isSearch($_POST))
-            ? $this->transformChampsRecherche($_POST)
-            : ['statut' => AHeure::STATUT_DEMANDE];
+        ? $this->transformChampsRecherche($_POST)
+        : ['statut' => AHeure::STATUT_DEMANDE];
         $params = $champsRecherche + [
             'login' => $_SESSION['userlogin'],
         ];
@@ -289,24 +288,24 @@ class Repos extends \App\ProtoControllers\Employe\AHeure
             'table-striped',
         ]);
         $childTable = '<thead><tr><th>' . _('jour') . '</th><th>' . _('divers_debut_maj_1') . '</th><th>' . _('divers_fin_maj_1') . '</th><th>' . _('duree') . '</th><th>' . _('statut') . '</th><th>' . _('commentaire') . '</th><th></th></tr></thead><tbody>';
-        $session = session_id();
-        $listId = $this->getListeId($params);
+        $session    = session_id();
+        $listId     = $this->getListeId($params);
         if (empty($listId)) {
             $childTable .= '<tr><td colspan="6"><center>' . _('aucun_resultat') . '</center></td></tr>';
         } else {
             $listeRepos = $this->getListeSQL($listId);
             foreach ($listeRepos as $repos) {
-                $jour   = date('d/m/Y', $repos['debut']);
-                $debut  = date('H\:i', $repos['debut']);
-                $fin    = date('H\:i', $repos['fin']);
-                $duree  = \App\Helpers\Formatter::Timestamp2Duree($repos['duree']);
-                $statut = AHeure::statusText($repos['statut']);
+                $jour    = date('d/m/Y', $repos['debut']);
+                $debut   = date('H\:i', $repos['debut']);
+                $fin     = date('H\:i', $repos['fin']);
+                $duree   = \App\Helpers\Formatter::Timestamp2Duree($repos['duree']);
+                $statut  = AHeure::statusText($repos['statut']);
                 $comment = \includes\SQL::quote($repos['comment']);
                 if (AHeure::STATUT_DEMANDE == $repos['statut']) {
                     $modification = '<a title="' . _('form_modif') . '" href="user_index.php?onglet=modif_heure_repos&id=' . $repos['id_heure'] . '&session=' . $session . '"><i class="fa fa-pencil"></i></a>';
                     $annulation   = '<input type="hidden" name="id_heure" value="' . $repos['id_heure'] . '" /><input type="hidden" name="_METHOD" value="DELETE" /><button type="submit" class="btn btn-link" title="' . _('Annuler') . '"><i class="fa fa-times-circle"></i></button>';
                 } else {
-                    $modification = '<i class="fa fa-pencil disabled" title="'  . _('heure_non_modifiable') . '"></i>';
+                    $modification = '<i class="fa fa-pencil disabled" title="' . _('heure_non_modifiable') . '"></i>';
                     $annulation   = '<button title="' . _('heure_non_supprimable') . '" type="button" class="btn btn-link disabled"><i class="fa fa-times-circle"></i></button>';
                 }
                 $childTable .= '<tr><td>' . $jour . '</td><td>' . $debut . '</td><td>' . $fin . '</td><td>' . $duree . '</td><td>' . $statut . '</td><td>' . $comment . '</td><td><form action="" method="post" accept-charset="UTF-8"
@@ -330,18 +329,18 @@ enctype="application/x-www-form-urlencoded">' . $modification . '&nbsp;&nbsp;' .
         $form = '<form method="post" action="" class="form-inline search" role="form"><div class="form-group"><label class="control-label col-md-4" for="statut">Statut&nbsp;:</label><div class="col-md-8"><select class="form-control" name="search[statut]" id="statut">';
         foreach (AHeure::getOptionsStatuts() as $key => $value) {
             $selected = (isset($champs['statut']) && $key == $champs['statut'])
-                ? 'selected="selected"'
-                : '';
+            ? 'selected="selected"'
+            : '';
             $form .= '<option value="' . $key . '" ' . $selected . '>' . $value . '</option>';
         }
         $form .= '</select></div></div><div class="form-group"><label class="control-label col-md-4" for="annee">Année&nbsp;:</label><div class="col-md-8"><select class="form-control" name="search[annee]" id="sel1">';
         foreach (\utilisateur\Fonctions::getOptionsAnnees() as $key => $value) {
             $selected = (isset($champs['annee']) && $key == $champs['annee'])
-                ? 'selected="selected"'
-                : '';
+            ? 'selected="selected"'
+            : '';
             $form .= '<option value="' . $key . '" ' . $selected . '>' . $value . '</option>';
         }
-        $form .= '</select></div></div><div class="form-group"><div class="input-group"><button type="submit" class="btn btn-default"><i class="fa fa-search" aria-hidden="true"></i></button>&nbsp;<a href="' . ROOT_PATH . 'utilisateur/user_index.php?session='. session_id() . '&onglet=liste_heure_repos" type="reset" class="btn btn-default">Reset</a></div></div></form>';
+        $form .= '</select></div></div><div class="form-group"><div class="input-group"><button type="submit" class="btn btn-default"><i class="fa fa-search" aria-hidden="true"></i></button>&nbsp;<a href="' . ROOT_PATH . 'utilisateur/user_index.php?session=' . session_id() . '&onglet=liste_heure_repos" type="reset" class="btn btn-default">Reset</a></div></div></form>';
 
         return $form;
     }
@@ -375,7 +374,7 @@ enctype="application/x-www-form-urlencoded">' . $modification . '&nbsp;&nbsp;' .
         $sql = \includes\SQL::singleton();
         $req = 'SELECT id_heure AS id
                 FROM heure_repos '
-                . ((!empty($where)) ? ' WHERE ' . implode(' AND ', $where) : '');
+            . ((!empty($where)) ? ' WHERE ' . implode(' AND ', $where) : '');
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {
             $ids[] = (int) $data['id'];
@@ -407,8 +406,8 @@ enctype="application/x-www-form-urlencoded">' . $modification . '&nbsp;&nbsp;' .
     protected function isChevauchement($jour, $heureDebut, $heureFin, $user, $id)
     {
         return $this->isChevauchementHeureAdditionnelle($jour, $heureDebut, $heureFin, $user)
-            || $this->isChevauchementHeureRepos($jour, $heureDebut, $heureFin, $user, $id)
-            || $this->isChevauchementConges($jour, $heureDebut, $heureFin, $user)
+        || $this->isChevauchementHeureRepos($jour, $heureDebut, $heureFin, $user, $id)
+        || $this->isChevauchementConges($jour, $heureDebut, $heureFin, $user)
         ;
     }
 
@@ -431,7 +430,7 @@ enctype="application/x-www-form-urlencoded">' . $modification . '&nbsp;&nbsp;' .
             NULL,
             "' . $user . '",
             ' . (int) $data['debut'] . ',
-            ' . (int) $data['fin'] .',
+            ' . (int) $data['fin'] . ',
             ' . (int) $data['duree'] . ',
             ' . (int) $data['typePeriode'] . ',
             ' . (int) $data['statut'] . ',
@@ -447,14 +446,14 @@ enctype="application/x-www-form-urlencoded">' . $modification . '&nbsp;&nbsp;' .
      */
     protected function update(array $data, $user, $id)
     {
-        $sql   = \includes\SQL::singleton();
-        $req   = 'UPDATE heure_repos
+        $sql = \includes\SQL::singleton();
+        $req = 'UPDATE heure_repos
                 SET debut = ' . (int) $data['debut'] . ',
                     fin = ' . (int) $data['fin'] . ',
                     duree = ' . (int) $data['duree'] . ',
                     type_periode = ' . (int) $data['typePeriode'] . ',
-                    comment = \''.$data['comment'].'\'
-                WHERE id_heure = '. (int) $id . '
+                    comment = \'' . $data['comment'] . '\'
+                WHERE id_heure = ' . (int) $id . '
                 AND login = "' . $user . '"';
         $query = $sql->query($req);
 

--- a/App/ProtoControllers/Groupe.php
+++ b/App/ProtoControllers/Groupe.php
@@ -34,14 +34,14 @@ class Groupe
      * SQL
      */
 
-     /**
-      * Retourne la liste des groupes de l'application
-      *
-      * Il est fort probable que cette méthode change de portée. Pour le moment c'est pas utile
-      *
-      * @return array
-      * @todo unescape_string ?
-      */
+    /**
+     * Retourne la liste des groupes de l'application
+     *
+     * Il est fort probable que cette méthode change de portée. Pour le moment c'est pas utile
+     *
+     * @return array
+     * @todo unescape_string ?
+     */
     private static function getListe()
     {
         $sql = \includes\SQL::singleton();

--- a/App/ProtoControllers/Groupe/Responsable.php
+++ b/App/ProtoControllers/Groupe/Responsable.php
@@ -8,7 +8,8 @@ namespace App\ProtoControllers\Groupe;
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina <wouldsmina@tuxfamily.org>
  */
-class Responsable {
+class Responsable
+{
     /*
      * SQL
      */

--- a/App/ProtoControllers/Groupe/Utilisateur.php
+++ b/App/ProtoControllers/Groupe/Utilisateur.php
@@ -8,7 +8,8 @@ namespace App\ProtoControllers\Groupe;
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
  */
-class Utilisateur {
+class Utilisateur
+{
     /*
      * SQL
      */
@@ -27,8 +28,8 @@ class Utilisateur {
         }
 
         $groupeIds = array_map('intval', $groupeIds);
-        $sql = \includes\SQL::singleton();
-        $req = 'SELECT gu_login
+        $sql       = \includes\SQL::singleton();
+        $req       = 'SELECT gu_login
                 FROM `conges_groupe_users`
                 WHERE gu_gid IN (' . implode(',', $groupeIds) . ')';
         $res = $sql->query($req);

--- a/App/ProtoControllers/HautResponsable/Planning.php
+++ b/App/ProtoControllers/HautResponsable/Planning.php
@@ -80,7 +80,7 @@ class Planning extends \App\ProtoControllers\APlanning
      */
     private static function putPlanning($id, array $put, array &$errors)
     {
-        $id = (int) $id;
+        $id           = (int) $id;
         $utilisateurs = \App\ProtoControllers\Utilisateur::getListByPlanning($id);
         foreach ($utilisateurs as $utilisateur) {
             if (\App\ProtoControllers\Utilisateur::hasSortiesEnCours($utilisateur['u_login'])) {
@@ -242,8 +242,8 @@ class Planning extends \App\ProtoControllers\APlanning
         }
 
         $listId = array_map('intval', $listId);
-        $sql = \includes\SQL::singleton();
-        $req = 'SELECT *
+        $sql    = \includes\SQL::singleton();
+        $req    = 'SELECT *
                 FROM planning
                 WHERE planning_id IN (' . implode(',', $listId) . ')
                 ORDER BY planning_id DESC';
@@ -264,9 +264,9 @@ class Planning extends \App\ProtoControllers\APlanning
             return [];
         }
         $listId = array_map('intval', $listId);
-        $ids = [];
-        $sql = \includes\SQL::singleton();
-        $req = 'SELECT planning_id AS id
+        $ids    = [];
+        $sql    = \includes\SQL::singleton();
+        $req    = 'SELECT planning_id AS id
                 FROM conges_users
                 WHERE planning_id IN (' . implode(',', $listId) . ')';
         $res = $sql->query($req);
@@ -309,8 +309,8 @@ class Planning extends \App\ProtoControllers\APlanning
      */
     private static function insertPlanning(array $planning)
     {
-        $sql   = \includes\SQL::singleton();
-        $req   = 'INSERT INTO planning (planning_id, name, status)
+        $sql = \includes\SQL::singleton();
+        $req = 'INSERT INTO planning (planning_id, name, status)
                   VALUES (null, "' . htmlspecialchars($sql->quote($planning['name'])) . '", ' . \App\Models\Planning::STATUS_ACTIVE . ')';
         $query = $sql->query($req);
 

--- a/App/ProtoControllers/HautResponsable/Planning/Creneau.php
+++ b/App/ProtoControllers/HautResponsable/Planning/Creneau.php
@@ -44,9 +44,9 @@ class Creneau
      */
     private static function verifieCoherenceCreneaux(array $periodes, array &$errors)
     {
-        $localError = [];
+        $localError              = [];
         $precedentsCreneauxJours = [];
-        $pattern = '/^(([01]?[0-9])|(2[0-3])):[0-5][0-9]$/';
+        $pattern                 = '/^(([01]?[0-9])|(2[0-3])):[0-5][0-9]$/';
         foreach ($periodes as $typeCreneau => $creneaux) {
             foreach ($creneaux as $creneauxJour) {
                 $debut = $creneauxJour[ModelCreneau::TYPE_HEURE_DEBUT];
@@ -54,7 +54,7 @@ class Creneau
                 if (-1 !== strnatcmp($debut, $fin)) {
                     $localError['Créneaux de travail'][] = _('date_fin_superieure_date_debut');
                 }
-                if (!preg_match($pattern, $debut) || !preg_match($pattern, $fin))  {
+                if (!preg_match($pattern, $debut) || !preg_match($pattern, $fin)) {
                     $localError['Créneaux de travail'][] = _('format_heure_incorrect');
                 }
                 if (!empty($precedentsCreneauxJours) && 1 !== strnatcmp($debut, $precedentsCreneauxJours[ModelCreneau::TYPE_HEURE_FIN])) {
@@ -83,7 +83,7 @@ class Creneau
                 foreach ($creneaux as $creneauxJour) {
                     $grouped[$jourId][$typeCreneau][] = [
                         ModelCreneau::TYPE_HEURE_DEBUT => $creneauxJour[ModelCreneau::TYPE_HEURE_DEBUT],
-                        ModelCreneau::TYPE_HEURE_FIN => $creneauxJour[ModelCreneau::TYPE_HEURE_FIN]
+                        ModelCreneau::TYPE_HEURE_FIN   => $creneauxJour[ModelCreneau::TYPE_HEURE_FIN],
                     ];
                 }
             }
@@ -148,21 +148,21 @@ class Creneau
      */
     private static function insertCreneauList(array $list, $idPlanning)
     {
-        $sql = \includes\SQL::singleton();
+        $sql      = \includes\SQL::singleton();
         $toInsert = [];
         foreach ($list as $typeSemaine => $jours) {
             foreach ($jours as $jourId => $periodes) {
                 foreach ($periodes as $typeCreneau => $creneaux) {
                     foreach ($creneaux as $creneauxJour) {
-                        $timeDebut = \App\Helpers\Formatter::hour2Time($creneauxJour[\App\Models\Planning\Creneau::TYPE_HEURE_DEBUT]);
-                        $timeFin   = \App\Helpers\Formatter::hour2Time($creneauxJour[\App\Models\Planning\Creneau::TYPE_HEURE_FIN]);
+                        $timeDebut  = \App\Helpers\Formatter::hour2Time($creneauxJour[\App\Models\Planning\Creneau::TYPE_HEURE_DEBUT]);
+                        $timeFin    = \App\Helpers\Formatter::hour2Time($creneauxJour[\App\Models\Planning\Creneau::TYPE_HEURE_FIN]);
                         $toInsert[] = '(null, ' . (int) $idPlanning . ', ' . (int) $jourId . ', ' . (int) $typeSemaine . ', ' . (int) $typeCreneau . ', "' . (int) $timeDebut . '", "' . (int) $timeFin . '")';
                     }
                 }
             }
         }
         // insertion multiple en fonction de la liste
-        $req = 'INSERT INTO planning_creneau (creneau_id, planning_id, jour_id, type_semaine, type_periode, debut, fin) VALUES ' . implode(', ', $toInsert);
+        $req   = 'INSERT INTO planning_creneau (creneau_id, planning_id, jour_id, type_semaine, type_periode, debut, fin) VALUES ' . implode(', ', $toInsert);
         $query = $sql->query($req);
 
         return $sql->insert_id;

--- a/App/ProtoControllers/Responsable.php
+++ b/App/ProtoControllers/Responsable.php
@@ -22,7 +22,7 @@ class Responsable
         $ids = [];
 
         $sql = \includes\SQL::singleton();
-        $req = 'SELECT gr_gid AS id FROM `conges_groupe_resp` WHERE gr_login =\''.$resp.'\'';
+        $req = 'SELECT gr_gid AS id FROM `conges_groupe_resp` WHERE gr_login =\'' . $resp . '\'';
         $res = $sql->query($req);
 
         while ($data = $res->fetch_array()) {
@@ -41,18 +41,17 @@ class Responsable
      */
     public static function getIdGroupeGrandResponsable($gresp)
     {
-        $ids=[];
-         $sql = \includes\SQL::singleton();
-         $req = 'SELECT ggr_gid AS id FROM `conges_groupe_grd_resp` WHERE ggr_login =\''.$gresp.'\'';
-         $res = $sql->query($req);
+        $ids = [];
+        $sql = \includes\SQL::singleton();
+        $req = 'SELECT ggr_gid AS id FROM `conges_groupe_grd_resp` WHERE ggr_login =\'' . $gresp . '\'';
+        $res = $sql->query($req);
 
-         while ($data = $res->fetch_array()) {
-             $ids[] = (int) $data['id'];
-         }
+        while ($data = $res->fetch_array()) {
+            $ids[] = (int) $data['id'];
+        }
 
-         return $ids;
+        return $ids;
     }
-
 
     /**
      * Retourne le login des utilisateurs d'un responsable direct
@@ -66,14 +65,14 @@ class Responsable
 
         $users = [];
 
-         $sql = \includes\SQL::singleton();
-         $req = 'SELECT u_login FROM `conges_users` WHERE u_resp_login ="'. $resp . '"';
-         $res = $sql->query($req);
+        $sql = \includes\SQL::singleton();
+        $req = 'SELECT u_login FROM `conges_users` WHERE u_resp_login ="' . $resp . '"';
+        $res = $sql->query($req);
 
-         while ($data = $res->fetch_array()) {
-             $users[] = $data['u_login'];
-         }
-         return $users;
+        while ($data = $res->fetch_array()) {
+            $users[] = $data['u_login'];
+        }
+        return $users;
     }
 
     /**
@@ -87,7 +86,7 @@ class Responsable
         $sql = \includes\SQL::singleton();
         $req = 'SELECT u_resp_login
                 FROM conges_users
-                WHERE u_login ="'.\includes\SQL::quote($user).'"';
+                WHERE u_login ="' . \includes\SQL::quote($user) . '"';
         $query = $sql->query($req);
 
         return $query->fetch_array()['u_resp_login'];
@@ -100,12 +99,13 @@ class Responsable
      *
      * @return bool
      */
-    public static function isRespAbsent($resp){
+    public static function isRespAbsent($resp)
+    {
         $sql = \includes\SQL::singleton();
         $req = 'SELECT EXISTS (
                     SELECT p_num FROM conges_periode WHERE p_login = "'
-                    . \includes\SQL::quote($resp).'" AND p_etat = \''. \App\Models\Conge::STATUT_VALIDATION_FINALE
-                    . '\' AND TO_DAYS(conges_periode.p_date_deb) <= TO_DAYS(NOW())
+        . \includes\SQL::quote($resp) . '" AND p_etat = \'' . \App\Models\Conge::STATUT_VALIDATION_FINALE
+            . '\' AND TO_DAYS(conges_periode.p_date_deb) <= TO_DAYS(NOW())
                     AND TO_DAYS(conges_periode.p_date_fin) >= TO_DAYS(NOW())
                 )';
 
@@ -114,16 +114,17 @@ class Responsable
         return 0 < (int) $query->fetch_array()[0];
     }
 
-    public static function getLoginGrandResponsableUtilisateur($user) {
+    public static function getLoginGrandResponsableUtilisateur($user)
+    {
         $groupesIdUser = \App\ProtoControllers\Utilisateur::getGroupesId($user);
-        
+
         $grandResp = [];
-        $sql = \includes\SQL::singleton();
-        $req = 'select ggr_login FROM conges_groupe_grd_resp where ggr_gid  IN (\'' . implode(',', $groupesIdUser) . '\')';
-        $res = $sql->query($req);
-        
+        $sql       = \includes\SQL::singleton();
+        $req       = 'select ggr_login FROM conges_groupe_grd_resp where ggr_gid  IN (\'' . implode(',', $groupesIdUser) . '\')';
+        $res       = $sql->query($req);
+
         while ($data = $res->fetch_array()) {
-             $grandResp[] = $data['ggr_login'];
+            $grandResp[] = $data['ggr_login'];
         }
         return $grandResp;
     }
@@ -134,38 +135,41 @@ class Responsable
      * @param string $user
      * @return array
      */
-    public static function getResponsablesUtilisateur($user) {
-        
-        $responsables = \App\ProtoControllers\Responsable::getResponsableGroupe(\App\ProtoControllers\Utilisateur::getGroupesId($user));
+    public static function getResponsablesUtilisateur($user)
+    {
+
+        $responsables   = \App\ProtoControllers\Responsable::getResponsableGroupe(\App\ProtoControllers\Utilisateur::getGroupesId($user));
         $responsables[] = \App\ProtoControllers\Responsable::getResponsableDirect($user);
-        $responsables = array_unique($responsables);
-        
+        $responsables   = array_unique($responsables);
+
         return $responsables;
     }
 
-    public static function getResponsableDirect($user) {
+    public static function getResponsableDirect($user)
+    {
         $resp = [];
-        $sql = \includes\SQL::singleton();
-        $req = 'SELECT u_resp_login FROM conges_users WHERE u_login ="' . \includes\SQL::quote($user) . '"';
-        $res = $sql->query($req);
+        $sql  = \includes\SQL::singleton();
+        $req  = 'SELECT u_resp_login FROM conges_users WHERE u_login ="' . \includes\SQL::quote($user) . '"';
+        $res  = $sql->query($req);
         return $res->fetch_array()['u_resp_login'];
-        
+
     }
-    
-    private static function getResponsableGroupe(array $groupesId) {
-        
+
+    private static function getResponsableGroupe(array $groupesId)
+    {
+
         $responsable = [];
-        
+
         $sql = \includes\SQL::singleton();
-        $req = 'SELECT gr_login FROM conges_groupe_resp 
+        $req = 'SELECT gr_login FROM conges_groupe_resp
                     WHERE gr_gid IN (\'' . implode(',', $groupesId) . '\')';
         $res = $sql->query($req);
 
-         while ($data = $res->fetch_array()) {
-             $responsable[] = $data['gr_login'];
-         }
-         
-         return $responsable;
+        while ($data = $res->fetch_array()) {
+            $responsable[] = $data['gr_login'];
+        }
+
+        return $responsable;
     }
 
     /**
@@ -176,10 +180,11 @@ class Responsable
      *
      * @return bool
      */
-    public static function isRespDeUtilisateur($resp, $user) {
-        return $resp != $user 
-                && (\App\ProtoControllers\Responsable::isRespDirect($resp, $user) 
-                || \App\ProtoControllers\Responsable::isRespGroupe($resp, \App\ProtoControllers\Utilisateur::getGroupesId($user)));
+    public static function isRespDeUtilisateur($resp, $user)
+    {
+        return $resp != $user
+            && (\App\ProtoControllers\Responsable::isRespDirect($resp, $user)
+            || \App\ProtoControllers\Responsable::isRespGroupe($resp, \App\ProtoControllers\Utilisateur::getGroupesId($user)));
     }
 
     /**
@@ -191,30 +196,31 @@ class Responsable
      *
      * @return boolean
      */
-    public static function isRespParDelegation($resp, $user) {
-        if(!$_SESSION['config']['gestion_cas_absence_responsable']){
-            return FALSE;
+    public static function isRespParDelegation($resp, $user)
+    {
+        if (!$_SESSION['config']['gestion_cas_absence_responsable']) {
+            return false;
         }
         $usersRespRespAbs = [];
-        $groupesIdResp = \App\ProtoControllers\Responsable::getIdGroupeResp($resp);
-        $usersResp = \App\ProtoControllers\Groupe\Utilisateur::getListUtilisateurByGroupeIds($groupesIdResp);
-        $usersResp = array_merge($usersResp,\App\ProtoControllers\Responsable::getUsersRespDirect($resp));
+        $groupesIdResp    = \App\ProtoControllers\Responsable::getIdGroupeResp($resp);
+        $usersResp        = \App\ProtoControllers\Groupe\Utilisateur::getListUtilisateurByGroupeIds($groupesIdResp);
+        $usersResp        = array_merge($usersResp, \App\ProtoControllers\Responsable::getUsersRespDirect($resp));
         foreach ($usersResp as $userResp) {
-            if(\App\ProtoControllers\Utilisateur::isResponsable($userResp) && \App\ProtoControllers\Responsable::isRespAbsent($userResp)){
+            if (\App\ProtoControllers\Utilisateur::isResponsable($userResp) && \App\ProtoControllers\Responsable::isRespAbsent($userResp)) {
                 $usersRespRespAbs[] = $userResp;
             }
         }
-        if (empty($usersRespRespAbs)){
-            return FALSE;
+        if (empty($usersRespRespAbs)) {
+            return false;
         }
 
-        $RespsUser = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($user);
-        $RespUserPresent = array_diff($RespsUser,$usersRespRespAbs);
-        if (empty($RespUserPresent)){
-            return TRUE;
+        $RespsUser       = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($user);
+        $RespUserPresent = array_diff($RespsUser, $usersRespRespAbs);
+        if (empty($RespUserPresent)) {
+            return true;
         }
 
-        return FALSE;
+        return false;
     }
     /**
      * Vérifie si un utilisateur est bien le grand responsable d'un employé
@@ -224,13 +230,14 @@ class Responsable
      *
      * @return bool
      */
-    public static function isGrandRespDeGroupe($resp, array $groupesId) {
+    public static function isGrandRespDeGroupe($resp, array $groupesId)
+    {
         $sql = \includes\SQL::singleton();
         $req = 'SELECT EXISTS (
                     SELECT ggr_gid
                     FROM conges_groupe_grd_resp
                     WHERE ggr_gid IN (\'' . implode(',', $groupesId) . '\')
-                        AND ggr_login = "'.\includes\SQL::quote($resp).'"
+                        AND ggr_login = "' . \includes\SQL::quote($resp) . '"
                 )';
         $query = $sql->query($req);
 
@@ -252,7 +259,7 @@ class Responsable
                     SELECT gr_gid
                     FROM conges_groupe_resp
                     WHERE gr_gid IN (\'' . implode(',', $groupesId) . '\')
-                        AND gr_login = "'.\includes\SQL::quote($resp).'"
+                        AND gr_login = "' . \includes\SQL::quote($resp) . '"
                 )';
         $query = $sql->query($req);
 
@@ -273,12 +280,12 @@ class Responsable
         $req = 'SELECT EXISTS (
                     SELECT u_resp_login
                     FROM conges_users
-                    WHERE u_login ="'.\includes\SQL::quote($user).'"
-                        AND u_resp_login ="'.\includes\SQL::quote($resp).'"
+                    WHERE u_login ="' . \includes\SQL::quote($user) . '"
+                        AND u_resp_login ="' . \includes\SQL::quote($resp) . '"
            )';
-    $query = $sql->query($req);
+        $query = $sql->query($req);
 
-    return 0 < (int) $query->fetch_array()[0];
+        return 0 < (int) $query->fetch_array()[0];
     }
 
     /**
@@ -292,7 +299,7 @@ class Responsable
     {
         $groupes = [];
         $groupes = \App\ProtoControllers\Utilisateur::getGroupesId($user);
-        if(empty($groupes)){
+        if (empty($groupes)) {
             return false;
         }
 
@@ -300,7 +307,7 @@ class Responsable
         $req = 'SELECT EXISTS (
                     SELECT g_double_valid
                     FROM conges_groupe
-                    WHERE g_gid ='. $groupes[0] . '
+                    WHERE g_gid =' . $groupes[0] . '
                     AND g_double_valid = "Y"
                 )';
         $query = $sql->query($req);

--- a/App/ProtoControllers/Responsable/ATraitement.php
+++ b/App/ProtoControllers/Responsable/ATraitement.php
@@ -32,7 +32,6 @@ abstract class ATraitement
      */
     abstract public function put(array $put, $resp, &$notice, array &$errors);
 
-
     /**
      * Vérifie et traite une demande en tant que responsable
      *
@@ -65,8 +64,6 @@ abstract class ATraitement
      * @return array $ids
      */
     abstract protected function getIdDemandesResponsable($resp);
-
-
 
     /**
      * Retourne la liste détaillée des demandes
@@ -108,7 +105,7 @@ abstract class ATraitement
         $sql = \includes\SQL::singleton();
         $sql->getPdoObj()->begin_transaction();
 
-        $updateSolde = $this->updateSolde($demandeId);
+        $updateSolde  = $this->updateSolde($demandeId);
         $updateStatut = $this->updateStatutValidationFinale($demandeId);
         if (0 < $updateSolde && 0 < $updateStatut) {
             $sql->getPdoObj()->commit();
@@ -161,36 +158,36 @@ abstract class ATraitement
      */
     protected function getFormDemandes(array $demandes)
     {
-        $i=true;
-        $Table='';
+        $i       = true;
+        $Table   = '';
         $session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
         foreach ($demandes as $demande) {
-            $jour   = date('d/m/Y', $demande['debut']);
-            $debut  = date('H\:i', $demande['debut']);
-            $fin    = date('H\:i', $demande['fin']);
-            $duree  = \App\Helpers\Formatter::timestamp2Duree($demande['duree']);
-            $id = $demande['id_heure'];
+            $jour            = date('d/m/Y', $demande['debut']);
+            $debut           = date('H\:i', $demande['debut']);
+            $fin             = date('H\:i', $demande['fin']);
+            $duree           = \App\Helpers\Formatter::timestamp2Duree($demande['duree']);
+            $id              = $demande['id_heure'];
             $infoUtilisateur = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($demande['login']);
-            $solde = \App\Helpers\Formatter::timestamp2Duree($infoUtilisateur['u_heure_solde']);
-            $Table .= '<tr class="'.($i?'i':'p').'">';
-            $Table .= '<td><b>'.$infoUtilisateur['u_nom'].'</b><br>'.$infoUtilisateur['u_prenom'].'</td><td>'.$jour.'</td><td>'.$debut.'</td><td>'.$fin.'</td><td>'.$duree.'</td><td>'.$solde.'</td>';
+            $solde           = \App\Helpers\Formatter::timestamp2Duree($infoUtilisateur['u_heure_solde']);
+            $Table .= '<tr class="' . ($i ? 'i' : 'p') . '">';
+            $Table .= '<td><b>' . $infoUtilisateur['u_nom'] . '</b><br>' . $infoUtilisateur['u_prenom'] . '</td><td>' . $jour . '</td><td>' . $debut . '</td><td>' . $fin . '</td><td>' . $duree . '</td><td>' . $solde . '</td>';
             $Table .= '<input type="hidden" name="_METHOD" value="PUT" />';
             $Table .= '<td>' . $demande['comment'] . '</td>';
-            $Table .= '<td><input type="radio" name="demande['.$id.']" value="1"></td>';
-            $Table .= '<td><input type="radio" name="demande['.$id.']" value="2"></td>';
-            $Table .= '<td><input type="radio" name="demande['.$id.']" value="NULL" checked></td>';
+            $Table .= '<td><input type="radio" name="demande[' . $id . ']" value="1"></td>';
+            $Table .= '<td><input type="radio" name="demande[' . $id . ']" value="2"></td>';
+            $Table .= '<td><input type="radio" name="demande[' . $id . ']" value="NULL" checked></td>';
 
             /* Informations pour le positionnement du calendrier */
-            $dateDebut = new \DateTimeImmutable(date('Y-m', $demande['debut']) . '-01');
+            $dateDebut        = new \DateTimeImmutable(date('Y-m', $demande['debut']) . '-01');
             $paramsCalendrier = [
                 'session' => $session,
-                'vue' => \App\ProtoControllers\Calendrier::VUE_MOIS,
-                'begin' => $dateDebut->format('Y-m-d'),
-                'end' => $dateDebut->modify('+1 month')->format('Y-m-d'),
+                'vue'     => \App\ProtoControllers\Calendrier::VUE_MOIS,
+                'begin'   => $dateDebut->format('Y-m-d'),
+                'end'     => $dateDebut->modify('+1 month')->format('Y-m-d'),
             ];
             $Table .= '<td><a href="' . ROOT_PATH . 'calendrier.php?' . http_build_query($paramsCalendrier) . '" title="' . _('consulter_calendrier_de_periode') . '"><i class="fa fa-lg fa-calendar" aria-hidden="true"></i></a></td>';
-            $Table .= '<td><input class="form-control" type="text" name="comment_refus['.$id.']" size="20" maxlength="100"></td></tr>';
+            $Table .= '<td><input class="form-control" type="text" name="comment_refus[' . $id . ']" size="20" maxlength="100"></td></tr>';
 
             $i = !$i;
         }
@@ -238,8 +235,8 @@ abstract class ATraitement
      */
     public function getNbDemandesATraiter($resp)
     {
-        $demandesResp= $this->getIdDemandesResponsable($resp);
-        $demandesGResp=  $this->getIdDemandesGrandResponsable($resp);
+        $demandesResp  = $this->getIdDemandesResponsable($resp);
+        $demandesGResp = $this->getIdDemandesGrandResponsable($resp);
 
         return count($demandesResp) + count($demandesGResp);
     }

--- a/App/ProtoControllers/Responsable/Planning.php
+++ b/App/ProtoControllers/Responsable/Planning.php
@@ -20,7 +20,7 @@ class Planning extends \App\ProtoControllers\APlanning
      */
     public static function putPlanning($id, array $put, array &$errors)
     {
-        $id = (int) $id;
+        $id           = (int) $id;
         $utilisateurs = \App\ProtoControllers\Utilisateur::getListByPlanning($id);
         foreach ($utilisateurs as $utilisateur) {
             if (\App\ProtoControllers\Utilisateur::hasSortiesEnCours($utilisateur['u_login'])) {
@@ -29,7 +29,7 @@ class Planning extends \App\ProtoControllers\APlanning
             }
         }
 
-        $subalternes =  \App\ProtoControllers\Responsable::getUsersRespDirect($_SESSION['userlogin']);
+        $subalternes = \App\ProtoControllers\Responsable::getUsersRespDirect($_SESSION['userlogin']);
         \App\ProtoControllers\Utilisateur::deleteListAssociationPlanning($id, $subalternes);
         $utilisateursAssocies = array_intersect($put['utilisateurs'], $subalternes);
         if (!empty($utilisateursAssocies)) {

--- a/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
+++ b/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
@@ -24,7 +24,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
      */
     public function put(array $put, $resp, &$notice, array &$errorLst)
     {
-        $return = '1';
+        $return       = '1';
         $infoDemandes = $this->getInfoDemandes(array_keys($put['demande']));
 
         foreach ($put['demande'] as $id_heure => $statut) {
@@ -34,7 +34,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
                 $return = $this->putGrandResponsable($infoDemandes[$id_heure], $statut, $put, $errorLst);
             } else {
                 $errorLst[] = _('erreur_pas_responsable_de') . ' ' . $infoDemandes[$id_heure]['login'];
-                $return = NIL_INT;
+                $return     = NIL_INT;
             }
         }
         $notice = _('traitement_effectue');
@@ -47,9 +47,10 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
     protected function putResponsable(array $infoDemande, $statut, array $put, array &$errors)
     {
         $localError = [];
-        $return = NIL_INT;
-        $id_heure = $infoDemande['id_heure'];
-        if ($this->isDemandeTraitable($infoDemande['statut'])) { // demande est traitable
+        $return     = NIL_INT;
+        $id_heure   = $infoDemande['id_heure'];
+        if ($this->isDemandeTraitable($infoDemande['statut'])) {
+            // demande est traitable
             if (\App\Models\AHeure::REFUSE === $statut) {
                 $return = $this->updateStatutRefus($id_heure, $put['comment_refus'][$id_heure]);
                 log_action(0, '', '', 'Refus de la demande d\'heure additionnelle ' . $id_heure . ' de ' . $infoDemande['login']);
@@ -64,13 +65,13 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
             }
         } else {
             $localError[] = _('demande_deja_traite') . ': ' . $infoDemande['login'];
-            $return = NIL_INT;
+            $return       = NIL_INT;
         }
-        if( 0 < $return) {
+        if (0 < $return) {
             $notif = new \App\Libraries\Notification\Additionnelle($id_heure);
             if (!$notif->send()) {
                 $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
-                $return = NIL_INT;
+                $return       = NIL_INT;
             }
         }
         $errors = array_merge($errors, $localError);
@@ -83,9 +84,10 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
     protected function putGrandResponsable(array $infoDemande, $statut, array $put, array &$errors)
     {
         $localError = [];
-        $return = NIL_INT;
-        $id_heure = $infoDemande['id_heure'];
-        if ($this->isDemandeTraitable($infoDemande['statut'])) { // demande est traitable
+        $return     = NIL_INT;
+        $id_heure   = $infoDemande['id_heure'];
+        if ($this->isDemandeTraitable($infoDemande['statut'])) {
+            // demande est traitable
             if (\App\Models\AHeure::REFUSE === $statut) {
                 $return = $this->updateStatutRefus($id_heure, $put['comment_refus'][$id_heure]);
                 log_action(0, '', '', 'Refus de la demande d\'heure additionnelle ' . $id_heure . ' de ' . $infoDemande['login']);
@@ -94,18 +96,18 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
                     $return = $this->putValidationFinale($id_heure);
                     log_action(0, '', '', 'Validation de la demande d\'heure additionnelle ' . $id_heure . ' de ' . $infoDemande['login']);
                 } else {
-                $localError[] = _('traitement_non_autorise') . ': ' . $infoDemande['login'];
+                    $localError[] = _('traitement_non_autorise') . ': ' . $infoDemande['login'];
                 }
             }
         } else {
             $localError[] = _('demande_deja_traite') . ': ' . $infoDemande['login'];
-            $return = NIL_INT;
+            $return       = NIL_INT;
         }
-        if( 0 < $return) {
+        if (0 < $return) {
             $notif = new \App\Libraries\Notification\Additionnelle($id);
             if (!$notif->send()) {
                 $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
-                $return = NIL_INT;
+                $return       = NIL_INT;
             }
         }
         $errors = array_merge($errors, $localError);
@@ -123,14 +125,13 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
     {
         $sql = \includes\SQL::singleton();
 
-        $req   = 'UPDATE heure_additionnelle
+        $req = 'UPDATE heure_additionnelle
                 SET statut = ' . \App\Models\AHeure::STATUT_VALIDATION_FINALE . '
-                WHERE id_heure = '. (int) $demandeId;
+                WHERE id_heure = ' . (int) $demandeId;
         $query = $sql->query($req);
 
         return $sql->affected_rows;
     }
-
 
     /**
      * Refus de la demande d'heure
@@ -144,10 +145,10 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
     {
         $sql = \includes\SQL::singleton();
 
-        $req   = 'UPDATE heure_additionnelle
+        $req = 'UPDATE heure_additionnelle
                 SET statut = ' . \App\Models\AHeure::STATUT_REFUS . ',
-                    comment_refus = \''.\includes\SQL::quote($comment).'\'
-                WHERE id_heure = '. (int) $demandeId;
+                    comment_refus = \'' . \includes\SQL::quote($comment) . '\'
+                WHERE id_heure = ' . (int) $demandeId;
         $query = $sql->query($req);
 
         return $sql->affected_rows;
@@ -164,9 +165,9 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
     {
         $sql = \includes\SQL::singleton();
 
-        $req   = 'UPDATE heure_additionnelle
+        $req = 'UPDATE heure_additionnelle
                 SET statut = ' . \App\Models\AHeure::STATUT_PREMIERE_VALIDATION . '
-                WHERE id_heure = '. (int) $demandeId;
+                WHERE id_heure = ' . (int) $demandeId;
         $query = $sql->query($req);
 
         return $sql->affected_rows;
@@ -182,10 +183,10 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
     protected function updateSolde($demandeId)
     {
         $user = $this->getInfoDemandes([$demandeId]);
-        $sql = \includes\SQL::singleton();
-        $req   = 'UPDATE conges_users
-                SET u_heure_solde = u_heure_solde+' .$user[$demandeId]['duree'] . '
-                WHERE u_login = \''. $user[$demandeId]['login'] .'\'';
+        $sql  = \includes\SQL::singleton();
+        $req  = 'UPDATE conges_users
+                SET u_heure_solde = u_heure_solde+' . $user[$demandeId]['duree'] . '
+                WHERE u_login = \'' . $user[$demandeId]['login'] . '\'';
         $query = $sql->query($req);
 
         return $sql->affected_rows;
@@ -196,10 +197,10 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
      */
     public function getForm()
     {
-        $return     = '';
-        $notice = '';
-        $errorsLst  = [];
-        $i = true;
+        $return    = '';
+        $notice    = '';
+        $errorsLst = [];
+        $i         = true;
 
         $return .= '<h1>' . _('traitement_heure_additionnelle_titre') . '</h1>';
 
@@ -214,8 +215,8 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
                         $errors .= '<li>' . $key . ' : ' . $value . '</li>';
                     }
                     $return .= '<br><div class="alert alert-danger">' . _('erreur_recommencer') . '<ul>' . $errors . '</ul></div>';
-                } elseif(!empty($notice)) {
-                    $return .= '<br><div class="alert alert-info">' .  $notice . '.</div>';
+                } elseif (!empty($notice)) {
+                    $return .= '<br><div class="alert alert-info">' . $notice . '.</div>';
 
                 }
             }
@@ -228,7 +229,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         $childTable = '<thead><tr><th>' . _('divers_nom_maj_1') . '<br>' . _('divers_prenom_maj_1') . '</th>';
         $childTable .= '<th>' . _('jour') . '</th>';
@@ -241,16 +242,16 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
         $childTable .= '<th>' . _('resp_traite_demandes_motif_refus') . '</th>';
         $childTable .= '</tr></thead><tbody>';
 
-        $demandesResp = $this->getDemandesResponsable($_SESSION['userlogin']);
+        $demandesResp      = $this->getDemandesResponsable($_SESSION['userlogin']);
         $demandesGrandResp = $this->getDemandesGrandResponsable($_SESSION['userlogin']);
-        if (empty($demandesResp) && empty($demandesGrandResp) ) {
+        if (empty($demandesResp) && empty($demandesGrandResp)) {
             $childTable .= '<tr><td colspan="11"><center>' . _('aucune_demande') . '</center></td></tr>';
         } else {
-            if(!empty($demandesResp)) {
+            if (!empty($demandesResp)) {
                 $childTable .= $this->getFormDemandes($demandesResp);
             }
             if (!empty($demandesGrandResp)) {
-                $childTable .='<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="11"><i>'._('resp_etat_users_titre_double_valid').'</i></td></tr>';
+                $childTable .= '<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="11"><i>' . _('resp_etat_users_titre_double_valid') . '</i></td></tr>';
                 $childTable .= $this->getFormDemandes($demandesGrandResp);
 
             }
@@ -262,18 +263,17 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
         ob_start();
         $table->render();
         $return .= ob_get_clean();
-        if (!empty($demandesResp) || !empty($demandesGrandResp) ) {
+        if (!empty($demandesResp) || !empty($demandesGrandResp)) {
             $return .= '<div class="form-group"><input type="submit" class="btn btn-success" value="' . _('form_submit') . '" /></div>';
         }
-        $return .='</form>';
+        $return .= '</form>';
 
         return $return;
     }
 
-
-     /**
-      * {@inheritDoc}
-      */
+    /**
+     * {@inheritDoc}
+     */
     protected function getIdDemandesResponsable($resp)
     {
         $groupId = \App\ProtoControllers\Responsable::getIdGroupeResp($resp);
@@ -282,7 +282,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
         $usersResp = \App\ProtoControllers\Groupe\Utilisateur::getListUtilisateurByGroupeIds($groupId);
 
         $usersRespDirect = \App\ProtoControllers\Responsable::getUsersRespDirect($resp);
-        $usersResp = array_merge($usersResp,$usersRespDirect);
+        $usersResp       = array_merge($usersResp, $usersRespDirect);
 
         if (empty($usersResp)) {
             return [];
@@ -293,7 +293,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
         $req = 'SELECT id_heure AS id
                 FROM heure_additionnelle
                 WHERE login IN (\'' . implode('\',\'', $usersResp) . '\')
-                AND statut = '.AHeure::STATUT_DEMANDE;
+                AND statut = ' . AHeure::STATUT_DEMANDE;
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {
             $ids[] = (int) $data['id'];
@@ -301,9 +301,9 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
         return $ids;
     }
 
-     /**
-      * {@inheritDoc}
-      */
+    /**
+     * {@inheritDoc}
+     */
     protected function getIdDemandesGrandResponsable($gResp)
     {
         $groupId = \App\ProtoControllers\Responsable::getIdGroupeGrandResponsable($gResp);
@@ -321,7 +321,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
         $req = 'SELECT id_heure AS id
                 FROM heure_additionnelle
                 WHERE login IN (\'' . implode('\',\'', $usersResp) . '\')
-                AND statut = '.AHeure::STATUT_PREMIERE_VALIDATION;
+                AND statut = ' . AHeure::STATUT_PREMIERE_VALIDATION;
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {
             $ids[] = (int) $data['id'];
@@ -334,7 +334,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
      */
     protected function getInfoDemandes(array $listId)
     {
-        $infoDemande =[];
+        $infoDemande = [];
 
         if (empty($listId)) {
             return [];
@@ -346,7 +346,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
                 ORDER BY debut DESC, statut ASC';
 
         $ListeDemande = $sql->query($req)->fetch_all(MYSQLI_ASSOC);
-        foreach ($ListeDemande as $demande){
+        foreach ($ListeDemande as $demande) {
             $infoDemande[$demande['id_heure']] = $demande;
         }
 

--- a/App/ProtoControllers/Responsable/Traitement/Conge.php
+++ b/App/ProtoControllers/Responsable/Traitement/Conge.php
@@ -15,10 +15,9 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
      */
     public function getForm()
     {
-        $return     = '';
-        $notice = '';
-        $errorsLst  = [];
-
+        $return    = '';
+        $notice    = '';
+        $errorsLst = [];
 
         $return .= '<h1>' . _('resp_traite_demandes_titre_tableau_1') . '</h1>';
 
@@ -33,8 +32,8 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
                         $errors .= '<li>' . $key . ' : ' . $value . '</li>';
                     }
                     $return .= '<br><div class="alert alert-danger">' . _('erreur_recommencer') . '<ul>' . $errors . '</ul></div>';
-                } elseif(!empty($notice)) {
-                    $return .= '<br><div class="alert alert-info">' .  $notice . '.</div>';
+                } elseif (!empty($notice)) {
+                    $return .= '<br><div class="alert alert-info">' . $notice . '.</div>';
                 }
             }
         }
@@ -46,9 +45,9 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
-        $childTable = '<thead><tr><th>' . _('divers_nom_maj_1') . '<br>' . _('divers_prenom_maj_1') .  '</th>';
+        $childTable = '<thead><tr><th>' . _('divers_nom_maj_1') . '<br>' . _('divers_prenom_maj_1') . '</th>';
         $childTable .= '<th>' . _('divers_debut_maj_1') . '</th>';
         $childTable .= '<th>' . _('divers_fin_maj_1') . '</th>';
         $childTable .= '<th>' . _('divers_type_maj_1') . '</th>';
@@ -61,22 +60,22 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
         $childTable .= '<th>' . _('resp_traite_demandes_motif_refus') . '</th>';
         $childTable .= '</tr></thead><tbody>';
 
-        $demandesResp = $this->getDemandesResponsable($_SESSION['userlogin']);
-        $demandesGrandResp = $this->getDemandesGrandResponsable($_SESSION['userlogin']);
+        $demandesResp       = $this->getDemandesResponsable($_SESSION['userlogin']);
+        $demandesGrandResp  = $this->getDemandesGrandResponsable($_SESSION['userlogin']);
         $demandesRespAbsent = $this->getDemandesResponsableAbsent($_SESSION['userlogin']);
-        if (empty($demandesResp) && empty($demandesGrandResp) && empty($demandesRespAbsent) ) {
+        if (empty($demandesResp) && empty($demandesGrandResp) && empty($demandesRespAbsent)) {
             $childTable .= '<tr><td colspan="12"><center>' . _('aucune_demande') . '</center></td></tr>';
         } else {
-            if(!empty($demandesResp)) {
+            if (!empty($demandesResp)) {
                 $childTable .= $this->getFormDemandes($demandesResp);
             }
             if (!empty($demandesGrandResp)) {
-                $childTable .='<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="12"><i>'._('resp_etat_users_titre_double_valid').'</i></td></tr>';
+                $childTable .= '<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="12"><i>' . _('resp_etat_users_titre_double_valid') . '</i></td></tr>';
                 $childTable .= $this->getFormDemandes($demandesGrandResp);
             }
-            
+
             if (!empty($demandesRespAbsent)) {
-                $childTable .='<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="11"><i>'._('traitement_demande_par_delegation').'</i></td></tr>';
+                $childTable .= '<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="11"><i>' . _('traitement_demande_par_delegation') . '</i></td></tr>';
                 $childTable .= $this->getFormDemandes($demandesRespAbsent);
             }
         }
@@ -87,10 +86,10 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
         ob_start();
         $table->render();
         $return .= ob_get_clean();
-        if (!empty($demandesResp) || !empty($demandesGrandResp) || !empty($demandesRespAbsent) ) {
+        if (!empty($demandesResp) || !empty($demandesGrandResp) || !empty($demandesRespAbsent)) {
             $return .= '<div class="form-group"><input type="submit" class="btn btn-success" value="' . _('form_submit') . '" /></div>';
         }
-        $return .='</form>';
+        $return .= '</form>';
 
         return $return;
     }
@@ -100,50 +99,50 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
      */
     protected function getFormDemandes(array $demandes)
     {
-        $i=true;
-        $Table='';
+        $i       = true;
+        $Table   = '';
         $session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
         foreach ($demandes as $demande) {
-            $id = $demande['p_num'];
+            $id              = $demande['p_num'];
             $infoUtilisateur = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($demande['p_login']);
-            $solde = \App\ProtoControllers\Utilisateur::getSoldeconge($demande['p_login'],$demande['p_type']);
-            $type = $this->getTypeLabel($demande['p_type']);
-            $debut = \App\Helpers\Formatter::dateIso2Fr($demande['p_date_deb']);
-            $fin = \App\Helpers\Formatter::dateIso2Fr($demande['p_date_fin']);
-            if ($demande['p_demi_jour_deb']=="am") {
+            $solde           = \App\ProtoControllers\Utilisateur::getSoldeconge($demande['p_login'], $demande['p_type']);
+            $type            = $this->getTypeLabel($demande['p_type']);
+            $debut           = \App\Helpers\Formatter::dateIso2Fr($demande['p_date_deb']);
+            $fin             = \App\Helpers\Formatter::dateIso2Fr($demande['p_date_fin']);
+            if ($demande['p_demi_jour_deb'] == "am") {
                 $demideb = _('form_am');
-            }  else {
+            } else {
                 $demideb = _('form_pm');
             }
 
-            if ($demande['p_demi_jour_fin']=="am") {
+            if ($demande['p_demi_jour_fin'] == "am") {
                 $demifin = _('form_am');
             } else {
                 $demifin = _('form_pm');
             }
 
-            $Table .= '<tr class="'.($i?'i':'p').'">';
-            $Table .= '<td><b>'.$infoUtilisateur['u_nom'].'</b><br>'.$infoUtilisateur['u_prenom'].'</td>';
-            $Table .= '<td>'.$debut.'<span class="demi">' . $demideb . '</span></td><td>'.$fin.'<span class="demi">' . $demifin . '</span></td>';
-            $Table .= '<td>'.$type.'</td><td><b>'.floatval($demande['p_nb_jours']).'</b></td><td>'.floatval($solde).'</td>';
-            $Table .= '<td>'.$demande['p_commentaire'].'</td>';
+            $Table .= '<tr class="' . ($i ? 'i' : 'p') . '">';
+            $Table .= '<td><b>' . $infoUtilisateur['u_nom'] . '</b><br>' . $infoUtilisateur['u_prenom'] . '</td>';
+            $Table .= '<td>' . $debut . '<span class="demi">' . $demideb . '</span></td><td>' . $fin . '<span class="demi">' . $demifin . '</span></td>';
+            $Table .= '<td>' . $type . '</td><td><b>' . floatval($demande['p_nb_jours']) . '</b></td><td>' . floatval($solde) . '</td>';
+            $Table .= '<td>' . $demande['p_commentaire'] . '</td>';
             $Table .= '<input type="hidden" name="_METHOD" value="PUT" />';
-            $Table .= '<td><input type="radio" name="demande['.$id.']" value="1"></td>';
-            $Table .= '<td><input type="radio" name="demande['.$id.']" value="2"></td>';
-            $Table .= '<td><input type="radio" name="demande['.$id.']" value="NULL" checked></td>';
+            $Table .= '<td><input type="radio" name="demande[' . $id . ']" value="1"></td>';
+            $Table .= '<td><input type="radio" name="demande[' . $id . ']" value="2"></td>';
+            $Table .= '<td><input type="radio" name="demande[' . $id . ']" value="NULL" checked></td>';
 
             /* Informations pour le positionnement du calendrier */
             list($anneeDebut, $moisDebut) = explode('-', $demande['p_date_deb']);
-            $dateDebut = new \DateTimeImmutable($anneeDebut . '-' . $moisDebut . '-01');
-            $paramsCalendrier = [
+            $dateDebut                    = new \DateTimeImmutable($anneeDebut . '-' . $moisDebut . '-01');
+            $paramsCalendrier             = [
                 'session' => $session,
-                'vue' => \App\ProtoControllers\Calendrier::VUE_MOIS,
-                'begin' => $dateDebut->format('Y-m-d'),
-                'end' => $dateDebut->modify('+1 month')->format('Y-m-d'),
+                'vue'     => \App\ProtoControllers\Calendrier::VUE_MOIS,
+                'begin'   => $dateDebut->format('Y-m-d'),
+                'end'     => $dateDebut->modify('+1 month')->format('Y-m-d'),
             ];
             $Table .= '<td><a href="' . ROOT_PATH . 'calendrier.php?' . http_build_query($paramsCalendrier) . '" title="' . _('consulter_calendrier_de_periode') . '"><i class="fa fa-lg fa-calendar" aria-hidden="true"></i></a></td>';
-            $Table .= '<td><input class="form-control" type="text" name="comment_refus['.$id.']" size="20" maxlength="100"></td></tr>';
+            $Table .= '<td><input class="form-control" type="text" name="comment_refus[' . $id . ']" size="20" maxlength="100"></td></tr>';
             $i = !$i;
         }
 
@@ -155,7 +154,7 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
      */
     public function put(array $put, $resp, &$notice, array &$errorLst)
     {
-        $return = '1';
+        $return       = '1';
         $infoDemandes = $this->getInfoDemandes(array_keys($put['demande']));
 
         foreach ($put['demande'] as $id_conge => $statut) {
@@ -165,7 +164,7 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
                 $return = $this->putGrandResponsable($infoDemandes[$id_conge], $statut, $put, $errorLst);
             } else {
                 $errorLst[] = _('erreur_pas_responsable_de') . ' ' . $infoDemandes[$id_conge]['p_login'];
-                $return = NIL_INT;
+                $return     = NIL_INT;
             }
         }
         $notice = _('traitement_effectue');
@@ -177,25 +176,26 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
      */
     protected function putResponsable(array $infoDemande, $statut, array $put, array &$errorLst)
     {
-        $return = NIL_INT;
+        $return   = NIL_INT;
         $id_conge = $infoDemande['p_num'];
-        if ($this->isDemandeTraitable($infoDemande['p_etat'])) { // demande est traitable
+        if ($this->isDemandeTraitable($infoDemande['p_etat'])) {
+            // demande est traitable
             if (\App\Models\Conge::REFUSE === $statut) {
                 $return = $this->updateStatutRefus($id_conge, $put['comment_refus'][$id_conge]);
-                if($_SESSION['config']['mail_refus_conges_alerte_user']) {
+                if ($_SESSION['config']['mail_refus_conges_alerte_user']) {
                     alerte_mail($_SESSION['userlogin'], $infoDemande['p_login'], $infoDemande['p_num'], "refus_conges");
                 }
                 log_action($infoDemande['p_num'], 'refus', '', $infoDemande['p_login'], 'traitement demande ' . $id_conge . ' (' . $infoDemande['p_login'] . ') (' . $infoDemande['p_nb_jours'] . ' jours) : refus');
             } elseif (\App\Models\Conge::ACCEPTE === $statut) {
                 if (\App\ProtoControllers\Responsable::isDoubleValGroupe($infoDemande['p_login']) && !\App\ProtoControllers\Responsable::isRespDeUtilisateur($_SESSION['userlogin'], $infoDemande['p_login'])) {
                     $return = $this->updateStatutPremiereValidation($id_conge);
-                    if($_SESSION['config']['mail_valid_conges_alerte_user']) {
+                    if ($_SESSION['config']['mail_valid_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $infoDemande['p_login'], $infoDemande['p_num'], "valid_conges");
                     }
                     log_action($infoDemande['p_num'], 'valid', $infoDemande['p_login'], 'traitement demande conges ' . $id_conge . ' de ' . $infoDemande['p_login'] . ' première validation');
                 } else {
                     $return = $this->putValidationFinale($id_conge);
-                    if($_SESSION['config']['mail_valid_conges_alerte_user']) {
+                    if ($_SESSION['config']['mail_valid_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $infoDemande['p_login'], $infoDemande['p_num'], "accept_conges");
                     }
                     log_action($infoDemande['p_num'], 'ok', $infoDemande['p_login'], 'traitement demande ' . $id_conge . ' (' . $infoDemande['p_login'] . ') (' . $infoDemande['p_nb_jours'] . ' jours) : OK');
@@ -203,7 +203,7 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
             }
         } else {
             $errorLst[] = _('demande_deja_traite') . ': ' . $infoDemande['p_login'];
-            $return = NIL_INT;
+            $return     = NIL_INT;
         }
         return $return;
     }
@@ -213,30 +213,31 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
      */
     protected function putGrandResponsable(array $infoDemande, $statut, array $put, array &$errorLst)
     {
-        $return = NIL_INT;
+        $return   = NIL_INT;
         $id_conge = $infoDemande['p_num'];
-        if ($this->isDemandeTraitable($infoDemande['p_etat'])) { // demande est traitable
+        if ($this->isDemandeTraitable($infoDemande['p_etat'])) {
+            // demande est traitable
             if (\App\Models\Conge::REFUSE === $statut) {
                 $return = $this->updateStatutRefus($id_conge, $put['comment_refus'][$id_conge]);
-                if($_SESSION['config']['mail_refus_conges_alerte_user']) {
+                if ($_SESSION['config']['mail_refus_conges_alerte_user']) {
                     alerte_mail($_SESSION['userlogin'], $infoDemande['p_login'], $infoDemande['p_num'], "refus_conges");
                 }
                 log_action($infoDemande['p_num'], 'refus', '', $infoDemande['p_login'], 'traitement demande ' . $id_conge . ' (' . $infoDemande['p_login'] . ') (' . $infoDemande['p_nb_jours'] . ' jours) : refus');
             } elseif (\App\Models\Conge::ACCEPTE === $statut) {
                 if (\App\ProtoControllers\Responsable::isDoubleValGroupe($infoDemande['p_login'])) {
                     $return = $this->putValidationFinale($id_conge);
-                    if($_SESSION['config']['mail_valid_conges_alerte_user']) {
+                    if ($_SESSION['config']['mail_valid_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $infoDemande['p_login'], $infoDemande['p_num'], "accept_conges");
                     }
                     log_action($infoDemande['p_num'], 'ok', $infoDemande['p_login'], 'traitement demande ' . $id_conge . ' (' . $infoDemande['p_login'] . ') (' . $infoDemande['p_nb_jours'] . ' jours) : OK');
                 } else {
-                $errorLst[] = _('traitement_non_autorise') . ': ' . $infoDemande['p_login'];
-                $return = NIL_INT;
+                    $errorLst[] = _('traitement_non_autorise') . ': ' . $infoDemande['p_login'];
+                    $return     = NIL_INT;
                 }
             }
         } else {
             $errorLst[] = _('demande_deja_traite') . ': ' . $infoDemande['p_login'];
-            $return = NIL_INT;
+            $return     = NIL_INT;
         }
         return $return;
     }
@@ -249,16 +250,16 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
      */
     protected function putValidationFinale($demandeId)
     {
-        $demande = $this->getInfoDemandes(explode(" ", $demandeId))[$demandeId];
+        $demande       = $this->getInfoDemandes(explode(" ", $demandeId))[$demandeId];
         $SoldeReliquat = $this->getReliquatconge($demande['p_login'], $demande['p_type']);
 
-        if($this->isOptionReliquatActive() && $this->isReliquatUtilisable($demande['p_date_fin']) && 0 < $SoldeReliquat) {
+        if ($this->isOptionReliquatActive() && $this->isReliquatUtilisable($demande['p_date_fin']) && 0 < $SoldeReliquat) {
 
-            if($SoldeReliquat>=$demande['p_nb_jours']) {
+            if ($SoldeReliquat >= $demande['p_nb_jours']) {
                 $sql = \includes\SQL::singleton();
                 $sql->getPdoObj()->begin_transaction();
                 $updateReliquat = $this->updateReliquatUser($demande['p_login'], $demande['p_nb_jours'], $demande['p_type']);
-                $updateStatut = $this->updateStatutValidationFinale($demande['p_num']);
+                $updateStatut   = $this->updateStatutValidationFinale($demande['p_num']);
                 if (0 < $updateReliquat && 0 < $updateStatut) {
                     $sql->getPdoObj()->commit();
                 } else {
@@ -268,11 +269,11 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
                 return $demande['p_num'];
             } else {
                 $ResteSolde = $demande['p_nb_jours'] - $SoldeReliquat;
-                $sql = \includes\SQL::singleton();
+                $sql        = \includes\SQL::singleton();
                 $sql->getPdoObj()->begin_transaction();
                 $updateReliquat = $this->updateReliquatUser($demande['p_login'], $SoldeReliquat, $demande['p_type']);
-                $updateSolde = $this->updateSoldeUser($demande['p_login'], $ResteSolde, $demande['p_type']);
-                $updateStatut = $this->updateStatutValidationFinale($demande['p_num']);
+                $updateSolde    = $this->updateSoldeUser($demande['p_login'], $ResteSolde, $demande['p_type']);
+                $updateStatut   = $this->updateStatutValidationFinale($demande['p_num']);
                 if (0 < $updateReliquat && 0 < $updateStatut && 0 < $updateSolde) {
                     $sql->getPdoObj()->commit();
                 } else {
@@ -284,7 +285,7 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
         } else {
             $id = $this->updateSoldeUser($demande['p_login'], $demande['p_nb_jours'], $demande['p_type']);
             $this->updateStatutValidationFinale($demande['p_num']);
-            log_action($demande['p_num'],"ok", $demande['p_login'], 'traitement demande ' . $demande['p_num'] . ' (' . $demande['p_login'] . ') (' . $demande['p_nb_jours'] . ' jours) : OK');
+            log_action($demande['p_num'], "ok", $demande['p_login'], 'traitement demande ' . $demande['p_num'] . ' (' . $demande['p_login'] . ') (' . $demande['p_nb_jours'] . ' jours) : OK');
         }
     }
 
@@ -299,9 +300,9 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
     {
         $sql = \includes\SQL::singleton();
 
-        $req   = 'UPDATE conges_periode
+        $req = 'UPDATE conges_periode
                 SET p_etat = \'' . \App\Models\Conge::STATUT_PREMIERE_VALIDATION . '\'
-                WHERE p_num = '. (int) $demandeId;
+                WHERE p_num = ' . (int) $demandeId;
         $query = $sql->query($req);
 
         return $sql->affected_rows;
@@ -318,12 +319,12 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
     protected function updateStatutRefus($demandeId, $comm)
     {
         $comm = htmlentities($comm, ENT_QUOTES | ENT_HTML401);
-        $sql = \includes\SQL::singleton();
+        $sql  = \includes\SQL::singleton();
 
-        $req   = 'UPDATE conges_periode
+        $req = 'UPDATE conges_periode
                 SET p_etat = \'' . \App\Models\Conge::STATUT_REFUS . '\',
-                    p_motif_refus = \'' . \includes\SQL::quote($comm) .'\'
-                WHERE p_num = '. (int) $demandeId;
+                    p_motif_refus = \'' . \includes\SQL::quote($comm) . '\'
+                WHERE p_num = ' . (int) $demandeId;
         $query = $sql->query($req);
 
         return $sql->affected_rows;
@@ -340,9 +341,9 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
     {
         $sql = \includes\SQL::singleton();
 
-        $req   = 'UPDATE conges_periode
+        $req = 'UPDATE conges_periode
                 SET p_etat = \'' . \App\Models\Conge::STATUT_VALIDATION_FINALE . '\'
-                WHERE p_num = '. (int) $demandeId;
+                WHERE p_num = ' . (int) $demandeId;
         $query = $sql->query($req);
 
         return $sql->affected_rows;
@@ -357,14 +358,14 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
      *
      * @return int
      */
-    protected function updateSoldeUser($user,$duree,$typeId)
+    protected function updateSoldeUser($user, $duree, $typeId)
     {
         $sql = \includes\SQL::singleton();
 
-        $req   = 'UPDATE conges_solde_user
-                SET su_solde = su_solde-' .number_format($duree,2) . '
-                WHERE su_login = \''. $user .'\'
-                AND su_abs_id = '. (int) $typeId;
+        $req = 'UPDATE conges_solde_user
+                SET su_solde = su_solde-' . number_format($duree, 2) . '
+                WHERE su_login = \'' . $user . '\'
+                AND su_abs_id = ' . (int) $typeId;
         $query = $sql->query($req);
 
         return $sql->affected_rows;
@@ -379,35 +380,34 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
      *
      * @return int
      */
-    protected function updateReliquatUser($user,$duree,$typeId)
+    protected function updateReliquatUser($user, $duree, $typeId)
     {
         $sql = \includes\SQL::singleton();
 
-        $req   = 'UPDATE conges_solde_user
-                SET su_reliquat = su_reliquat-' .number_format($duree,2) . '
-                WHERE su_login = \''. $user .'\'
-                AND su_abs_id = '. (int) $typeId;
+        $req = 'UPDATE conges_solde_user
+                SET su_reliquat = su_reliquat-' . number_format($duree, 2) . '
+                WHERE su_login = \'' . $user . '\'
+                AND su_abs_id = ' . (int) $typeId;
         $query = $sql->query($req);
 
         return $sql->affected_rows;
     }
 
-     /**
-      * {@inheritDoc}
-      * @todo après refonte gestion des groupes retirer array_diff
-      */
+    /**
+     * {@inheritDoc}
+     * @todo après refonte gestion des groupes retirer array_diff
+     */
     protected function getIdDemandesResponsable($resp)
     {
         $groupId = \App\ProtoControllers\Responsable::getIdGroupeResp($resp);
 
-
-        $usersResp = [];
-        $usersResp = \App\ProtoControllers\Groupe\Utilisateur::getListUtilisateurByGroupeIds($groupId);
+        $usersResp       = [];
+        $usersResp       = \App\ProtoControllers\Groupe\Utilisateur::getListUtilisateurByGroupeIds($groupId);
         $usersRespDirect = \App\ProtoControllers\Responsable::getUsersRespDirect($resp);
-        $usersResp = array_merge($usersResp,$usersRespDirect);
+        $usersResp       = array_merge($usersResp, $usersRespDirect);
 
         // un utilisateur ne peut etre son propre responsable
-        $usersResp = array_diff($usersResp,[$_SESSION['userlogin']]);
+        $usersResp = array_diff($usersResp, [$_SESSION['userlogin']]);
 
         if (empty($usersResp)) {
             return [];
@@ -415,72 +415,72 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
 
         $ids = [];
         foreach ($usersResp as $user) {
-            $ids = array_merge($ids,\App\ProtoControllers\Employe\Conge::getIdDemandesUtilisateur($user));
+            $ids = array_merge($ids, \App\ProtoControllers\Employe\Conge::getIdDemandesUtilisateur($user));
         }
         return $ids;
     }
 
-
     /**
      * Transmet à respN+2 les id des demandes des utilisateurs d'un respN+1 absent
-     * 
+     *
      * @param string $resp login du respN+2
-     * 
-     * @return array $ids 
+     *
+     * @return array $ids
      */
     protected function getIdDemandesResponsableAbsent($resp)
-    { 
-        if(!$_SESSION['config']['gestion_cas_absence_responsable']){
+    {
+        if (!$_SESSION['config']['gestion_cas_absence_responsable']) {
             return [];
         }
         $groupesIdResponsable = \App\ProtoControllers\Responsable::getIdGroupeResp($resp);
 
-        $ids = [];
+        $ids                       = [];
         $usersgroupesIdResponsable = [];
-        $usersRespResp = [];
+        $usersRespResp             = [];
         $usersgroupesIdResponsable = \App\ProtoControllers\Groupe\Utilisateur::getListUtilisateurByGroupeIds($groupesIdResponsable);
 
-        $usersRespDirect = \App\ProtoControllers\Responsable::getUsersRespDirect($resp);
-        $usersgroupesIdResponsable = array_merge($usersgroupesIdResponsable,$usersRespDirect);
-        
+        $usersRespDirect           = \App\ProtoControllers\Responsable::getUsersRespDirect($resp);
+        $usersgroupesIdResponsable = array_merge($usersgroupesIdResponsable, $usersRespDirect);
+
         foreach ($usersgroupesIdResponsable as $user) {
             if (is_resp($user)) {
                 $usersduRespResponsable[] = $user;
             }
         }
-        if(empty($usersduRespResponsable)){
+        if (empty($usersduRespResponsable)) {
             return [];
         }
         foreach ($usersduRespResponsable as $userduRespResponsable) {
-            if (!\App\ProtoControllers\Responsable::isRespAbsent($userduRespResponsable)){
+            if (!\App\ProtoControllers\Responsable::isRespAbsent($userduRespResponsable)) {
                 continue;
             }
-            $usersGroupes = \App\ProtoControllers\Groupe\Utilisateur::getListUtilisateurByGroupeIds(\App\ProtoControllers\Responsable::getIdGroupeResp($userduRespResponsable));
+            $usersGroupes   = \App\ProtoControllers\Groupe\Utilisateur::getListUtilisateurByGroupeIds(\App\ProtoControllers\Responsable::getIdGroupeResp($userduRespResponsable));
             $respDirectUser = \App\ProtoControllers\Responsable::getUsersRespDirect($userduRespResponsable);
-            $allUsersResp = array_unique(array_merge($usersGroupes,$respDirectUser));
-            $ids = $this->getIdDemandeDelegable($allUsersResp);
+            $allUsersResp   = array_unique(array_merge($usersGroupes, $respDirectUser));
+            $ids            = $this->getIdDemandeDelegable($allUsersResp);
         }
         return $ids;
     }
 
     /**
      * Retourne les id des demandes délégable
-     * 
+     *
      * @param array $usersRespAbsent
      * @return array $id
      */
-    protected function getIdDemandeDelegable($usersRespAbsent) {
+    protected function getIdDemandeDelegable($usersRespAbsent)
+    {
         $ids = [];
-        foreach ($usersRespAbsent as $userResp){
-            $delegation = TRUE;
-            $respsUser = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($userResp);
-            foreach ($respsUser as $respUser){
-                if (!\App\ProtoControllers\Responsable::isRespAbsent($respUser)){
-                    $delegation = FALSE;
-            break;
+        foreach ($usersRespAbsent as $userResp) {
+            $delegation = true;
+            $respsUser  = \App\ProtoControllers\Responsable::getResponsablesUtilisateur($userResp);
+            foreach ($respsUser as $respUser) {
+                if (!\App\ProtoControllers\Responsable::isRespAbsent($respUser)) {
+                    $delegation = false;
+                    break;
                 }
             }
-            if($delegation){
+            if ($delegation) {
                 $ids = array_merge($ids, \App\ProtoControllers\Employe\Conge::getidDemandesUtilisateur($userResp));
             }
         }
@@ -488,8 +488,8 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
     }
 
     /**
-      * {@inheritDoc}
-      */
+     * {@inheritDoc}
+     */
     protected function getIdDemandesGrandResponsable($gResp)
     {
         $groupId = \App\ProtoControllers\Responsable::getIdGroupeGrandResponsable($gResp);
@@ -507,7 +507,7 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
         $req = 'SELECT p_num AS id
                 FROM conges_periode
                 WHERE p_login IN (\'' . implode(',', $usersResp) . '\')
-                AND p_etat = \''. \App\Models\Conge::STATUT_PREMIERE_VALIDATION .'\'';
+                AND p_etat = \'' . \App\Models\Conge::STATUT_PREMIERE_VALIDATION . '\'';
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {
             $ids[] = (int) $data['id'];
@@ -520,7 +520,7 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
      */
     protected function getInfoDemandes(array $listId)
     {
-        $infoDemande =[];
+        $infoDemande = [];
 
         if (empty($listId)) {
             return [];
@@ -533,7 +533,7 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
 
         $ListeDemande = $sql->query($req)->fetch_all(MYSQLI_ASSOC);
 
-        foreach ($ListeDemande as $demande){
+        foreach ($ListeDemande as $demande) {
             $infoDemande[$demande['p_num']] = $demande;
         }
 
@@ -551,10 +551,10 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
     public function getReliquatconge($login, $typeId)
     {
         $sql = \includes\SQL::singleton();
-        $req = 'SELECT su_reliquat FROM conges_solde_user WHERE su_login = \''.$login.'\'
-                AND su_abs_id ='. (int) $typeId;
+        $req = 'SELECT su_reliquat FROM conges_solde_user WHERE su_login = \'' . $login . '\'
+                AND su_abs_id =' . (int) $typeId;
         $query = $sql->query($req);
-        $rel = $query->fetch_array()[0];
+        $rel   = $query->fetch_array()[0];
 
         return $rel;
     }
@@ -588,7 +588,7 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
         return $query->fetch_array()[0];
     }
 
-   /**
+    /**
      * verifie si la date limite d'usage des reliquats n'est pas dépassée
      *
      * @param int $findemande date de fin de la demande
@@ -618,24 +618,24 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
      */
     public function getTypeLabel($type)
     {
-        $sql = \includes\SQL::singleton();
-        $req = 'SELECT ta_libelle FROM conges_type_absence WHERE ta_id = '.$type;
-        $query = $sql->query($req);
+        $sql    = \includes\SQL::singleton();
+        $req    = 'SELECT ta_libelle FROM conges_type_absence WHERE ta_id = ' . $type;
+        $query  = $sql->query($req);
         $tLabel = $query->fetch_array()[0];
 
         return $tLabel;
     }
-    
+
     /**
      * Retourne le nombre de demande en cours d'un responsable
-     * 
+     *
      * @param $resp
-     * 
+     *
      * @return int
      */
     public function getNbDemandesATraiter($resp)
     {
-        $demandesResp = $this->getIdDemandesResponsable($resp);
+        $demandesResp  = $this->getIdDemandesResponsable($resp);
         $demandesGResp = $this->getIdDemandesGrandResponsable($resp);
         $demandesDeleg = $this->getIdDemandesResponsableAbsent($resp);
         return count($demandesResp) + count($demandesGResp) + count($demandesDeleg);

--- a/App/ProtoControllers/Responsable/Traitement/Repos.php
+++ b/App/ProtoControllers/Responsable/Traitement/Repos.php
@@ -24,7 +24,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
      */
     public function put(array $put, $resp, &$notice, array &$errorLst)
     {
-        $return = '1';
+        $return       = '1';
         $infoDemandes = $this->getInfoDemandes(array_keys($put['demande']));
 
         foreach ($put['demande'] as $id_heure => $statut) {
@@ -34,7 +34,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
                 $return = $this->putGrandResponsable($infoDemandes[$id_heure], $statut, $put, $errorLst);
             } else {
                 $errorLst[] = _('erreur_pas_responsable_de') . ' ' . $infoDemandes[$id_heure]['login'];
-                $return = NIL_INT;
+                $return     = NIL_INT;
             }
         }
         $notice = _('traitement_effectue');
@@ -47,12 +47,13 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
     protected function putResponsable(array $infoDemande, $statut, array $put, array &$errors)
     {
         $localError = [];
-        $return = NIL_INT;
-        $id_heure = $infoDemande['id_heure'];
-        if ($this->isDemandeTraitable($infoDemande['statut'])) { // demande est traitable
+        $return     = NIL_INT;
+        $id_heure   = $infoDemande['id_heure'];
+        if ($this->isDemandeTraitable($infoDemande['statut'])) {
+            // demande est traitable
             if (AHeure::REFUSE === $statut) {
                 $return = $this->updateStatutRefus($id_heure, $put['comment_refus'][$id_heure]);
-                    log_action(0, '', '', 'Refus de la demande d\'heure de repos ' . $id_heure . ' de ' . $infoDemande['login']);
+                log_action(0, '', '', 'Refus de la demande d\'heure de repos ' . $id_heure . ' de ' . $infoDemande['login']);
             } elseif (AHeure::ACCEPTE === $statut) {
                 if (\App\ProtoControllers\Responsable::isDoubleValGroupe($infoDemande['login'])) {
                     $return = $this->updateStatutPremiereValidation($id_heure);
@@ -64,14 +65,14 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
             }
         } else {
             $localError[] = _('demande_deja_traite') . ': ' . $infoDemande['login'];
-            $return = NIL_INT;
+            $return       = NIL_INT;
         }
-        
-        if( 0 < $return) {
+
+        if (0 < $return) {
             $notif = new \App\Libraries\Notification\Repos($id_heure);
             if (!$notif->send()) {
                 $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
-                $return = NIL_INT;
+                $return       = NIL_INT;
             }
         }
         $errors = array_merge($errors, $localError);
@@ -84,9 +85,10 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
     protected function putGrandResponsable(array $infoDemande, $statut, array $put, array &$errors)
     {
         $localError = [];
-        $return = NIL_INT;
-        $id_heure = $infoDemande['id_heure'];
-        if ($this->isDemandeTraitable($infoDemande['statut'])) { // demande est traitable
+        $return     = NIL_INT;
+        $id_heure   = $infoDemande['id_heure'];
+        if ($this->isDemandeTraitable($infoDemande['statut'])) {
+            // demande est traitable
             if (AHeure::REFUSE === $statut) {
                 $return = $this->updateStatutRefus($id_heure, $put['comment_refus'][$id_heure]);
                 log_action(0, '', '', 'Refus de la demande d\'heure de repos ' . $id_heure . ' de ' . $infoDemande['login']);
@@ -95,17 +97,17 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
                     $return = $this->putValidationFinale($id_heure);
                     log_action(0, '', '', 'Validation de la demande d\'heure de repos ' . $id_heure . ' de ' . $infoDemande['login']);
                 } else {
-                $localError[] = _('traitement_non_autorise') . ': ' . $infoDemande['login'];
+                    $localError[] = _('traitement_non_autorise') . ': ' . $infoDemande['login'];
                 }
             }
         } else {
             $localError[] = _('demande_deja_traite') . ': ' . $infoDemande['login'];
-            $return = NIL_INT;
+            $return       = NIL_INT;
         }
-        
-        if( 0 < $return) {
+
+        if (0 < $return) {
             $notif = new \App\Libraries\Notification\Repos($id);
-            $send = $notif->send();
+            $send  = $notif->send();
 
             if (false === $send) {
                 $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
@@ -127,9 +129,9 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
     {
         $sql = \includes\SQL::singleton();
 
-        $req   = 'UPDATE heure_repos
+        $req = 'UPDATE heure_repos
                 SET statut = ' . AHeure::STATUT_VALIDATION_FINALE . '
-                WHERE id_heure = '. (int) $demandeId;
+                WHERE id_heure = ' . (int) $demandeId;
         $query = $sql->query($req);
 
         return $sql->affected_rows;
@@ -147,10 +149,10 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
     {
         $sql = \includes\SQL::singleton();
 
-        $req   = 'UPDATE heure_repos
+        $req = 'UPDATE heure_repos
                 SET statut = ' . AHeure::STATUT_REFUS . ',
                     comment_refus = \'' . \includes\SQL::quote($comment) . '\'
-                WHERE id_heure = '. (int) $demandeId;
+                WHERE id_heure = ' . (int) $demandeId;
         $query = $sql->query($req);
 
         return $sql->affected_rows;
@@ -167,9 +169,9 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
     {
         $sql = \includes\SQL::singleton();
 
-        $req   = 'UPDATE heure_repos
+        $req = 'UPDATE heure_repos
                 SET statut = ' . AHeure::STATUT_PREMIERE_VALIDATION . '
-                WHERE id_heure = '. (int) $demandeId;
+                WHERE id_heure = ' . (int) $demandeId;
         $query = $sql->query($req);
 
         return $sql->affected_rows;
@@ -184,12 +186,12 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
      */
     protected function updateSolde($demandeId)
     {
-        $user = $this->getInfoDemandes(explode(" ",$demandeId));
-        $sql = \includes\SQL::singleton();
+        $user = $this->getInfoDemandes(explode(" ", $demandeId));
+        $sql  = \includes\SQL::singleton();
 
-        $req   = 'UPDATE conges_users
-                SET u_heure_solde = u_heure_solde-' .$user[$demandeId]['duree'] . '
-                WHERE u_login = \''. $user[$demandeId]['login'] .'\'';
+        $req = 'UPDATE conges_users
+                SET u_heure_solde = u_heure_solde-' . $user[$demandeId]['duree'] . '
+                WHERE u_login = \'' . $user[$demandeId]['login'] . '\'';
         $query = $sql->query($req);
 
         return $sql->affected_rows;
@@ -200,10 +202,10 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
      */
     public function getForm()
     {
-        $return     = '';
-        $notice = '';
-        $errorsLst  = [];
-        $i = true;
+        $return    = '';
+        $notice    = '';
+        $errorsLst = [];
+        $i         = true;
 
         $return .= '<h1>' . _('traitement_heure_repos_titre') . '</h1>';
 
@@ -218,8 +220,8 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
                         $errors .= '<li>' . $key . ' : ' . $value . '</li>';
                     }
                     $return .= '<br><div class="alert alert-danger">' . _('erreur_recommencer') . '<ul>' . $errors . '</ul></div>';
-                } elseif(!empty($notice)) {
-                    $return .= '<br><div class="alert alert-info">' .  $notice . '.</div>';
+                } elseif (!empty($notice)) {
+                    $return .= '<br><div class="alert alert-info">' . $notice . '.</div>';
 
                 }
             }
@@ -232,7 +234,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         $childTable = '<thead><tr><th>' . _('divers_nom_maj_1') . '<br>' . _('divers_prenom_maj_1') . '</th>';
         $childTable .= '<th>' . _('jour') . '</th>';
@@ -245,12 +247,12 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         $childTable .= '<th>' . _('resp_traite_demandes_motif_refus') . '</th>';
         $childTable .= '</tr></thead><tbody>';
 
-        $demandesResp = $this->getDemandesResponsable($_SESSION['userlogin']);
+        $demandesResp      = $this->getDemandesResponsable($_SESSION['userlogin']);
         $demandesGrandResp = $this->getDemandesGrandResponsable($_SESSION['userlogin']);
-        if (empty($demandesResp) && empty($demandesGrandResp) ) {
+        if (empty($demandesResp) && empty($demandesGrandResp)) {
             $childTable .= '<tr><td colspan="12"><center>' . _('aucune_demande') . '</center></td></tr>';
         } else {
-            if(!empty($demandesResp)) {
+            if (!empty($demandesResp)) {
                 $childTable .= $this->getFormDemandes($demandesResp);
             }
             if (!empty($demandesGrandResp)) {
@@ -265,27 +267,26 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         ob_start();
         $table->render();
         $return .= ob_get_clean();
-        if (!empty($demandesResp) || !empty($demandesGrandResp) ) {
+        if (!empty($demandesResp) || !empty($demandesGrandResp)) {
             $return .= '<div class="form-group"><input type="submit" class="btn btn-success" value="' . _('form_submit') . '" /></div>';
         }
-        $return .='</form>';
+        $return .= '</form>';
 
         return $return;
     }
 
-     /**
-      * {@inheritDoc}
-      */
+    /**
+     * {@inheritDoc}
+     */
     protected function getIdDemandesResponsable($resp)
     {
         $groupId = \App\ProtoControllers\Responsable::getIdGroupeResp($resp);
-
 
         $usersResp = [];
         $usersResp = \App\ProtoControllers\Groupe\Utilisateur::getListUtilisateurByGroupeIds($groupId);
 
         $usersRespDirect = \App\ProtoControllers\Responsable::getUsersRespDirect($resp);
-        $usersResp = array_merge($usersResp,$usersRespDirect);
+        $usersResp       = array_merge($usersResp, $usersRespDirect);
 
         if (empty($usersResp)) {
             return [];
@@ -296,7 +297,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         $req = 'SELECT id_heure AS id
                 FROM heure_repos
                 WHERE login IN (\'' . implode(',', $usersResp) . '\')
-                AND statut = '.AHeure::STATUT_DEMANDE;
+                AND statut = ' . AHeure::STATUT_DEMANDE;
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {
             $ids[] = (int) $data['id'];
@@ -304,9 +305,9 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         return $ids;
     }
 
-     /**
-      * {@inheritDoc}
-      */
+    /**
+     * {@inheritDoc}
+     */
     protected function getIdDemandesGrandResponsable($gResp)
     {
         $groupId = \App\ProtoControllers\Responsable::getIdGroupeGrandResponsable($gResp);
@@ -324,7 +325,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         $req = 'SELECT id_heure AS id
                 FROM heure_repos
                 WHERE login IN (\'' . implode(',', $usersResp) . '\')
-                AND statut = '.AHeure::STATUT_PREMIERE_VALIDATION;
+                AND statut = ' . AHeure::STATUT_PREMIERE_VALIDATION;
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {
             $ids[] = (int) $data['id'];
@@ -337,7 +338,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
      */
     protected function getInfoDemandes(array $listId)
     {
-        $infoDemande =[];
+        $infoDemande = [];
 
         if (empty($listId)) {
             return [];
@@ -350,7 +351,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
 
         $ListeDemande = $sql->query($req)->fetch_all(MYSQLI_ASSOC);
 
-        foreach ($ListeDemande as $demande){
+        foreach ($ListeDemande as $demande) {
             $infoDemande[$demande['id_heure']] = $demande;
         }
 

--- a/App/ProtoControllers/Utilisateur.php
+++ b/App/ProtoControllers/Utilisateur.php
@@ -39,7 +39,7 @@ class Utilisateur
      */
     public static function getListeGroupesVisibles($utilisateur)
     {
-        if(!$_SESSION['config']['gestion_groupes']) {
+        if (!$_SESSION['config']['gestion_groupes']) {
             return [];
         }
 
@@ -49,10 +49,10 @@ class Utilisateur
         ) {
             $groupesVisibles = \App\ProtoControllers\Groupe::getListeId();
         } elseif (\App\ProtoControllers\Utilisateur::isResponsable()) {
-            $groupesResponsable = \App\ProtoControllers\Responsable::getIdGroupeResp($utilisateur);
+            $groupesResponsable      = \App\ProtoControllers\Responsable::getIdGroupeResp($utilisateur);
             $groupesGrandResponsable = \App\ProtoControllers\Responsable::getIdGroupeGrandResponsable($utilisateur);
-            $groupesEmploye = \App\ProtoControllers\Utilisateur::getGroupesId($utilisateur);
-            $groupesVisibles = $groupesResponsable + $groupesGrandResponsable + $groupesEmploye;
+            $groupesEmploye          = \App\ProtoControllers\Utilisateur::getGroupesId($utilisateur);
+            $groupesVisibles         = $groupesResponsable + $groupesGrandResponsable + $groupesEmploye;
         } else {
             $groupesVisibles = \App\ProtoControllers\Utilisateur::getGroupesId($utilisateur);
         }
@@ -73,8 +73,8 @@ class Utilisateur
         $donneesUtilisateur = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($utilisateur);
 
         return (!empty($donneesUtilisateur))
-            ? $donneesUtilisateur['u_is_hr']
-            : false;
+        ? $donneesUtilisateur['u_is_hr']
+        : false;
     }
 
     /**
@@ -90,8 +90,8 @@ class Utilisateur
         $donneesUtilisateur = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($utilisateur);
 
         return (!empty($donneesUtilisateur))
-            ? $donneesUtilisateur['u_is_admin']
-            : false;
+        ? $donneesUtilisateur['u_is_admin']
+        : false;
     }
 
     /**
@@ -107,8 +107,8 @@ class Utilisateur
         $donneesUtilisateur = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($utilisateur);
 
         return (!empty($donneesUtilisateur))
-            ? $donneesUtilisateur['u_is_resp']
-            : false;
+        ? $donneesUtilisateur['u_is_resp']
+        : false;
     }
 
     /**
@@ -123,25 +123,25 @@ class Utilisateur
         $sql = \includes\SQL::singleton();
         $req = 'SELECT *
                 FROM conges_users
-                WHERE u_login = \''.  \includes\SQL::quote($login).'\'';
-        $query = $sql->query($req);
+                WHERE u_login = \'' . \includes\SQL::quote($login) . '\'';
+        $query   = $sql->query($req);
         $donnees = $query->fetch_array();
 
         return $donnees;
     }
 
-     /**
-      * Retourne la liste des utilisateurs associés à un planning
-      *
-      * @param int $planningId
-      *
-      * @return array
-      */
+    /**
+     * Retourne la liste des utilisateurs associés à un planning
+     *
+     * @param int $planningId
+     *
+     * @return array
+     */
     public static function getListByPlanning($planningId)
     {
         $planningId = (int) $planningId;
-        $sql = \includes\SQL::singleton();
-        $req = 'SELECT *
+        $sql        = \includes\SQL::singleton();
+        $req        = 'SELECT *
                 FROM conges_users
                 WHERE planning_id = ' . $planningId . '
                     AND u_login <> "admin"
@@ -163,7 +163,7 @@ class Utilisateur
         $sql = \includes\SQL::singleton();
         $req = 'SELECT gu_gid AS id
                     FROM conges_groupe_users
-                    WHERE gu_login ="'.\includes\SQL::quote($user).'"';
+                    WHERE gu_login ="' . \includes\SQL::quote($user) . '"';
         $res = $sql->query($req);
         while ($data = $res->fetch_array()) {
             $ids[] = (int) $data['id'];
@@ -183,8 +183,8 @@ class Utilisateur
     public static function getSoldeconge($login, $typeId)
     {
         $sql = \includes\SQL::singleton();
-        $req = 'SELECT su_solde FROM conges_solde_user WHERE su_login = \''.$login.'\'
-                AND su_abs_id ='. (int) $typeId;
+        $req = 'SELECT su_solde FROM conges_solde_user WHERE su_login = \'' . $login . '\'
+                AND su_abs_id =' . (int) $typeId;
         $query = $sql->query($req);
         $solde = $query->fetch_array()[0];
 
@@ -201,24 +201,25 @@ class Utilisateur
     public static function hasSortiesEnCours($login)
     {
         return static::hasCongesEnCours($login)
-            || static::hasHeureReposEnCours($login)
-            || static::hasHeureAdditionnelleEnCours($login)
+        || static::hasHeureReposEnCours($login)
+        || static::hasHeureAdditionnelleEnCours($login)
         ;
     }
 
     /**
      * Récupère l'adresse email de l'utilisateur
-     * 
+     *
      * @todo En attendant l'objet ldap utilisation de find_email_adress_for_user
-     * 
+     *
      * @param string $login
      * @return string $mail
-     */    
-    public static function getEmailUtilisateur($login)  {
-        require_once ROOT_PATH.'fonctions_conges.php';
+     */
+    public static function getEmailUtilisateur($login)
+    {
+        require_once ROOT_PATH . 'fonctions_conges.php';
         return find_email_adress_for_user($login)[1];
     }
-    
+
     /**
      * Vérifie si l'utilisateur a des congés en cours
      *
@@ -229,7 +230,7 @@ class Utilisateur
     public static function hasCongesEnCours($login)
     {
         $params = ['p_login' => $login, 'p_etat' => \App\Models\Conge::STATUT_DEMANDE];
-        $conge = new \App\ProtoControllers\Employe\Conge();
+        $conge  = new \App\ProtoControllers\Employe\Conge();
 
         return $conge->exists($params);
     }
@@ -244,7 +245,7 @@ class Utilisateur
     public static function hasHeureReposEnCours($login)
     {
         $params = ['login' => $login, 'statut' => \App\Models\Heure\Repos::STATUT_DEMANDE];
-        $repos = new \App\ProtoControllers\Employe\Heure\Repos();
+        $repos  = new \App\ProtoControllers\Employe\Heure\Repos();
 
         return $repos->exists($params);
     }
@@ -258,7 +259,7 @@ class Utilisateur
      */
     public static function hasHeureAdditionnelleEnCours($login)
     {
-        $params = ['login' => $login, 'statut' => \App\Models\Heure\Additionnelle::STATUT_DEMANDE];
+        $params        = ['login' => $login, 'statut' => \App\Models\Heure\Additionnelle::STATUT_DEMANDE];
         $additionnelle = new \App\ProtoControllers\Employe\Heure\Additionnelle();
 
         return $additionnelle->exists($params);
@@ -273,9 +274,10 @@ class Utilisateur
      *
      * @return string
      */
-    public static function getNomComplet($prenom, $nom, $initialPrenomSeulement = false) {
+    public static function getNomComplet($prenom, $nom, $initialPrenomSeulement = false)
+    {
         $prenom = ucfirst($prenom);
-        $nom = ucfirst($nom);
+        $nom    = ucfirst($nom);
         if ($initialPrenomSeulement && 0 < strlen($prenom)) {
             $prenom = $prenom[0] . '.';
         }
@@ -294,10 +296,10 @@ class Utilisateur
     public static function deleteListAssociationPlanning($idPlanning, array $utilisateurs = [])
     {
         $where[] = 'planning_id = ' . (int) $idPlanning;
-        $sql = \includes\SQL::singleton();
+        $sql     = \includes\SQL::singleton();
         if (!empty($utilisateurs)) {
             $utilisateurs = array_map([$sql, 'quote'], $utilisateurs);
-            $where[] = 'u_login IN ("' . implode('","', $utilisateurs) . '")';
+            $where[]      = 'u_login IN ("' . implode('","', $utilisateurs) . '")';
         }
         $req = 'UPDATE conges_users
             SET planning_id = 0
@@ -317,10 +319,10 @@ class Utilisateur
      */
     public static function putListAssociationPlanning(array $utilisateursListe, $idPlanning)
     {
-        $sql = \includes\SQL::singleton();
+        $sql               = \includes\SQL::singleton();
         $utilisateursListe = array_map([$sql, 'quote'], $utilisateursListe);
-        $req = 'UPDATE conges_users
-            SET planning_id = ' . (int) $idPlanning  . '
+        $req               = 'UPDATE conges_users
+            SET planning_id = ' . (int) $idPlanning . '
             WHERE u_login IN ("' . implode('","', $utilisateursListe) . '")';
         $sql->query($req);
 

--- a/Public/Assets/Css/datepicker.css
+++ b/Public/Assets/Css/datepicker.css
@@ -6,178 +6,172 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  */
+
 .datepicker {
-  top: 0;
-  left: 0;
-  padding: 4px;
-  margin-top: 1px;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px;
-  /*.dow {
+    top: 0;
+    left: 0;
+    padding: 4px;
+    margin-top: 1px;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+    /*.dow {
     border-top: 1px solid #ddd !important;
   }*/
-
 }
+
 .datepicker:before {
-  content: '';
-  display: inline-block;
-  border-left: 7px solid transparent;
-  border-right: 7px solid transparent;
-  border-bottom: 7px solid #ccc;
-  border-bottom-color: rgba(0, 0, 0, 0.2);
-  position: absolute;
-  top: -7px;
-  left: 6px;
+    content: '';
+    display: inline-block;
+    border-left: 7px solid transparent;
+    border-right: 7px solid transparent;
+    border-bottom: 7px solid #ccc;
+    border-bottom-color: rgba(0, 0, 0, 0.2);
+    position: absolute;
+    top: -7px;
+    left: 6px;
 }
+
 .datepicker:after {
-  content: '';
-  display: inline-block;
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
-  border-bottom: 6px solid #ffffff;
-  position: absolute;
-  top: -6px;
-  left: 7px;
+    content: '';
+    display: inline-block;
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+    border-bottom: 6px solid #ffffff;
+    position: absolute;
+    top: -6px;
+    left: 7px;
 }
-.datepicker > div {
-  display: none;
+
+.datepicker>div {
+    display: none;
 }
+
 .datepicker table {
-  width: 100%;
-  margin: 0;
+    width: 100%;
+    margin: 0;
 }
-.datepicker td,
-.datepicker th {
-  text-align: center;
-  width: 20px;
-  height: 20px;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px;
+
+.datepicker td, .datepicker th {
+    text-align: center;
+    width: 20px;
+    height: 20px;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
 }
+
 .datepicker td.day:hover {
-  background: #eeeeee;
-  cursor: pointer;
+    background: #eeeeee;
+    cursor: pointer;
 }
+
 .datepicker td.day.disabled {
-  color: #eeeeee;
+    color: #eeeeee;
 }
-.datepicker td.old,
-.datepicker td.new {
-  color: #999999;
-}
-.datepicker td.active,
-.datepicker td.active:hover {
-  color: #ffffff;
-  background-color: #006dcc;
-  background-image: -moz-linear-gradient(top, #0088cc, #0044cc);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0044cc));
-  background-image: -webkit-linear-gradient(top, #0088cc, #0044cc);
-  background-image: -o-linear-gradient(top, #0088cc, #0044cc);
-  background-image: linear-gradient(to bottom, #0088cc, #0044cc);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0044cc', GradientType=0);
-  border-color: #0044cc #0044cc #002a80;
-  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #0044cc;
-  /* Darken IE7 buttons by default so they stand out more given they won't have borders */
 
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
-  color: #fff;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+.datepicker td.old, .datepicker td.new {
+    color: #999999;
 }
-.datepicker td.active:hover,
-.datepicker td.active:hover:hover,
-.datepicker td.active:focus,
-.datepicker td.active:hover:focus,
-.datepicker td.active:active,
-.datepicker td.active:hover:active,
-.datepicker td.active.active,
-.datepicker td.active:hover.active,
-.datepicker td.active.disabled,
-.datepicker td.active:hover.disabled,
-.datepicker td.active[disabled],
-.datepicker td.active:hover[disabled] {
-  color: #ffffff;
-  background-color: #0044cc;
-  *background-color: #003bb3;
+
+.datepicker td.active, .datepicker td.active:hover {
+    color: #ffffff;
+    background-color: #006dcc;
+    background-image: -moz-linear-gradient(top, #0088cc, #0044cc);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0044cc));
+    background-image: -webkit-linear-gradient(top, #0088cc, #0044cc);
+    background-image: -o-linear-gradient(top, #0088cc, #0044cc);
+    background-image: linear-gradient(to bottom, #0088cc, #0044cc);
+    background-repeat: repeat-x;
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0044cc', GradientType=0);
+    border-color: #0044cc #0044cc #002a80;
+    border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+    *background-color: #0044cc;
+    /* Darken IE7 buttons by default so they stand out more given they won't have borders */
+    filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
+    color: #fff;
+    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
 }
-.datepicker td.active:active,
-.datepicker td.active:hover:active,
-.datepicker td.active.active,
-.datepicker td.active:hover.active {
-  background-color: #003399 \9;
+
+.datepicker td.active:hover, .datepicker td.active:hover:hover, .datepicker td.active:focus, .datepicker td.active:hover:focus, .datepicker td.active:active, .datepicker td.active:hover:active, .datepicker td.active.active, .datepicker td.active:hover.active, .datepicker td.active.disabled, .datepicker td.active:hover.disabled, .datepicker td.active[disabled], .datepicker td.active:hover[disabled] {
+    color: #ffffff;
+    background-color: #0044cc;
+    *background-color: #003bb3;
 }
+
+.datepicker td.active:active, .datepicker td.active:hover:active, .datepicker td.active.active, .datepicker td.active:hover.active {
+    background-color: #003399 \9;
+}
+
 .datepicker td span {
-  display: block;
-  width: 47px;
-  height: 54px;
-  line-height: 54px;
-  float: left;
-  margin: 2px;
-  cursor: pointer;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px;
+    display: block;
+    width: 47px;
+    height: 54px;
+    line-height: 54px;
+    float: left;
+    margin: 2px;
+    cursor: pointer;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
 }
+
 .datepicker td span:hover {
-  background: #eeeeee;
+    background: #eeeeee;
 }
+
 .datepicker td span.active {
-  color: #ffffff;
-  background-color: #006dcc;
-  background-image: -moz-linear-gradient(top, #0088cc, #0044cc);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0044cc));
-  background-image: -webkit-linear-gradient(top, #0088cc, #0044cc);
-  background-image: -o-linear-gradient(top, #0088cc, #0044cc);
-  background-image: linear-gradient(to bottom, #0088cc, #0044cc);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0044cc', GradientType=0);
-  border-color: #0044cc #0044cc #002a80;
-  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-  *background-color: #0044cc;
-  /* Darken IE7 buttons by default so they stand out more given they won't have borders */
+    color: #ffffff;
+    background-color: #006dcc;
+    background-image: -moz-linear-gradient(top, #0088cc, #0044cc);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0044cc));
+    background-image: -webkit-linear-gradient(top, #0088cc, #0044cc);
+    background-image: -o-linear-gradient(top, #0088cc, #0044cc);
+    background-image: linear-gradient(to bottom, #0088cc, #0044cc);
+    background-repeat: repeat-x;
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0044cc', GradientType=0);
+    border-color: #0044cc #0044cc #002a80;
+    border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+    *background-color: #0044cc;
+    /* Darken IE7 buttons by default so they stand out more given they won't have borders */
+    filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
+    color: #fff;
+    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+}
 
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
-  color: #fff;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+.datepicker td span.active:hover, .datepicker td span.active:focus, .datepicker td span.active:active, .datepicker td span.active.active, .datepicker td span.active.disabled, .datepicker td span.active[disabled] {
+    color: #ffffff;
+    background-color: #0044cc;
+    *background-color: #003bb3;
 }
-.datepicker td span.active:hover,
-.datepicker td span.active:focus,
-.datepicker td span.active:active,
-.datepicker td span.active.active,
-.datepicker td span.active.disabled,
-.datepicker td span.active[disabled] {
-  color: #ffffff;
-  background-color: #0044cc;
-  *background-color: #003bb3;
+
+.datepicker td span.active:active, .datepicker td span.active.active {
+    background-color: #003399 \9;
 }
-.datepicker td span.active:active,
-.datepicker td span.active.active {
-  background-color: #003399 \9;
-}
+
 .datepicker td span.old {
-  color: #999999;
-}
-.datepicker th.switch {
-  width: 145px;
-}
-.datepicker th.next,
-.datepicker th.prev {
-  font-size: 21px;
-}
-.datepicker thead tr:first-child th {
-  cursor: pointer;
-}
-.datepicker thead tr:first-child th:hover {
-  background: #eeeeee;
-}
-.input-append.date .add-on i,
-.input-prepend.date .add-on i {
-  display: block;
-  cursor: pointer;
-  width: 16px;
-  height: 16px;
+    color: #999999;
 }
 
+.datepicker th.switch {
+    width: 145px;
+}
+
+.datepicker th.next, .datepicker th.prev {
+    font-size: 21px;
+}
+
+.datepicker thead tr:first-child th {
+    cursor: pointer;
+}
+
+.datepicker thead tr:first-child th:hover {
+    background: #eeeeee;
+}
+
+.input-append.date .add-on i, .input-prepend.date .add-on i {
+    display: block;
+    cursor: pointer;
+    width: 16px;
+    height: 16px;
+}

--- a/Public/Assets/Css/responsive.css
+++ b/Public/Assets/Css/responsive.css
@@ -1,6 +1,7 @@
 /*--- layout ---*/
-@media (min-width: 768px){
-/*	.hbox>aside, .hbox>section {
+
+@media (min-width: 768px) {
+    /*	.hbox>aside, .hbox>section {
 	display: table-cell;
 	vertical-align: top;
 	height: 100%;
@@ -9,34 +10,34 @@
 	vertical-align: top;
 	height: 100%;
 	}*/
-	#content{
-		margin-left: 200px
-	}
-	#content{
-		width: 100%;
-		height: 100%;
-		display: table-cell;
-	}
-	#toolbar{
-		/*float: left;*/
-		min-width: 200px;
-		height: 100%;
-		display: table-cell;
-		vertical-align: top;
-	}
-	body.connected{
-		background: #F3F5F9 url(img/toolbar-bg-2.png) repeat-y -600px top;
-	}
-	.calendar-link i{
-  		display: block;
-  		margin: 0;
-  		font-size: 40px;
-  		border: solid 2px #FFF;
-  		padding: 10px;
-  		-webkit-border-radius: 60px;
-  		-moz-border-radius: 60px;
-  		border-radius: 60px;
-  		width: 64px;
-  		margin: 0 auto 10px auto;
-	}
+    #content {
+        margin-left: 200px
+    }
+    #content {
+        width: 100%;
+        height: 100%;
+        display: table-cell;
+    }
+    #toolbar {
+        /*float: left;*/
+        min-width: 200px;
+        height: 100%;
+        display: table-cell;
+        vertical-align: top;
+    }
+    body.connected {
+        background: #F3F5F9 url(img/toolbar-bg-2.png) repeat-y -600px top;
+    }
+    .calendar-link i {
+        display: block;
+        margin: 0;
+        font-size: 40px;
+        border: solid 2px #FFF;
+        padding: 10px;
+        -webkit-border-radius: 60px;
+        -moz-border-radius: 60px;
+        border-radius: 60px;
+        width: 64px;
+        margin: 0 auto 10px auto;
+    }
 }

--- a/Public/Assets/Js/reboot.js
+++ b/Public/Assets/Js/reboot.js
@@ -6,13 +6,11 @@
  * @param int    MyWidth  entier indiquant la largeur de la fenêtre en pixels
  * @param int    MyHeight entier indiquant la hauteur de la fenêtre en pixels
  */
-function OpenPopUp(MyFile,MyWindow,MyWidth,MyHeight)
-{
-    var ns4 = (document.layers)? true:false; //NS 4
-    var ie4 = (document.all)? true:false; //IE 4
-    var dom = (document.getElementById)? true:false; //DOM
+function OpenPopUp(MyFile, MyWindow, MyWidth, MyHeight) {
+    var ns4 = (document.layers) ? true : false; //NS 4
+    var ie4 = (document.all) ? true : false; //IE 4
+    var dom = (document.getElementById) ? true : false; //DOM
     var xMax, yMax, xOffset, yOffset;;
-
     if (ie4 || dom) {
         xMax = screen.width;
         yMax = screen.height;
@@ -23,129 +21,105 @@ function OpenPopUp(MyFile,MyWindow,MyWidth,MyHeight)
         xMax = 800;
         yMax = 600;
     }
-    xOffset = (xMax - MyWidth)/2;
-    yOffset = (yMax - MyHeight)/2;
-    window.open(MyFile,MyWindow,'width='+MyWidth
-        +',height='+MyHeight
-        +',screenX='+xOffset
-        +',screenY='+yOffset
-        +',top='+yOffset
-        +',left='+xOffset
-        +',scrollbars=yes,resizable=yes');
+    xOffset = (xMax - MyWidth) / 2;
+    yOffset = (yMax - MyHeight) / 2;
+    window.open(MyFile, MyWindow, 'width=' + MyWidth + ',height=' + MyHeight + ',screenX=' + xOffset + ',screenY=' + yOffset + ',top=' + yOffset + ',left=' + xOffset + ',scrollbars=yes,resizable=yes');
 }
-
 /**
  * Compte le nombre de jours de congés entre deux dates en fonctions du contexte (temps partiel, jours fériés, fermeture, ...)
  */
-function compter_jours()
-{
-    $(document).ready(function () {
+function compter_jours() {
+    $(document).ready(function() {
         var login = document.forms["dem_conges"].user_login.value;
         var session = document.forms["dem_conges"].session.value;
         var d_debut = document.forms["dem_conges"].new_debut.value;
         var d_fin = document.forms["dem_conges"].new_fin.value;
-	    var opt_deb = document.querySelector('input[name = "new_demi_jour_deb"]:checked').value;
-	    var opt_fin = document.querySelector('input[name = "new_demi_jour_fin"]:checked').value;
+        var opt_deb = document.querySelector('input[name = "new_demi_jour_deb"]:checked').value;
+        var opt_fin = document.querySelector('input[name = "new_demi_jour_fin"]:checked').value;
         var p_num = "";
-
-        if( document.forms["dem_conges"].p_num_to_update ) {
+        if (document.forms["dem_conges"].p_num_to_update) {
             var p_num = document.forms["dem_conges"].p_num_to_update.value;
         }
-
-        if( (d_debut) && (d_fin)) {
-            var page = '../calcul_nb_jours_pris.php?session=' + session + '&date_debut=' + d_debut + '&date_fin=' + d_fin+'&user=' + login + '&opt_debut=' +opt_deb + '&opt_fin=' + opt_fin + '&p_num=' +p_num;
-
+        if ((d_debut) && (d_fin)) {
+            var page = '../calcul_nb_jours_pris.php?session=' + session + '&date_debut=' + d_debut + '&date_fin=' + d_fin + '&user=' + login + '&opt_debut=' + opt_deb + '&opt_fin=' + opt_fin + '&p_num=' + p_num;
             $.ajax({
-                type : 'GET',
-                url : page,
-                dataType : 'text', // expected returned data format.
-                success : function(data)
-                {
+                type: 'GET',
+                url: page,
+                dataType: 'text', // expected returned data format.
+                success: function(data) {
                     var arr = new Array();
                     arr = JSON.parse(data);
-                    document.forms["dem_conges"].new_nb_jours.value=arr["nb"];
+                    document.forms["dem_conges"].new_nb_jours.value = arr["nb"];
                     document.getElementById('comment_nbj').innerHTML = arr["comm"];
                 },
             });
         }
     });
 }
-
 /**
  * Génère le datepicker sur un champ, paramétré par des options précises
  *
  * @param object opts
  */
-function generateDatePicker(opts, compter = true)
-{
+function generateDatePicker(opts, compter = true) {
     var defaultOpts = {
-        format             : 'dd/mm/yyyy',
-        language           : 'fr',
-        autoclose          : true,
-        todayHighlight     : true,
-        daysOfWeekDisabled : [],
-        datesDisabled      : [],
-        startDate          : ''
+        format: 'dd/mm/yyyy',
+        language: 'fr',
+        autoclose: true,
+        todayHighlight: true,
+        daysOfWeekDisabled: [],
+        datesDisabled: [],
+        startDate: ''
     };
     var toApply = defaultOpts;
-
     /* On ne peut pas écraser une option qui n'existe en défaut */
     for (var i in defaultOpts) {
         toApply[i] = (undefined !== opts[i]) ? opts[i] : defaultOpts[i];
     }
-    $(document).ready(function () {
+    $(document).ready(function() {
         $('input.date').datepicker(toApply).on("change", function() {
-            if( compter == true) {
+            if (compter == true) {
                 compter_jours();
             }
         });
     });
 }
-
 /**
  * Génère le timePicker sur un champ, paramétré par des options précises
  *
  * @param string elementId L'id unique du champ sur lequel on applique le timePicker
  * @param object opts
  */
-function generateTimePicker(elementId, opts)
-{
+function generateTimePicker(elementId, opts) {
     var defaultOpts = {
-        minuteStep             : 30,
-        showInputs             : false,
-        showMeridian           : false,
-        showWidgetOnAddonClick : false,
-        defaultTime            : '12:00',
+        minuteStep: 30,
+        showInputs: false,
+        showMeridian: false,
+        showWidgetOnAddonClick: false,
+        defaultTime: '12:00',
     };
     var toApply = defaultOpts;
-
     if (undefined !== opts) {
         /* On ne peut pas écraser une option qui n'existe en défaut */
         for (var i in defaultOpts) {
             toApply[i] = (undefined !== opts[i]) ? opts[i] : defaultOpts[i];
         }
     }
-
     $('#' + elementId).timepicker(toApply);
 }
-
 /**
  * Objet de présentation de l'affichage des semaines
  */
-var semaineDisplayer = function (idElement, idCommon, typeSemaines, texts)
-{
-    this.element      = document.getElementById(idElement);
-    this.idCommon     = idCommon;
+var semaineDisplayer = function(idElement, idCommon, typeSemaines, texts) {
+    this.element = document.getElementById(idElement);
+    this.idCommon = idCommon;
     this.typeSemaines = typeSemaines;
-    this.texts        = texts;
-
+    this.texts = texts;
     /**
      * Lance l'initialisation de l'afficheur
      */
-    this.init = function ()
-    {
+    this.init = function() {
         var displayedNot = false;
-
         for (var idType in this.typeSemaines) {
             if (this.typeSemaines.hasOwnProperty(idType)) {
                 if (idType !== this.idCommon) {
@@ -160,56 +134,45 @@ var semaineDisplayer = function (idElement, idCommon, typeSemaines, texts)
         if (!displayedNot) {
             this._unclickedElement(this.element);
         }
-
         /* Événementiel */
-        this.element.addEventListener('click', function (e) {
+        this.element.addEventListener('click', function(e) {
             var element = e.target;
             if (element.classList.contains('active')) {
                 this._unclickedElement(element);
             } else {
                 this._clickedElement(element);
             }
-
         }.bind(this));
-
         return this;
     }
-
     /**
      * Présente l'élément comme cliqué en affichant les semaines correspondantes
      */
-    this._clickedElement = function (element)
-    {
+    this._clickedElement = function(element) {
         element.classList.add('active');
         element.value = this.texts['common'];
         this._displayNotCommon();
     }
-
     /**
      * Présente l'élément comme non cliqué en affichant les semaines correspondantes
      */
-    this._unclickedElement = function (element)
-    {
+    this._unclickedElement = function(element) {
         element.classList.remove('active');
         element.value = this.texts['notCommon'];
         this._displayCommon();
     }
-
     /**
      * Vérifie que la semaine a des inputs décisifs en son sein
      *
      * @return bool
      */
-    this._hasWeekInputs = function (typeSemaine)
-    {
+    this._hasWeekInputs = function(typeSemaine) {
         return 0 < this._getWeekInputs(typeSemaine).length;
     }
-
     /**
      * Affiche les semaines non communes
      */
-    this._displayNotCommon = function ()
-    {
+    this._displayNotCommon = function() {
         /* Show not common */
         for (var idType in this.typeSemaines) {
             if (this.typeSemaines.hasOwnProperty(idType)) {
@@ -219,19 +182,15 @@ var semaineDisplayer = function (idElement, idCommon, typeSemaines, texts)
                 }
             }
         }
-
         /* Hide common */
         this._hideBlock(this.typeSemaines[this.idCommon]);
     }
-
     /**
      * Affiche les semaines communes
      */
-    this._displayCommon = function ()
-    {
+    this._displayCommon = function() {
         /* Show common */
         this._showBlock(this.typeSemaines[this.idCommon]);
-
         /* Hide not common */
         for (var idType in this.typeSemaines) {
             if (this.typeSemaines.hasOwnProperty(idType)) {
@@ -242,72 +201,58 @@ var semaineDisplayer = function (idElement, idCommon, typeSemaines, texts)
             }
         }
     }
-
     /**
      * Affiche un bloc et active tous les champs décisifs en son sein
      */
-    this._showBlock = function (typeSemaine)
-    {
+    this._showBlock = function(typeSemaine) {
         var inputs = this._getWeekInputs(typeSemaine);
         for (var i = 0; i < inputs.length; ++i) {
             inputs[i].disabled = '';
         }
-
         document.getElementById(typeSemaine).style.display = 'block';
     }
-
     /**
      * Cache un bloc et désactive tous les champs décisifs en son sein
      */
-    this._hideBlock = function (typeSemaine)
-    {
+    this._hideBlock = function(typeSemaine) {
         var inputs = this._getWeekInputs(typeSemaine);
         for (var i = 0; i < inputs.length; ++i) {
             inputs[i].disabled = 'disabled';
         }
-
         document.getElementById(typeSemaine).style.display = 'none';
     }
-
     /**
      * Retourne tous les inputs décisifs de la semaine
      *
      * @return Object
      */
-    this._getWeekInputs = function (typeSemaine)
-    {
+    this._getWeekInputs = function(typeSemaine) {
         // TODO : not with reference sur un autre form ?
         return document.getElementById(typeSemaine).querySelectorAll('input[type=hidden]');
     }
-
     /**
      * Lance l'initialisation de l'afficheur en mode lecture seule
      */
-    this.readOnly = function ()
-    {
+    this.readOnly = function() {
         this.element.style.display = 'none';
     }
 }
-
 /**
  * Objet de manipulation du planning
  */
-var planningController = function (idElement, options, creneaux)
-{
+var planningController = function(idElement, options, creneaux) {
     this.element = document.getElementById(idElement);
     this.options = options;
     this.typeSemaine = this.options['typeSemaine'];
     this.debut = this.options['typeHeureDebut'];
-    this.fin   = this.options['typeHeureFin'];
+    this.fin = this.options['typeHeureFin'];
     this.incrementMatin = 0;
     this.incrementApresMidi = 0;
-
     /**
      * Lance l'initialisation de l'afficheur
      */
-    this.init = function ()
-    {
-        this.element.addEventListener('click', function () {
+    this.init = function() {
+        this.element.addEventListener('click', function() {
             var select = document.getElementById(this.options['selectJourId']);
             var jourSelectionne = select.options[select.selectedIndex].value;
             var radios = document.body.querySelectorAll('input[type="radio"]');
@@ -340,39 +285,31 @@ var planningController = function (idElement, options, creneaux)
                 this._fillHelper(this.options['erreurOptionManquante']);
             }
         }.bind(this));
-
         /* Remplissage des valeurs préexistantes */
         this._addPeriods(creneaux);
     }
-
     /**
      * Vérifie qu'une période n'existe pas déjà sur le jour demandé
      */
-    this._alreadyExistPeriod = function (jour, debut, fin) {
+    this._alreadyExistPeriod = function(jour, debut, fin) {
         var table = document.getElementById(this.options['tableId']);
-        var ligneCible = table.querySelector('tr[data-id-jour="' +  jour + '"]');
-
+        var ligneCible = table.querySelector('tr[data-id-jour="' + jour + '"]');
         return null !== ligneCible.querySelector('span[data-heures="' + debut + '-' + fin + '"]');
     }
-
     /**
      * Vide le helper
      */
-    this._emptyHelper = function ()
-    {
+    this._emptyHelper = function() {
         document.getElementById(this.options['helperId']).innerHTML = '';
     }
-
     /**
      * Remplis le helper avec le texte fourni
      *
      * @param string text
      */
-    this._fillHelper = function (text)
-    {
+    this._fillHelper = function(text) {
         document.getElementById(this.options['helperId']).innerHTML = text;
     }
-
     /**
      * Vérifie que l'heure respecte bien un format donné
      *
@@ -380,14 +317,11 @@ var planningController = function (idElement, options, creneaux)
      *
      * @return bool
      */
-    this._checkTimeValue = function (timeValue)
-    {
-        timeValue   = timeValue.trim();
+    this._checkTimeValue = function(timeValue) {
+        timeValue = timeValue.trim();
         var pattern = new RegExp("^(([01]?[0-9])|(2[0-3])):[0-5][0-9]$");
-
         return pattern.test(timeValue);
     }
-
     /**
      * Ajoute une liste de périodes au planning
      *
@@ -395,8 +329,7 @@ var planningController = function (idElement, options, creneaux)
      *
      * @return void
      */
-    this._addPeriods = function (creneaux)
-    {
+    this._addPeriods = function(creneaux) {
         for (var jour in creneaux) {
             var dataJour = creneaux[jour];
             for (var periode in dataJour) {
@@ -411,7 +344,6 @@ var planningController = function (idElement, options, creneaux)
             }
         }
     }
-
     /**
      * Ajoute une nouvelle période au planning
      *
@@ -422,14 +354,11 @@ var planningController = function (idElement, options, creneaux)
      *
      * @return void
      */
-    this._addPeriod = function (jourSelectionne, typePeriodeSelected, debutVal, finVal)
-    {
+    this._addPeriod = function(jourSelectionne, typePeriodeSelected, debutVal, finVal) {
         var table = document.getElementById(this.options['tableId']);
-        var ligneCible = table.querySelector('tr[data-id-jour="' +  jourSelectionne + '"]');
+        var ligneCible = table.querySelector('tr[data-id-jour="' + jourSelectionne + '"]');
         var cellCible = ligneCible.getElementsByClassName('creneaux')[0];
-
         var periode = this._getVisiblePeriod(jourSelectionne, typePeriodeSelected, debutVal, finVal);
-
         var allPeriods = ligneCible.querySelectorAll('span[data-heures]');
         if (0 < allPeriods.length) {
             cellCible.insertBefore(periode, this._findSuccPeriod(periode, allPeriods));
@@ -437,7 +366,6 @@ var planningController = function (idElement, options, creneaux)
             cellCible.appendChild(periode);
         }
     }
-
     /**
      * Retourne la structure DOM d'une période à afficher
      *
@@ -448,20 +376,20 @@ var planningController = function (idElement, options, creneaux)
      *
      * @return HTMLSpanElement
      */
-    this._getVisiblePeriod = function (jourSelectionne, typePeriodeSelected, debutVal, finVal) {
+    this._getVisiblePeriod = function(jourSelectionne, typePeriodeSelected, debutVal, finVal) {
         var span = document.createElement('span');
         var iBaseTag = document.createElement('i');
         var iTo = iBaseTag.cloneNode(false);
         var buttonTag = document.createElement('button');
         buttonTag.className = 'btn btn-default btn-xs';
         buttonTag.type = 'button';
-        buttonTag.addEventListener('click', function (e) {
+        buttonTag.addEventListener('click', function(e) {
             this._removePeriod(buttonTag.parentNode);
         }.bind(this));
         iTo.className = 'fa fa-caret-right';
         var debut = document.createTextNode(' ' + debutVal + ' ');
-        var labelTypePeriode = (this.options['typePeriodeMatin'] == typePeriodeSelected ) ? 'am' : 'pm';
-        var fin   = document.createTextNode(' ' + finVal + ' (' + labelTypePeriode + ') ');
+        var labelTypePeriode = (this.options['typePeriodeMatin'] == typePeriodeSelected) ? 'am' : 'pm';
+        var fin = document.createTextNode(' ' + finVal + ' (' + labelTypePeriode + ') ');
         var iMinus = iBaseTag.cloneNode(false);
         iMinus.className = 'fa fa-minus';
         span.appendChild(debut);
@@ -471,10 +399,8 @@ var planningController = function (idElement, options, creneaux)
         span.appendChild(buttonTag);
         span.appendChild(this._getHiddenFieldPeriod(jourSelectionne, typePeriodeSelected, debutVal, finVal));
         span.dataset.heures = debutVal + '-' + finVal;
-
         return span;
     }
-
     /**
      * Retourne la structure DOM des champs cachés d'une période à afficher
      *
@@ -485,8 +411,8 @@ var planningController = function (idElement, options, creneaux)
      *
      * @return HTMLSpanElement
      */
-    this._getHiddenFieldPeriod = function (jourSelectionne, typePeriodeSelected, debutVal, finVal) {
-        var span  = document.createElement('span');
+    this._getHiddenFieldPeriod = function(jourSelectionne, typePeriodeSelected, debutVal, finVal) {
+        var span = document.createElement('span');
         var input = document.createElement('input');
         var debut = input.cloneNode(false);
         var prefixName = 'creneaux[' + this.typeSemaine + '][' + jourSelectionne + '][' + typePeriodeSelected + ']';
@@ -495,29 +421,25 @@ var planningController = function (idElement, options, creneaux)
         } else {
             var prefixName = prefixName + '[' + (++this.incrementMatin) + ']';
         }
-        debut.type  = 'hidden';
-        debut.name  = prefixName + '[' + this.debut + ']';
+        debut.type = 'hidden';
+        debut.name = prefixName + '[' + this.debut + ']';
         debut.value = debutVal;
-        var fin     = input.cloneNode(false);
-        fin.type    = 'hidden';
-        fin.name    = prefixName + '[' + this.fin + ']';
-        fin.value   = finVal;
+        var fin = input.cloneNode(false);
+        fin.type = 'hidden';
+        fin.name = prefixName + '[' + this.fin + ']';
+        fin.value = finVal;
         span.appendChild(debut);
         span.appendChild(fin);
-
         return span;
     }
-
     /**
      * Supprime une période du planning
      *
      * @return void
      */
-    this._removePeriod = function (period)
-    {
+    this._removePeriod = function(period) {
         period.parentNode.removeChild(period);
     }
-
     /**
      * Retourne la période suivante à period dans l'ordre lexicographique parmi allPeriods
      *
@@ -526,8 +448,7 @@ var planningController = function (idElement, options, creneaux)
      *
      * @return HTMLSpanElement | null
      */
-    this._findSuccPeriod = function (period, allPeriods)
-    {
+    this._findSuccPeriod = function(period, allPeriods) {
         for (var i = 0; i < allPeriods.length; ++i) {
             var brother = allPeriods[i];
             var heurePeriode = period.dataset.heures;
@@ -537,29 +458,22 @@ var planningController = function (idElement, options, creneaux)
             }
         }
     }
-
     /**
      * Lance l'initialisation de l'afficheur en mode lecture seule
      */
-    this.readOnly = function ()
-    {
+    this.readOnly = function() {
         /* Remplissage des valeurs préexistantes */
         this._addPeriods(creneaux);
         var boutons = document.getElementById(this.options.tableId).querySelectorAll('button');
         for (var i = 0; i < boutons.length; ++i) {
             bouton = boutons[i].style.display = 'none';
         }
-
         var inputs = document.getElementById(this.options.tableId).querySelectorAll('input');
-
         for (var i = 0; i < inputs.length; ++i) {
             inputs[i].style.display = 'none';
         }
-
     }
 }
-
-
 /**
  * Objet de gestion des utilisateurs de planning
  *
@@ -567,17 +481,15 @@ var planningController = function (idElement, options, creneaux)
  * @param Object associationsGroupe Associations groupes <> utilisateurs
  * @param int nilId Nullité numérique
  */
-var selectAssociationPlanning = function (idElement, associationsGroupe, nilId)
-{
+var selectAssociationPlanning = function(idElement, associationsGroupe, nilId) {
     this.element = document.getElementById(idElement);
     this.associationsGroupe = associationsGroupe;
     this.nilId = parseInt(nilId);
     this.utilisateurs = document.querySelectorAll('form > div > div.checkbox-utilisateur');
-
     /**
      * Event
      */
-    this.element.addEventListener('change', function (e) {
+    this.element.addEventListener('change', function(e) {
         var idGroupe = e.target.value;
         if (this.nilId != idGroupe) {
             this._filterUsers(idGroupe);
@@ -585,14 +497,12 @@ var selectAssociationPlanning = function (idElement, associationsGroupe, nilId)
             this._resetFilter();
         }
     }.bind(this));
-
     /**
      * Filtre les utilisateurs en fonction du groupe passé
      *
      * @param int idGroupe
      */
-    this._filterUsers = function (idGroupe)
-    {
+    this._filterUsers = function(idGroupe) {
         this._resetFilter();
         idGroupe = parseInt(idGroupe);
         if (this.associationsGroupe.hasOwnProperty(idGroupe)) {
@@ -606,12 +516,10 @@ var selectAssociationPlanning = function (idElement, associationsGroupe, nilId)
             }
         }
     }
-
     /**
      * Annule tout filtre de groupe
      */
-    this._resetFilter = function ()
-    {
+    this._resetFilter = function() {
         for (var i = 0; i < this.utilisateurs.length; ++i) {
             this.utilisateurs[i].style.display = 'block';
         }

--- a/Tests/Units/App/Helpers/Formatter.php
+++ b/Tests/Units/App/Helpers/Formatter.php
@@ -188,13 +188,13 @@ class Formatter extends \Tests\Units\TestUnit
     }
 
     /**
-    * Test la transformation d'un nombre de secondes négatif en hh:ii
+     * Test la transformation d'un nombre de secondes négatif en hh:ii
      *
      * @since 1.9
      */
     public function testNegatifTimestamp2Duree()
     {
-        $ts = - 3600;
+        $ts = -3600;
 
         $time = _Formatter::timestamp2Duree($ts);
 

--- a/Tests/Units/App/Libraries/Calendrier/Evenement/Commun.php
+++ b/Tests/Units/App/Libraries/Calendrier/Evenement/Commun.php
@@ -30,13 +30,13 @@ class Commun extends \Tests\Units\TestUnit
      */
     public function beforeTestMethod($method)
     {
-        $uid = 'uniqid';
-        $debut = new \DateTimeImmutable($this->debutEvenement);
-        $fin = new \DateTimeImmutable($this->finEvenement);
-        $name = 'John Malkovich';
-        $title = 'titre';
-        $class = 'class';
-        $this->tested = new _Commun($uid, $debut, $fin, $name, $title, $class);
+        $uid            = 'uniqid';
+        $debut          = new \DateTimeImmutable($this->debutEvenement);
+        $fin            = new \DateTimeImmutable($this->finEvenement);
+        $name           = 'John Malkovich';
+        $title          = 'titre';
+        $class          = 'class';
+        $this->tested   = new _Commun($uid, $debut, $fin, $name, $title, $class);
         $this->calendar = new \CalendR\Calendar();
     }
 
@@ -199,7 +199,7 @@ class Commun extends \Tests\Units\TestUnit
      */
     public function testIsDuringAfterEnd()
     {
-        $date = new \DateTime('2006-12-28');
+        $date    = new \DateTime('2006-12-28');
         $semaine = $this->calendar->getWeek($date);
 
         $this->boolean($this->tested->isDuring($semaine))->isFalse();
@@ -210,11 +210,11 @@ class Commun extends \Tests\Units\TestUnit
      */
     public function testIsDuringInPeriod()
     {
-        $debut = new \DateTimeImmutable($this->debutEvenement);
-        $fin = new \DateTimeImmutable('2006-12-28');
+        $debut  = new \DateTimeImmutable($this->debutEvenement);
+        $fin    = new \DateTimeImmutable('2006-12-28');
         $tested = new _Commun('', $debut, $fin, '', '', '');
-        $date = new \DateTime('2006-12-01');
-        $mois = $this->calendar->getMonth($date);
+        $date   = new \DateTime('2006-12-01');
+        $mois   = $this->calendar->getMonth($date);
 
         $this->boolean($tested->isDuring($mois))->isTrue();
     }

--- a/Tests/Units/App/Libraries/Structure/Table.php
+++ b/Tests/Units/App/Libraries/Structure/Table.php
@@ -45,8 +45,8 @@ class Table extends \Tests\Units\TestUnit
         $this->output(function () use ($table, $child) {
             $this->when($table->render())
                 ->mock($child)
-                    ->call('render')
-                        ->once();
+                ->call('render')
+                ->once();
         });
     }
 }

--- a/Tests/Units/utilisateur/Fonctions.php
+++ b/Tests/Units/utilisateur/Fonctions.php
@@ -64,7 +64,7 @@ class Fonctions extends \Tests\Units\TestUnit
     public function testGetRealWeekTypeNone()
     {
         $planningUser = [54 => []];
-        $res = _Fonctions::getRealWeekType($planningUser, 2);
+        $res          = _Fonctions::getRealWeekType($planningUser, 2);
         $this->integer($res)->isIdenticalTo(NIL_INT);
     }
 

--- a/admin/Fonctions.php
+++ b/admin/Fonctions.php
@@ -2,8 +2,8 @@
 namespace admin;
 
 /**
-* Regroupement des fonctions liées à l'admin
-*/
+ * Regroupement des fonctions liées à l'admin
+ */
 class Fonctions
 {
     // modifie, pour un resp donné,  les groupes dont il est resp et grands_resp
@@ -13,43 +13,43 @@ class Fonctions
         $session  = session_id();
         $return   = '';
 
-        $result_insert=TRUE;
-        $result_insert_2=TRUE;
+        $result_insert   = true;
+        $result_insert_2 = true;
 
         //echo "responsable : $choix_resp<br>\n";
         // on supprime tous les anciens resps du groupe puis on ajoute tous ceux qui sont dans le tableau de la checkbox
-        $sql_del = 'DELETE FROM conges_groupe_resp WHERE gr_login="'. \includes\SQL::quote($choix_resp).'"';
+        $sql_del    = 'DELETE FROM conges_groupe_resp WHERE gr_login="' . \includes\SQL::quote($choix_resp) . '"';
         $ReqLog_del = \includes\SQL::query($sql_del);
 
         // on supprime tous les anciens grands resps du groupe puis on ajoute tous ceux qui sont dans le tableau de la checkbox
-        $sql_del_2 = 'DELETE FROM conges_groupe_grd_resp WHERE ggr_login="'. \includes\SQL::quote($choix_resp).'"';
+        $sql_del_2    = 'DELETE FROM conges_groupe_grd_resp WHERE ggr_login="' . \includes\SQL::quote($choix_resp) . '"';
         $ReqLog_del_2 = \includes\SQL::query($sql_del_2);
 
         // ajout des resp qui sont dans la checkbox
-        if($checkbox_resp_group!="") // si la checkbox contient qq chose
+        if ($checkbox_resp_group != "") // si la checkbox contient qq chose
         {
-            foreach($checkbox_resp_group as $gid => $value) {
-                $sql_insert = "INSERT INTO conges_groupe_resp SET gr_gid=$gid, gr_login='$choix_resp' "  ;
+            foreach ($checkbox_resp_group as $gid => $value) {
+                $sql_insert    = "INSERT INTO conges_groupe_resp SET gr_gid=$gid, gr_login='$choix_resp' ";
                 $result_insert = \includes\SQL::query($sql_insert);
             }
         }
 
         // ajout des grands resp qui sont dans la checkbox
-        if($checkbox_grd_resp_group!="") // si la checkbox contient qq chose
+        if ($checkbox_grd_resp_group != "") // si la checkbox contient qq chose
         {
-            foreach($checkbox_grd_resp_group as $grd_gid => $value) {
-                $sql_insert_2 = "INSERT INTO conges_groupe_grd_resp SET ggr_gid=$grd_gid, ggr_login='$choix_resp' "  ;
+            foreach ($checkbox_grd_resp_group as $grd_gid => $value) {
+                $sql_insert_2    = "INSERT INTO conges_groupe_grd_resp SET ggr_gid=$grd_gid, ggr_login='$choix_resp' ";
                 $result_insert_2 = \includes\SQL::query($sql_insert_2);
             }
         }
 
-        if(($result_insert) && ($result_insert_2) ) {
+        if (($result_insert) && ($result_insert_2)) {
             $return .= _('form_modif_ok') . ' !<br><br>';
         } else {
             $return .= _('form_modif_not_ok') . ' !<br><br>';
         }
 
-        $comment_log = "mofification groupes dont $choix_resp est responsable ou grand responsable" ;
+        $comment_log = "mofification groupes dont $choix_resp est responsable ou grand responsable";
         log_action(0, "", $choix_resp, $comment_log);
 
         /* APPEL D'UNE AUTRE PAGE */
@@ -72,41 +72,41 @@ class Fonctions
         /* Affichage Responsable    */
         /****************************/
         // Récuperation des informations :
-        $sql_r = 'SELECT u_nom, u_prenom FROM conges_users WHERE u_login="'. \includes\SQL::quote($choix_resp).'"';
+        $sql_r    = 'SELECT u_nom, u_prenom FROM conges_users WHERE u_login="' . \includes\SQL::quote($choix_resp) . '"';
         $ReqLog_r = \includes\SQL::query($sql_r);
 
         $resultat_r = $ReqLog_r->fetch_array();
-        $sql_nom=$resultat_r["u_nom"] ;
-        $sql_prenom=$resultat_r["u_prenom"] ;
+        $sql_nom    = $resultat_r["u_nom"];
+        $sql_prenom = $resultat_r["u_prenom"];
 
-        $return .= '<h2>Responsable : <strong>' . $sql_prenom . ' ' . $sql_nom .'</strong></h2>';
+        $return .= '<h2>Responsable : <strong>' . $sql_prenom . ' ' . $sql_nom . '</strong></h2>';
         $return .= '<hr/>';
 
         //on rempli un tableau de tous les groupe avec le groupename, le commentaire (tableau de tableaux à 3 cellules)
         // Récuperation des groupes :
-        $tab_groupe=array();
-        $sql_groupe = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename "  ;
+        $tab_groupe    = array();
+        $sql_groupe    = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename ";
         $ReqLog_groupe = \includes\SQL::query($sql_groupe);
 
-        while($resultat_groupe=$ReqLog_groupe->fetch_array()) {
-            $tab_g=array();
-            $tab_g["gid"]=$resultat_groupe["g_gid"];
-            $tab_g["group"]=$resultat_groupe["g_groupename"];
-            $tab_g["comment"]=$resultat_groupe["g_comment"];
-            $tab_groupe[]=$tab_g;
+        while ($resultat_groupe = $ReqLog_groupe->fetch_array()) {
+            $tab_g            = array();
+            $tab_g["gid"]     = $resultat_groupe["g_gid"];
+            $tab_g["group"]   = $resultat_groupe["g_groupename"];
+            $tab_g["comment"] = $resultat_groupe["g_comment"];
+            $tab_groupe[]     = $tab_g;
         }
 
         //on rempli un tableau de tous les groupes a double validation avec le groupename, le commentaire (tableau de tableau à 3 cellules)
-        $tab_groupe_dbl_valid=array();
-        $sql_g2 = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe WHERE g_double_valid='Y' ORDER BY g_groupename "  ;
-        $ReqLog_g2 = \includes\SQL::query($sql_g2);
+        $tab_groupe_dbl_valid = array();
+        $sql_g2               = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe WHERE g_double_valid='Y' ORDER BY g_groupename ";
+        $ReqLog_g2            = \includes\SQL::query($sql_g2);
 
-        while($resultat_groupe_2=$ReqLog_g2->fetch_array()) {
-            $tab_g_2=array();
-            $tab_g_2["gid"]=$resultat_groupe_2["g_gid"];
-            $tab_g_2["group"]=$resultat_groupe_2["g_groupename"];
-            $tab_g_2["comment"]=$resultat_groupe_2["g_comment"];
-            $tab_groupe_dbl_valid[]=$tab_g_2;
+        while ($resultat_groupe_2 = $ReqLog_g2->fetch_array()) {
+            $tab_g_2                = array();
+            $tab_g_2["gid"]         = $resultat_groupe_2["g_gid"];
+            $tab_g_2["group"]       = $resultat_groupe_2["g_groupename"];
+            $tab_g_2["comment"]     = $resultat_groupe_2["g_comment"];
+            $tab_groupe_dbl_valid[] = $tab_g_2;
         }
 
         /*****************************************************************************/
@@ -136,30 +136,30 @@ class Fonctions
         $childTable .= '<tbody>';
 
         // on rempli un autre tableau des groupes dont resp est responsables
-        $tab_resp=array();
-        $sql_r = 'SELECT gr_gid FROM conges_groupe_resp WHERE gr_login="'. \includes\SQL::quote($choix_resp).'" ORDER BY gr_gid ';
+        $tab_resp = array();
+        $sql_r    = 'SELECT gr_gid FROM conges_groupe_resp WHERE gr_login="' . \includes\SQL::quote($choix_resp) . '" ORDER BY gr_gid ';
         $ReqLog_r = \includes\SQL::query($sql_r);
 
-        while($resultat_r=$ReqLog_r->fetch_array()) {
-            $tab_resp[]=$resultat_r["gr_gid"];
+        while ($resultat_r = $ReqLog_r->fetch_array()) {
+            $tab_resp[] = $resultat_r["gr_gid"];
         }
 
         // ensuite on affiche tous les groupes avec une case cochée si exist groupename dans le 2ieme tableau
         $count = count($tab_groupe);
         for ($i = 0; $i < $count; $i++) {
-            $gid=$tab_groupe[$i]["gid"] ;
-            $group=$tab_groupe[$i]["group"] ;
-            $comment=$tab_groupe[$i]["comment"] ;
+            $gid     = $tab_groupe[$i]["gid"];
+            $group   = $tab_groupe[$i]["group"];
+            $comment = $tab_groupe[$i]["comment"];
 
-            if (in_array ($gid, $tab_resp)) {
-                $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_resp_group[$gid]\" value=\"$gid\" checked>";
-                $class="histo-big";
+            if (in_array($gid, $tab_resp)) {
+                $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_resp_group[$gid]\" value=\"$gid\" checked>";
+                $class         = "histo-big";
             } else {
-                $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_resp_group[$gid]\" value=\"$gid\">";
-                $class="histo";
+                $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_resp_group[$gid]\" value=\"$gid\">";
+                $class         = "histo";
             }
 
-            $childTable .= '<tr class="' . (!($i%2) ? 'i' : 'p') . '">';
+            $childTable .= '<tr class="' . (!($i % 2) ? 'i' : 'p') . '">';
             $childTable .= '<td>' . $case_a_cocher . '</td>';
             $childTable .= '<td class="' . $class . '">' . $group . '</td>';
             $childTable .= '<td class="' . $class . '">' . $comment . '</td>';
@@ -174,7 +174,7 @@ class Fonctions
         /*******************************************/
         $return .= '</div>';
         // si on a configuré la double validation
-        if($_SESSION['config']['double_validation_conges']) {
+        if ($_SESSION['config']['double_validation_conges']) {
             $return .= '<div class="col-md-6">';
             $return .= '<h3>Grand Responsable</h3>';
             /*******************************************/
@@ -195,30 +195,30 @@ class Fonctions
             $childTable .= '</thead><tbody>';
 
             // on rempli un autre tableau des groupes dont resp est GRAND responsables
-            $tab_grd_resp=array();
-            $sql_gr = 'SELECT ggr_gid FROM conges_groupe_grd_resp WHERE ggr_login="'. \includes\SQL::quote($choix_resp).'" ORDER BY ggr_gid ';
-            $ReqLog_gr = \includes\SQL::query($sql_gr);
+            $tab_grd_resp = array();
+            $sql_gr       = 'SELECT ggr_gid FROM conges_groupe_grd_resp WHERE ggr_login="' . \includes\SQL::quote($choix_resp) . '" ORDER BY ggr_gid ';
+            $ReqLog_gr    = \includes\SQL::query($sql_gr);
 
-            while($resultat_gr=$ReqLog_gr->fetch_array()) {
-                $tab_grd_resp[]=$resultat_gr["ggr_gid"];
+            while ($resultat_gr = $ReqLog_gr->fetch_array()) {
+                $tab_grd_resp[] = $resultat_gr["ggr_gid"];
             }
 
             // ensuite on affiche tous les groupes avec une case cochée si exist groupename dans le 2ieme tableau
             $count = count($tab_groupe_dbl_valid);
             for ($i = 0; $i < $count; $i++) {
-                $gid=$tab_groupe_dbl_valid[$i]["gid"] ;
-                $group=$tab_groupe_dbl_valid[$i]["group"] ;
-                $comment=$tab_groupe_dbl_valid[$i]["comment"] ;
+                $gid     = $tab_groupe_dbl_valid[$i]["gid"];
+                $group   = $tab_groupe_dbl_valid[$i]["group"];
+                $comment = $tab_groupe_dbl_valid[$i]["comment"];
 
                 if (in_array($gid, $tab_grd_resp)) {
-                    $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_grd_resp_group[$gid]\" value=\"$gid\" checked>";
-                    $class="histo-big";
+                    $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_grd_resp_group[$gid]\" value=\"$gid\" checked>";
+                    $class         = "histo-big";
                 } else {
-                    $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_grd_resp_group[$gid]\" value=\"$gid\">";
-                    $class="histo";
+                    $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_grd_resp_group[$gid]\" value=\"$gid\">";
+                    $class         = "histo";
                 }
 
-                $childTable .= '<tr class="' . (!($i%2) ? 'i' : 'p') . '">';
+                $childTable .= '<tr class="' . (!($i % 2) ? 'i' : 'p') . '">';
                 $childTable .= '<td>' . $case_a_cocher . '</td>';
                 $childTable .= '<td class="' . $class . '">' . $group . '</td>';
                 $childTable .= '<td class="' . $class . '">' . $comment . '</td>';
@@ -237,7 +237,7 @@ class Fonctions
         $return .= '</div>';
         $return .= '<hr/>';
         $return .= '<input type="hidden" name="change_responsable_group" value="ok">';
-        $return .= '<input type="hidden" name="choix_resp" value="' .  $choix_resp . '">';
+        $return .= '<input type="hidden" name="choix_resp" value="' . $choix_resp . '">';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
         $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group-responsables&choix_gestion_groupes_responsables=resp-group">' . _('form_annul') . '</a>';
         $return .= '</form>';
@@ -254,7 +254,7 @@ class Fonctions
         $return .= '<h1>' . _('admin_onglet_resp_groupe') . '</h1>';
 
         // Récuperation des informations :
-        $sql_resp = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_is_resp='Y' AND u_login!='conges' AND u_login!='admin' ORDER BY u_nom, u_prenom"  ;
+        $sql_resp    = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_is_resp='Y' AND u_login!='conges' AND u_login!='admin' ORDER BY u_nom, u_prenom";
         $ReqLog_resp = \includes\SQL::query($sql_resp);
 
         /*************************/
@@ -281,11 +281,11 @@ class Fonctions
         $i = true;
         while ($resultat_resp = $ReqLog_resp->fetch_array()) {
 
-            $sql_login=$resultat_resp["u_login"] ;
-            $sql_nom=$resultat_resp["u_nom"] ;
-            $sql_prenom=$resultat_resp["u_prenom"] ;
+            $sql_login  = $resultat_resp["u_login"];
+            $sql_nom    = $resultat_resp["u_nom"];
+            $sql_prenom = $resultat_resp["u_prenom"];
 
-            $text_choix_resp="<a href=\"$PHP_SELF?session=$session&onglet=admin-group-responsables&choix_resp=$sql_login\"><strong>$sql_nom&nbsp;$sql_prenom</strong></a>" ;
+            $text_choix_resp = "<a href=\"$PHP_SELF?session=$session&onglet=admin-group-responsables&choix_resp=$sql_login\"><strong>$sql_nom&nbsp;$sql_prenom</strong></a>";
 
             $childTable .= '<tr class="' . ($i ? 'i' : 'p') . '">';
             $childTable .= '<td>' . $text_choix_resp . '</td>';
@@ -308,48 +308,47 @@ class Fonctions
         $session  = session_id();
         $return   = '';
 
-        $result_insert=TRUE;
-        $result_insert_2=TRUE;
+        $result_insert   = true;
+        $result_insert_2 = true;
 
         //echo "groupe : $choix_group<br>\n";
         // on supprime tous les anciens resp du groupe puis on ajoute tous ceux qui sont dans le tableau de la checkbox
-        $sql_del = 'DELETE FROM conges_groupe_resp WHERE gr_gid='.\includes\SQL::quote($choix_group);
+        $sql_del    = 'DELETE FROM conges_groupe_resp WHERE gr_gid=' . \includes\SQL::quote($choix_group);
         $ReqLog_del = \includes\SQL::query($sql_del);
 
         // on supprime tous les anciens grand resp du groupe puis on ajoute tous ceux qui sont dans le tableau de la checkbox
-        $sql_del_2 = 'DELETE FROM conges_groupe_grd_resp WHERE ggr_gid='. \includes\SQL::quote($choix_group);
+        $sql_del_2    = 'DELETE FROM conges_groupe_grd_resp WHERE ggr_gid=' . \includes\SQL::quote($choix_group);
         $ReqLog_del_2 = \includes\SQL::query($sql_del_2);
 
-
         // ajout des resp qui sont dans la checkbox
-        if($checkbox_group_resp!="") // si la checkbox contient qq chose
+        if ($checkbox_group_resp != "") // si la checkbox contient qq chose
         {
-            foreach($checkbox_group_resp as $login => $value) {
-                $sql_insert = "INSERT INTO conges_groupe_resp SET gr_gid=$choix_group, gr_login='$login' "  ;
+            foreach ($checkbox_group_resp as $login => $value) {
+                $sql_insert    = "INSERT INTO conges_groupe_resp SET gr_gid=$choix_group, gr_login='$login' ";
                 $result_insert = \includes\SQL::query($sql_insert);
             }
         }
 
         // ajout des grands resp qui sont dans la checkbox
-        if($checkbox_group_grd_resp!="") // si la checkbox contient qq chose
+        if ($checkbox_group_grd_resp != "") // si la checkbox contient qq chose
         {
-            foreach($checkbox_group_grd_resp as $grd_login => $grd_value) {
-                $sql_insert_2 = "INSERT INTO conges_groupe_grd_resp SET ggr_gid=$choix_group, ggr_login='$grd_login' "  ;
+            foreach ($checkbox_group_grd_resp as $grd_login => $grd_value) {
+                $sql_insert_2    = "INSERT INTO conges_groupe_grd_resp SET ggr_gid=$choix_group, ggr_login='$grd_login' ";
                 $result_insert_2 = \includes\SQL::query($sql_insert_2);
             }
         }
 
-        if( ($result_insert) && ($result_insert_2) ) {
+        if (($result_insert) && ($result_insert_2)) {
             $return .= _('form_modif_ok') . ' !<br><br>';
         } else {
             $return .= _('form_modif_not_ok') . ' !<br><br>';
         }
 
-        $comment_log = "mofification_responsables_du_groupe : $choix_group" ;
+        $comment_log = "mofification_responsables_du_groupe : $choix_group";
         log_action(0, "", "", $comment_log);
 
         /* APPEL D'UNE AUTRE PAGE */
-        $return .= '<form action="' . $PHP_SELF . '?session=' .  $session . '&onglet=admin-group-responsables&choix_gestion_groupes_responsables=group-resp" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group-responsables&choix_gestion_groupes_responsables=group-resp" method="POST">';
         $return .= '<input type="submit" value="' . _('form_retour') . '">';
         $return .= '</form>';
         return $return;
@@ -368,29 +367,29 @@ class Fonctions
         /* Affichage Groupe    */
         /***********************/
         // Récuperation des informations :
-        $sql_gr = 'SELECT g_groupename, g_comment, g_double_valid FROM conges_groupe WHERE g_gid='.\includes\SQL::quote($choix_group);
+        $sql_gr    = 'SELECT g_groupename, g_comment, g_double_valid FROM conges_groupe WHERE g_gid=' . \includes\SQL::quote($choix_group);
         $ReqLog_gr = \includes\SQL::query($sql_gr);
 
-        $resultat_gr = $ReqLog_gr->fetch_array();
-        $sql_groupename=$resultat_gr["g_groupename"] ;
-        $sql_comment=$resultat_gr["g_comment"] ;
-        $sql_double_valid=$resultat_gr["g_double_valid"] ;
+        $resultat_gr      = $ReqLog_gr->fetch_array();
+        $sql_groupename   = $resultat_gr["g_groupename"];
+        $sql_comment      = $resultat_gr["g_comment"];
+        $sql_double_valid = $resultat_gr["g_double_valid"];
 
         // AFFICHAGE NOM DU GROUPE
         $return .= '<h2>Groupe : <strong>' . $sql_groupename . '</strong></h2>';
         $return .= '<hr/>';
         //on rempli un tableau de tous les responsables avec le login, le nom, le prenom (tableau de tableau à 3 cellules
         // Récuperation des responsables :
-        $tab_resp=array();
-        $sql_resp = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_login!='conges' AND u_is_resp='Y' ORDER BY u_nom, u_prenom "  ;
+        $tab_resp    = array();
+        $sql_resp    = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_login!='conges' AND u_is_resp='Y' ORDER BY u_nom, u_prenom ";
         $ReqLog_resp = \includes\SQL::query($sql_resp);
 
-        while($resultat_resp=$ReqLog_resp->fetch_array()) {
-            $tab_r=array();
-            $tab_r["login"]=$resultat_resp["u_login"];
-            $tab_r["nom"]=$resultat_resp["u_nom"];
-            $tab_r["prenom"]=$resultat_resp["u_prenom"];
-            $tab_resp[]=$tab_r;
+        while ($resultat_resp = $ReqLog_resp->fetch_array()) {
+            $tab_r           = array();
+            $tab_r["login"]  = $resultat_resp["u_login"];
+            $tab_r["nom"]    = $resultat_resp["u_nom"];
+            $tab_r["prenom"] = $resultat_resp["u_prenom"];
+            $tab_resp[]      = $tab_r;
         }
         /*****************************************************************************/
         $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '" method="POST">';
@@ -420,30 +419,30 @@ class Fonctions
         $childTable .= '<tbody>';
 
         // on rempli un autre tableau des responsables du groupe
-        $tab_group=array();
-        $sql_gr = 'SELECT gr_login FROM conges_groupe_resp WHERE gr_gid='. \includes\SQL::quote($choix_group).' ORDER BY gr_login ';
+        $tab_group = array();
+        $sql_gr    = 'SELECT gr_login FROM conges_groupe_resp WHERE gr_gid=' . \includes\SQL::quote($choix_group) . ' ORDER BY gr_login ';
         $ReqLog_gr = \includes\SQL::query($sql_gr);
 
-        while($resultat_gr=$ReqLog_gr->fetch_array()) {
-            $tab_group[]=$resultat_gr["gr_login"];
+        while ($resultat_gr = $ReqLog_gr->fetch_array()) {
+            $tab_group[] = $resultat_gr["gr_login"];
         }
 
         // ensuite on affiche tous les responsables avec une case cochée si exist login dans le 2ieme tableau
         $count = count($tab_resp);
         for ($i = 0; $i < $count; $i++) {
-            $login=$tab_resp[$i]["login"] ;
-            $nom=$tab_resp[$i]["nom"] ;
-            $prenom=$tab_resp[$i]["prenom"] ;
+            $login  = $tab_resp[$i]["login"];
+            $nom    = $tab_resp[$i]["nom"];
+            $prenom = $tab_resp[$i]["prenom"];
 
-            if (in_array ($login, $tab_group)) {
-                $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_group_resp[$login]\" value=\"$login\" checked>";
-                $class="histo-big";
+            if (in_array($login, $tab_group)) {
+                $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_group_resp[$login]\" value=\"$login\" checked>";
+                $class         = "histo-big";
             } else {
-                $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_group_resp[$login]\" value=\"$login\">";
-                $class="histo";
+                $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_group_resp[$login]\" value=\"$login\">";
+                $class         = "histo";
             }
 
-            $childTable .= '<tr class="' . (!($i%2) ? 'i' : 'p') . '">';
+            $childTable .= '<tr class="' . (!($i % 2) ? 'i' : 'p') . '">';
             $childTable .= '<td>' . $case_a_cocher . '</td>';
             $childTable .= '<td class="' . $class . '">' . $nom . '&nbsp;' . $prenom . '</td>';
             $childTable .= '<td class="' . $class . '">' . $login . '</td>';
@@ -458,7 +457,7 @@ class Fonctions
         $return .= '</div>';
         $return .= '<div class="col-md-6">';
         // si on a configuré la double validation et que le groupe considéré est a double valid
-        if( ($_SESSION['config']['double_validation_conges']) && ($sql_double_valid=="Y") ) {
+        if (($_SESSION['config']['double_validation_conges']) && ($sql_double_valid == "Y")) {
             $return .= '<h3>' . _('admin_gestion_groupe_grand_resp_responsables') . '</h3>';
             /*******************************************/
             //AFFICHAGE DU TABLEAU DES GRANDS RESPONSBLES DU GROUPE
@@ -480,30 +479,30 @@ class Fonctions
             $childTable .= '</tr></thead><tbody>';
 
             // on rempli un autre tableau des grands responsables du groupe
-            $tab_group_grd=array();
-            $sql_ggr = 'SELECT ggr_login FROM conges_groupe_grd_resp WHERE ggr_gid='. \includes\SQL::quote($choix_group).' ORDER BY ggr_login ';
-            $ReqLog_ggr = \includes\SQL::query($sql_ggr);
+            $tab_group_grd = array();
+            $sql_ggr       = 'SELECT ggr_login FROM conges_groupe_grd_resp WHERE ggr_gid=' . \includes\SQL::quote($choix_group) . ' ORDER BY ggr_login ';
+            $ReqLog_ggr    = \includes\SQL::query($sql_ggr);
 
-            while($resultat_ggr=$ReqLog_ggr->fetch_array()) {
-                $tab_group_grd[]=$resultat_ggr["ggr_login"];
+            while ($resultat_ggr = $ReqLog_ggr->fetch_array()) {
+                $tab_group_grd[] = $resultat_ggr["ggr_login"];
             }
 
             // ensuite on affiche tous les grands responsables avec une case cochée si exist login dans le 3ieme tableau
             $count = count($tab_resp);
             for ($i = 0; $i < $count; $i++) {
-                $login=$tab_resp[$i]["login"] ;
-                $nom=$tab_resp[$i]["nom"] ;
-                $prenom=$tab_resp[$i]["prenom"] ;
+                $login  = $tab_resp[$i]["login"];
+                $nom    = $tab_resp[$i]["nom"];
+                $prenom = $tab_resp[$i]["prenom"];
 
-                if (in_array ($login, $tab_group_grd)) {
-                    $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_group_grd_resp[$login]\" value=\"$login\" checked>";
-                    $class="histo-big";
+                if (in_array($login, $tab_group_grd)) {
+                    $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_group_grd_resp[$login]\" value=\"$login\" checked>";
+                    $class         = "histo-big";
                 } else {
-                    $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_group_grd_resp[$login]\" value=\"$login\">";
-                    $class="histo";
+                    $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_group_grd_resp[$login]\" value=\"$login\">";
+                    $class         = "histo";
                 }
 
-                $childTable .= '<tr class="' . (!($i%2) ? 'i' : 'p') . '">';
+                $childTable .= '<tr class="' . (!($i % 2) ? 'i' : 'p') . '">';
                 $childTable .= '<td>' . $case_a_cocher . '</td>';
                 $childTable .= '<td class="' . $class . '">' . $nom . '&nbsp;' . $prenom . '</td>';
                 $childTable .= '<td class="' . $class . '">' . $login . '</td>';
@@ -522,7 +521,7 @@ class Fonctions
         $return .= '<input type="hidden" name="change_group_responsables" value="ok">';
         $return .= '<input type="hidden" name="choix_group" value="' . $choix_group . ' ">';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
-        $return .= '<a class="btn" href="'  . $PHP_SELF . '?session=' . $session . '&onglet=admin-group-responsables&choix_gestion_groupes_responsables=group-resp">' . _('form_annul') . '</a>';
+        $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group-responsables&choix_gestion_groupes_responsables=group-resp">' . _('form_annul') . '</a>';
         $return .= '</form>';
         return $return;
     }
@@ -538,7 +537,7 @@ class Fonctions
         /* Choix Groupe     */
         /********************/
         // Récuperation des informations :
-        $sql_gr = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename"  ;
+        $sql_gr = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename";
 
         // AFFICHAGE TABLEAU
         $return .= '<h1>' . _('admin_onglet_groupe_resp') . '</h1>';
@@ -559,11 +558,11 @@ class Fonctions
 
         $ReqLog_gr = \includes\SQL::query($sql_gr);
         while ($resultat_gr = $ReqLog_gr->fetch_array()) {
-            $sql_gid=$resultat_gr["g_gid"] ;
-            $sql_groupename=$resultat_gr["g_groupename"] ;
-            $sql_comment=$resultat_gr["g_comment"] ;
+            $sql_gid        = $resultat_gr["g_gid"];
+            $sql_groupename = $resultat_gr["g_groupename"];
+            $sql_comment    = $resultat_gr["g_comment"];
 
-            $text_choix_group="<a href=\"$PHP_SELF?session=$session&onglet=admin-group-responsables&choix_group=$sql_gid\"><strong>$sql_groupename</strong></a>" ;
+            $text_choix_group = "<a href=\"$PHP_SELF?session=$session&onglet=admin-group-responsables&choix_group=$sql_gid\"><strong>$sql_groupename</strong></a>";
 
             $childTable .= '<tr>';
             $childTable .= '<td>' . $text_choix_group . '</td>';
@@ -585,15 +584,13 @@ class Fonctions
         $session  = session_id();
         $return   = '';
 
-        if( $choix_group!="" )    // si un groupe choisi : on affiche la gestion par groupe
+        if ($choix_group != "") // si un groupe choisi : on affiche la gestion par groupe
         {
             $return .= \admin\Fonctions::affiche_gestion_groupes_responsables($choix_group, $onglet);
-        }
-        elseif( $choix_resp!="" )     // si un resp choisi : on affiche la gestion par resp
+        } elseif ($choix_resp != "") // si un resp choisi : on affiche la gestion par resp
         {
             $return .= \admin\Fonctions::affiche_gestion_responsable_groupes($choix_resp, $onglet);
-        }
-        else    // si pas de groupe ou de resp choisi : on affiche les choix
+        } else // si pas de groupe ou de resp choisi : on affiche les choix
         {
             $return .= '<div class="row">';
             $return .= '<div class="col-md-6">';
@@ -618,20 +615,20 @@ class Fonctions
      */
     public static function groupeResponsableModule($onglet)
     {
-        $choix_group    = htmlentities(getpost_variable('choix_group'), ENT_QUOTES | ENT_HTML401);
-        $choix_resp     = getpost_variable('choix_resp') ;
-        $return = '';
+        $choix_group = htmlentities(getpost_variable('choix_group'), ENT_QUOTES | ENT_HTML401);
+        $choix_resp  = getpost_variable('choix_resp');
+        $return      = '';
 
-        $change_group_responsables    = getpost_variable('change_group_responsables') ;
-        $change_responsable_group    = getpost_variable('change_responsable_group') ;
+        $change_group_responsables = getpost_variable('change_group_responsables');
+        $change_responsable_group  = getpost_variable('change_responsable_group');
 
-        if($change_group_responsables=="ok") {
-            $checkbox_group_resp        = getpost_variable('checkbox_group_resp') ;
-            $checkbox_group_grd_resp    = getpost_variable('checkbox_group_grd_resp') ;
+        if ($change_group_responsables == "ok") {
+            $checkbox_group_resp     = getpost_variable('checkbox_group_resp');
+            $checkbox_group_grd_resp = getpost_variable('checkbox_group_grd_resp');
             $return .= \admin\Fonctions::modif_group_responsables($choix_group, $checkbox_group_resp, $checkbox_group_grd_resp);
-        } elseif($change_responsable_group=="ok") {
-            $checkbox_resp_group        = getpost_variable('checkbox_resp_group') ;
-            $checkbox_grd_resp_group    = getpost_variable('checkbox_grd_resp_group') ;
+        } elseif ($change_responsable_group == "ok") {
+            $checkbox_resp_group     = getpost_variable('checkbox_resp_group');
+            $checkbox_grd_resp_group = getpost_variable('checkbox_grd_resp_group');
 
             $return .= \admin\Fonctions::modif_resp_groupes($choix_resp, $checkbox_resp_group, $checkbox_grd_resp_group);
         } else {
@@ -643,22 +640,22 @@ class Fonctions
     public static function modif_user_groups($choix_user, &$checkbox_user_groups)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
-        $result_insert= \admin\Fonctions::commit_modif_user_groups($choix_user, $checkbox_user_groups);
+        $result_insert = \admin\Fonctions::commit_modif_user_groups($choix_user, $checkbox_user_groups);
 
-        if($result_insert) {
+        if ($result_insert) {
             $return .= _('form_modif_ok') . ' !<br><br>';
         } else {
             $return .= _('form_modif_not_ok') . ' !<br><br>';
         }
 
-        $comment_log = "mofification_des groupes auxquels $choix_user appartient" ;
+        $comment_log = "mofification_des groupes auxquels $choix_user appartient";
         log_action(0, "", $choix_user, $comment_log);
 
         /* APPEL D'UNE AUTRE PAGE */
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session. '&onglet=admin-group-users" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group-users" method="POST">';
         $return .= '<input type="submit" value="' . _('form_retour') . '">';
         $return .= '</form>';
         return $return;
@@ -671,36 +668,37 @@ class Fonctions
         $return   = '';
 
         // on supprime tous les anciens users du groupe puis on ajoute tous ceux qui sont dans le tableau checkbox (si il n'est pas vide)
-        $sql_del = 'DELETE FROM conges_groupe_users WHERE gu_gid='. \includes\SQL::quote($choix_group).' ';
+        $sql_del    = 'DELETE FROM conges_groupe_users WHERE gu_gid=' . \includes\SQL::quote($choix_group) . ' ';
         $ReqLog_del = \includes\SQL::query($sql_del);
 
-        if(is_array($checkbox_group_users) && count ($checkbox_group_users)!=0) {
-            foreach($checkbox_group_users as $login => $value) {
+        if (is_array($checkbox_group_users) && count($checkbox_group_users) != 0) {
+            foreach ($checkbox_group_users as $login => $value) {
                 //$login=$checkbox_group_users[$i] ;
-                $sql_insert = "INSERT INTO conges_groupe_users SET gu_gid=$choix_group, gu_login='$login' "  ;
+                $sql_insert    = "INSERT INTO conges_groupe_users SET gu_gid=$choix_group, gu_login='$login' ";
                 $result_insert = \includes\SQL::query($sql_insert);
             }
         } else {
-            $result_insert=TRUE;
+            $result_insert = true;
         }
 
-        if($result_insert) {
+        if ($result_insert) {
             $return .= _('form_modif_ok') . '<br><br>';
         } else {
             $return .= _('form_modif_not_ok') . '<br><br>';
         }
 
-        $comment_log = "mofification_users_du_groupe : $choix_group" ;
+        $comment_log = "mofification_users_du_groupe : $choix_group";
         log_action(0, "", "", $comment_log);
 
         /* APPEL D'UNE AUTRE PAGE */
-        $return .= '<form action="' . $PHP_SELF. '?session=' . $session . '&onglet=admin-group-users" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group-users" method="POST">';
         $return .= '<input type="submit" value="' . _('form_retour') . '">';
         $return .= '</form>';
         return $return;
     }
 
-    public static function affiche_gestion_groupes_users($choix_group, $onglet) {
+    public static function affiche_gestion_groupes_users($choix_group, $onglet)
+    {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
         $return   = '';
@@ -711,12 +709,11 @@ class Fonctions
         /* Affichage Groupes    */
         /************************/
         // Récuperation des informations :
-        $sql_gr = 'SELECT g_groupename, g_comment FROM conges_groupe WHERE g_gid='. \includes\SQL::quote($choix_group);
-        $ReqLog_gr = \includes\SQL::query($sql_gr);
+        $sql_gr      = 'SELECT g_groupename, g_comment FROM conges_groupe WHERE g_gid=' . \includes\SQL::quote($choix_group);
+        $ReqLog_gr   = \includes\SQL::query($sql_gr);
         $resultat_gr = $ReqLog_gr->fetch_array();
-        $sql_group=$resultat_gr["g_groupename"] ;
-        $sql_comment=$resultat_gr["g_comment"] ;
-
+        $sql_group   = $resultat_gr["g_groupename"];
+        $sql_comment = $resultat_gr["g_comment"];
 
         $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '" method="POST">';
 
@@ -745,42 +742,42 @@ class Fonctions
 
         //on rempli un tableau de tous les users avec le login, le nom, le prenom (tableau de tableau à 3 cellules
         // Récuperation des utilisateurs :
-        $tab_users=array();
-        $sql_users = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_nom, u_prenom "  ;
+        $tab_users    = array();
+        $sql_users    = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_nom, u_prenom ";
         $ReqLog_users = \includes\SQL::query($sql_users);
 
-        while($resultat_users=$ReqLog_users->fetch_array()) {
-            $tab_u=array();
-            $tab_u["login"]=$resultat_users["u_login"];
-            $tab_u["nom"]=$resultat_users["u_nom"];
-            $tab_u["prenom"]=$resultat_users["u_prenom"];
-            $tab_users[]=$tab_u;
+        while ($resultat_users = $ReqLog_users->fetch_array()) {
+            $tab_u           = array();
+            $tab_u["login"]  = $resultat_users["u_login"];
+            $tab_u["nom"]    = $resultat_users["u_nom"];
+            $tab_u["prenom"] = $resultat_users["u_prenom"];
+            $tab_users[]     = $tab_u;
         }
         // on rempli un autre tableau des users du groupe
-        $tab_group=array();
-        $sql_gu = 'SELECT gu_login FROM conges_groupe_users WHERE gu_gid="'. \includes\SQL::quote($choix_group).'" ORDER BY gu_login ';
+        $tab_group = array();
+        $sql_gu    = 'SELECT gu_login FROM conges_groupe_users WHERE gu_gid="' . \includes\SQL::quote($choix_group) . '" ORDER BY gu_login ';
         $ReqLog_gu = \includes\SQL::query($sql_gu);
 
-        while($resultat_gu=$ReqLog_gu->fetch_array()){
-            $tab_group[]=$resultat_gu["gu_login"];
+        while ($resultat_gu = $ReqLog_gu->fetch_array()) {
+            $tab_group[] = $resultat_gu["gu_login"];
         }
 
         // ensuite on affiche tous les users avec une case cochée si exist login dans le 2ieme tableau
         $count = count($tab_users);
         for ($i = 0; $i < $count; $i++) {
-            $login=$tab_users[$i]["login"] ;
-            $nom=$tab_users[$i]["nom"] ;
-            $prenom=$tab_users[$i]["prenom"] ;
+            $login  = $tab_users[$i]["login"];
+            $nom    = $tab_users[$i]["nom"];
+            $prenom = $tab_users[$i]["prenom"];
 
             if (in_array($login, $tab_group)) {
-                $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_group_users[$login]\" value=\"$login\" checked>";
-                $class="histo-big";
+                $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_group_users[$login]\" value=\"$login\" checked>";
+                $class         = "histo-big";
             } else {
-                $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_group_users[$login]\" value=\"$login\">";
-                $class="histo";
+                $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_group_users[$login]\" value=\"$login\">";
+                $class         = "histo";
             }
 
-            $childTable .= '<tr class="' . (!($i%2) ? 'i' :'p') . '">';
+            $childTable .= '<tr class="' . (!($i % 2) ? 'i' : 'p') . '">';
             $childTable .= '<td>' . $case_a_cocher . '</td>';
             $childTable .= '<td class="' . $class . '">' . $nom . ' ' . $prenom . '</td>';
             $childTable .= '<td class="' . $class . '">' . $login . '</td>';
@@ -794,7 +791,7 @@ class Fonctions
         $return .= ob_get_clean();
         $return .= '<hr/>';
         $return .= '<input type="hidden" name="change_group_users" value="ok">';
-        $return .= '<input type="hidden" name="choix_group" value="' .  $choix_group . '">';
+        $return .= '<input type="hidden" name="choix_group" value="' . $choix_group . '">';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
         $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group-users">' . _('form_annul') . '</a>';
         $return .= '</form>';
@@ -813,7 +810,7 @@ class Fonctions
         /* Choix Groupe     */
         /********************/
         // Récuperation des informations :
-        $sql_gr = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename"  ;
+        $sql_gr = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename";
 
         // AFFICHAGE TABLEAU
         $return .= '<h2>' . _('admin_aff_choix_groupe_titre') . '</h2>';
@@ -833,17 +830,17 @@ class Fonctions
         $childTable .= '</thead>';
         $childTable .= '<tbody>';
 
-        $i = true;
+        $i         = true;
         $ReqLog_gr = \includes\SQL::query($sql_gr);
         while ($resultat_gr = $ReqLog_gr->fetch_array()) {
-            $sql_gid=$resultat_gr["g_gid"] ;
-            $sql_group=$resultat_gr["g_groupename"] ;
-            $sql_comment=$resultat_gr["g_comment"] ;
+            $sql_gid     = $resultat_gr["g_gid"];
+            $sql_group   = $resultat_gr["g_groupename"];
+            $sql_comment = $resultat_gr["g_comment"];
 
-            $choix_group="<a href=\"$PHP_SELF?session=$session&onglet=admin-group-users&choix_group=$sql_gid\"><b>$sql_group</b></a>" ;
+            $choix_group = "<a href=\"$PHP_SELF?session=$session&onglet=admin-group-users&choix_group=$sql_gid\"><b>$sql_group</b></a>";
 
-            $childTable .= '<tr class="'.($i ? 'i' : 'p').'">';
-            $childTable .= '<td><b>' . $choix_group .'</b></td>';
+            $childTable .= '<tr class="' . ($i ? 'i' : 'p') . '">';
+            $childTable .= '<td><b>' . $choix_group . '</b></td>';
             $childTable .= '<td>' . $sql_comment . '</td>';
             $childTable .= '</tr>';
             $i = !$i;
@@ -889,12 +886,11 @@ class Fonctions
 
         $return .= '<h1>' . _('admin_onglet_user_groupe') . '</h1>';
 
-
         /********************/
         /* Choix User       */
         /********************/
         // Récuperation des informations :
-        $sql_user = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_nom, u_prenom"  ;
+        $sql_user = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_nom, u_prenom";
 
         // AFFICHAGE TABLEAU
         $return .= '<h2>' . _('admin_aff_choix_user_titre') . '</h2>';
@@ -915,17 +911,17 @@ class Fonctions
         $childTable .= '</thead>';
         $childTable .= '<tbody>';
 
-        $i = true;
+        $i           = true;
         $ReqLog_user = \includes\SQL::query($sql_user);
         while ($resultat_user = $ReqLog_user->fetch_array()) {
 
-            $sql_login=$resultat_user["u_login"] ;
-            $sql_nom=$resultat_user["u_nom"] ;
-            $sql_prenom=$resultat_user["u_prenom"] ;
+            $sql_login  = $resultat_user["u_login"];
+            $sql_nom    = $resultat_user["u_nom"];
+            $sql_prenom = $resultat_user["u_prenom"];
 
-            $choix="<a href=\"$PHP_SELF?session=$session&onglet=admin-group-users&choix_user=$sql_login\"><b>$sql_nom $sql_prenom</b></a>" ;
+            $choix = "<a href=\"$PHP_SELF?session=$session&onglet=admin-group-users&choix_user=$sql_login\"><b>$sql_nom $sql_prenom</b></a>";
 
-            $childTable .= '<tr class="'.( $i ? 'i' : 'p').'">';
+            $childTable .= '<tr class="' . ($i ? 'i' : 'p') . '">';
             $childTable .= '<td>' . $choix . '</td>';
             $childTable .= '<td>' . $sql_login . '</td>';
             $childTable .= '</tr>';
@@ -942,7 +938,7 @@ class Fonctions
     public static function affiche_tableau_affectation_user_groupes($choix_user)
     {
         $return = '';
-        $return .= '<h2>' . _('admin_gestion_groupe_users_group_of_user') . (($choix_user!='') ? ' <strong>' . $choix_user . '</strong>' : '') . '</h2>';
+        $return .= '<h2>' . _('admin_gestion_groupe_users_group_of_user') . (($choix_user != '') ? ' <strong>' . $choix_user . '</strong>' : '') . '</h2>';
 
         //AFFICHAGE DU TABLEAU DES GROUPES DU USER
         $table = new \App\Libraries\Structure\Table();
@@ -951,7 +947,7 @@ class Fonctions
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         $childTable = '<thead>';
         $childTable .= '<tr>';
@@ -965,48 +961,48 @@ class Fonctions
         // affichage des groupes
 
         //on rempli un tableau de tous les groupes avec le nom et libellé (tableau de tableau à 3 cellules)
-        $tab_groups=array();
-        $sql_g = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename "  ;
-        $ReqLog_g = \includes\SQL::query($sql_g);
+        $tab_groups = array();
+        $sql_g      = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename ";
+        $ReqLog_g   = \includes\SQL::query($sql_g);
 
-        while ($resultat_g=$ReqLog_g->fetch_array()) {
-            $tab_gg=array();
-            $tab_gg["gid"]=$resultat_g["g_gid"];
-            $tab_gg["groupename"]=$resultat_g["g_groupename"];
-            $tab_gg["comment"]=$resultat_g["g_comment"];
-            $tab_groups[]=$tab_gg;
+        while ($resultat_g = $ReqLog_g->fetch_array()) {
+            $tab_gg               = array();
+            $tab_gg["gid"]        = $resultat_g["g_gid"];
+            $tab_gg["groupename"] = $resultat_g["g_groupename"];
+            $tab_gg["comment"]    = $resultat_g["g_comment"];
+            $tab_groups[]         = $tab_gg;
         }
 
-        $tab_user="";
+        $tab_user = "";
         // si le user est connu
         // on rempli un autre tableau des groupes du user
-        if($choix_user!="") {
-            $tab_user=array();
-            $sql_gu = 'SELECT gu_gid FROM conges_groupe_users WHERE gu_login="'. \includes\SQL::quote($choix_user).'" ORDER BY gu_gid ';
+        if ($choix_user != "") {
+            $tab_user  = array();
+            $sql_gu    = 'SELECT gu_gid FROM conges_groupe_users WHERE gu_login="' . \includes\SQL::quote($choix_user) . '" ORDER BY gu_gid ';
             $ReqLog_gu = \includes\SQL::query($sql_gu);
 
-            while ($resultat_gu=$ReqLog_gu->fetch_array()) {
-                $tab_user[]=$resultat_gu["gu_gid"];
+            while ($resultat_gu = $ReqLog_gu->fetch_array()) {
+                $tab_user[] = $resultat_gu["gu_gid"];
             }
         }
 
         // ensuite on affiche tous les groupes avec une case cochée si existe le gid dans le 2ieme tableau
         $count = count($tab_groups);
         for ($i = 0; $i < $count; $i++) {
-            $gid=$tab_groups[$i]["gid"] ;
-            $group=$tab_groups[$i]["groupename"] ;
-            $libelle=$tab_groups[$i]["comment"] ;
+            $gid     = $tab_groups[$i]["gid"];
+            $group   = $tab_groups[$i]["groupename"];
+            $libelle = $tab_groups[$i]["comment"];
 
-            if ( ($tab_user!="") && (in_array ($gid, $tab_user)) ) {
-                $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_user_groups[$gid]\" value=\"$gid\" checked>";
-                $class="histo-big";
+            if (($tab_user != "") && (in_array($gid, $tab_user))) {
+                $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_user_groups[$gid]\" value=\"$gid\" checked>";
+                $class         = "histo-big";
             } else {
-                $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_user_groups[$gid]\" value=\"$gid\">";
-                $class="histo";
+                $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_user_groups[$gid]\" value=\"$gid\">";
+                $class         = "histo";
             }
 
-            $childTable .= '<tr class="' . (!($i%2) ? 'i' : 'p') . '">';
-            $childTable .= '<td>' . $case_a_cocher .  '</td>';
+            $childTable .= '<tr class="' . (!($i % 2) ? 'i' : 'p') . '">';
+            $childTable .= '<td>' . $case_a_cocher . '</td>';
             $childTable .= '<td class="' . $class . '">' . $group . '&nbsp</td>';
             $childTable .= '<td class="' . $class . '">' . $libelle . '</td>';
             $childTable .= '</tr>';
@@ -1025,14 +1021,13 @@ class Fonctions
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return   = '';
 
-        if( $choix_group!="" )     // si un groupe choisi : on affiche la gestion par groupe
+        if ($choix_group != "") // si un groupe choisi : on affiche la gestion par groupe
         {
             $return .= \admin\Fonctions::affiche_gestion_groupes_users($choix_group, $onglet);
-        } elseif( $choix_user!="" )     // si un user choisi : on affiche la gestion par user
+        } elseif ($choix_user != "") // si un user choisi : on affiche la gestion par user
         {
             $return .= \admin\Fonctions::affiche_gestion_user_groupes($choix_user, $onglet);
-        }
-        else    // si pas de groupe ou de user choisi : on affiche les choix
+        } else // si pas de groupe ou de user choisi : on affiche les choix
         {
             $return .= '<div class="row">';
             $return .= '<div class="col-md-6">';
@@ -1057,17 +1052,17 @@ class Fonctions
      */
     public static function groupUserModule($onglet)
     {
-        $change_group_users    = getpost_variable('change_group_users') ;
-        $change_user_groups    = getpost_variable('change_user_groups') ;
-        $choix_group        = (int) getpost_variable('choix_group') ;
-        $choix_user            = getpost_variable('choix_user') ;
-        $return = '';
+        $change_group_users = getpost_variable('change_group_users');
+        $change_user_groups = getpost_variable('change_user_groups');
+        $choix_group        = (int) getpost_variable('choix_group');
+        $choix_user         = getpost_variable('choix_user');
+        $return             = '';
 
-        if($change_group_users=="ok") {
-            $checkbox_group_users    = getpost_variable('checkbox_group_users');
+        if ($change_group_users == "ok") {
+            $checkbox_group_users = getpost_variable('checkbox_group_users');
             $return .= \admin\Fonctions::modif_group_users($choix_group, $checkbox_group_users);
-        } elseif($change_user_groups=="ok") {
-            $checkbox_user_groups    = getpost_variable('checkbox_user_groups');
+        } elseif ($change_user_groups == "ok") {
+            $checkbox_user_groups = getpost_variable('checkbox_user_groups');
             $return .= \admin\Fonctions::modif_user_groups($choix_user, $checkbox_user_groups);
         } else {
             $return .= \admin\Fonctions::affiche_choix_gestion_groupes_users($choix_group, $choix_user, $onglet);
@@ -1079,7 +1074,7 @@ class Fonctions
     public static function get_nb_users_du_groupe($group_id)
     {
 
-        $sql1='SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid = '. \includes\SQL::quote($group_id).' ORDER BY gu_login ';
+        $sql1    = 'SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid = ' . \includes\SQL::quote($group_id) . ' ORDER BY gu_login ';
         $ReqLog1 = \includes\SQL::query($sql1);
 
         $nb_users = $ReqLog1->num_rows;
@@ -1095,7 +1090,7 @@ class Fonctions
         $return   = '';
 
         // verif des parametres reçus :
-        if(strlen($new_group_name)==0) {
+        if (strlen($new_group_name) == 0) {
             $return .= '<H3>' . _('admin_verif_param_invalides') . '</H3>';
             $return .= '<new_group_name --- ' . $new_group_libelle . '<br>';
             $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group" method="POST">';
@@ -1109,10 +1104,10 @@ class Fonctions
             return true;
         } else {
             // verif si le groupe demandé n'existe pas déjà ....
-            $sql_verif='select g_groupename from conges_groupe where g_groupename="'. \includes\SQL::quote($new_group_name).'" ';
+            $sql_verif    = 'select g_groupename from conges_groupe where g_groupename="' . \includes\SQL::quote($new_group_name) . '" ';
             $ReqLog_verif = \includes\SQL::query($sql_verif);
-            $num_verif = $ReqLog_verif->num_rows;
-            if ($num_verif!=0) {
+            $num_verif    = $ReqLog_verif->num_rows;
+            if ($num_verif != 0) {
                 $return .= '<H3>' . _('admin_verif_groupe_invalide') . '</H3>';
                 $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group" method="POST">';
                 $return .= '<input type="hidden" name="new_group_name" value="' . $new_group_name . '">';
@@ -1135,23 +1130,23 @@ class Fonctions
         $session  = session_id();
         $return   = '';
 
-        if(\admin\Fonctions::verif_new_param_group($new_group_name, $new_group_libelle)==0)  // verif si les nouvelles valeurs sont coohérentes et n'existent pas déjà
+        if (\admin\Fonctions::verif_new_param_group($new_group_name, $new_group_libelle) == 0) // verif si les nouvelles valeurs sont coohérentes et n'existent pas déjà
         {
-            $ngm=stripslashes($new_group_name);
+            $ngm = stripslashes($new_group_name);
             $return .= $ngm . '---' . $new_group_libelle . '<br>';
 
-            $sql1 = "INSERT INTO conges_groupe SET g_groupename='$new_group_name', g_comment='$new_group_libelle', g_double_valid ='$new_group_double_valid' " ;
+            $sql1   = "INSERT INTO conges_groupe SET g_groupename='$new_group_name', g_comment='$new_group_libelle', g_double_valid ='$new_group_double_valid' ";
             $result = \includes\SQL::query($sql1);
 
-            $new_gid= \includes\SQL::getVar('insert_id');
+            $new_gid = \includes\SQL::getVar('insert_id');
 
-            if($result) {
+            if ($result) {
                 $return .= _('form_modif_ok') . '<br><br>';
             } else {
                 $return .= _('form_modif_not_ok') . '<br><br>';
             }
 
-            $comment_log = "ajout_groupe : $new_gid / $new_group_name / $new_group_libelle (double_validation : $new_group_double_valid)" ;
+            $comment_log = "ajout_groupe : $new_gid / $new_group_name / $new_group_libelle (double_validation : $new_group_double_valid)";
             log_action(0, "", "", $comment_log);
 
             /* APPEL D'UNE AUTRE PAGE */
@@ -1174,7 +1169,7 @@ class Fonctions
         /* Etat Groupes       */
         /*********************/
         // Récuperation des informations :
-        $sql_gr = "SELECT g_gid, g_groupename, g_comment, g_double_valid FROM conges_groupe ORDER BY g_groupename"  ;
+        $sql_gr = "SELECT g_gid, g_groupename, g_comment, g_double_valid FROM conges_groupe ORDER BY g_groupename";
 
         // AFFICHAGE TABLEAU
         $return .= '<h2>' . _('admin_gestion_groupe_etat') . '</h2>';
@@ -1184,35 +1179,35 @@ class Fonctions
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         $childTable = '<thead>';
         $childTable .= '<tr>';
         $childTable .= '<th>' . _('admin_groupes_groupe') . '</th>';
         $childTable .= '<th>' . _('admin_groupes_libelle') . '</th>';
         $childTable .= '<th>' . _('admin_groupes_nb_users') . '</th>';
-        if($_SESSION['config']['double_validation_conges']) {
+        if ($_SESSION['config']['double_validation_conges']) {
             $childTable .= '<th>' . _('admin_groupes_double_valid') . '</th>';
         }
         $childTable .= '<th></th></tr></thead><tbody>';
 
-        $i = true;
+        $i         = true;
         $ReqLog_gr = \includes\SQL::query($sql_gr);
         while ($resultat_gr = $ReqLog_gr->fetch_array()) {
-            $sql_gid=$resultat_gr["g_gid"] ;
-            $sql_group=$resultat_gr["g_groupename"] ;
-            $sql_comment=$resultat_gr["g_comment"] ;
-            $sql_double_valid=$resultat_gr["g_double_valid"] ;
-            $nb_users_groupe = \admin\Fonctions::get_nb_users_du_groupe($sql_gid);
+            $sql_gid          = $resultat_gr["g_gid"];
+            $sql_group        = $resultat_gr["g_groupename"];
+            $sql_comment      = $resultat_gr["g_comment"];
+            $sql_double_valid = $resultat_gr["g_double_valid"];
+            $nb_users_groupe  = \admin\Fonctions::get_nb_users_du_groupe($sql_gid);
 
             $admin_modif_group = '<a href="admin_index.php?onglet=modif_group&session=' . $session . '&group=' . $sql_gid . '" title="' . _('form_modif') . '"><i class="fa fa-pencil"></i></a>';
             $admin_suppr_group = '<a href="admin_index.php?onglet=suppr_group&session=' . $session . '&group=' . $sql_gid . '" title="' . _('form_supprim') . '"><i class="fa fa-times-circle"></i></a>';
 
             $childTable .= '<tr class="' . ($i ? 'i' : 'p') . '">';
-            $childTable .= '<td><b>' . $sql_group .'</b></td>';
+            $childTable .= '<td><b>' . $sql_group . '</b></td>';
             $childTable .= '<td>' . $sql_comment . '</td>';
             $childTable .= '<td>' . $nb_users_groupe . '</td>';
-            if($_SESSION['config']['double_validation_conges']) {
+            if ($_SESSION['config']['double_validation_conges']) {
                 $childTable .= '<td>' . $sql_double_valid . '</td>';
             }
             $childTable .= '<td class="action">' . $admin_modif_group . ' ' . $admin_suppr_group . '</td>';
@@ -1241,18 +1236,18 @@ class Fonctions
         $childTable = '<thead><tr>';
         $childTable .= '<th><b>' . _('admin_groupes_groupe') . '</b></th>';
         $childTable .= '<th>' . _('admin_groupes_libelle') . ' / ' . _('divers_comment_maj_1') . '</th>';
-        if($_SESSION['config']['double_validation_conges']) {
+        if ($_SESSION['config']['double_validation_conges']) {
             $childTable .= '<th>' . _('admin_groupes_double_valid') . '</th>';
         }
         $childTable .= '</tr></thead><tbody>';
 
         $text_groupname = '<input class="form-control" type="text" name="new_group_name" size="30" maxlength="50" value="' . $new_group_name . '">';
-        $text_libelle = '<input class="form-control" type="text" name="new_group_libelle" size="50" maxlength="250" value="' . $new_group_libelle . '">';
+        $text_libelle   = '<input class="form-control" type="text" name="new_group_libelle" size="50" maxlength="250" value="' . $new_group_libelle . '">';
 
         $childTable .= '<tr>';
         $childTable .= '<td>' . $text_groupname . '</td>';
         $childTable .= '<td>' . $text_libelle . '</td>';
-        if($_SESSION['config']['double_validation_conges']) {
+        if ($_SESSION['config']['double_validation_conges']) {
             $text_double_valid = '<select class="form-control" name="new_group_double_valid"><option value="N">N</option><option value="Y">Y</option></select>';
             $childTable .= '<td>' . $text_double_valid . '</td>';
         }
@@ -1279,13 +1274,13 @@ class Fonctions
      */
     public static function groupeModule($onglet)
     {
-        $saisie_group           = getpost_variable('saisie_group') ;
-        $new_group_name         = htmlentities(addslashes( getpost_variable('new_group_name')), ENT_QUOTES | ENT_HTML401);
-        $new_group_libelle      = addslashes( getpost_variable('new_group_libelle')) ;
+        $saisie_group           = getpost_variable('saisie_group');
+        $new_group_name         = htmlentities(addslashes(getpost_variable('new_group_name')), ENT_QUOTES | ENT_HTML401);
+        $new_group_libelle      = addslashes(getpost_variable('new_group_libelle'));
         $new_group_double_valid = getpost_variable('new_group_double_valid');
-        $return = '';
+        $return                 = '';
 
-        if($saisie_group=="ok") {
+        if ($saisie_group == "ok") {
             $return .= \admin\Fonctions::ajout_groupe($new_group_name, $new_group_libelle, $new_group_double_valid);
         } else {
             $return .= \admin\Fonctions::affiche_gestion_groupes($new_group_name, $new_group_libelle, $onglet);
@@ -1311,14 +1306,13 @@ class Fonctions
         /*********************/
 
         // recup du tableau des types de conges (seulement les conges)
-        $tab_type_conges=recup_tableau_types_conges();
+        $tab_type_conges               = recup_tableau_types_conges();
         $tab_type_conges_exceptionnels = [];
 
         // recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-            $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
+            $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
         }
-
 
         // AFFICHAGE TABLEAU
         $table = new \App\Libraries\Structure\Table();
@@ -1327,11 +1321,11 @@ class Fonctions
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         $childTable = '<thead>';
         $childTable .= '<tr>';
-        $childTable .= '<th>' .  _('user') . '</th>';
+        $childTable .= '<th>' . _('user') . '</th>';
         $childTable .= '<th>' . _('divers_quotite_maj_1') . '</th>';
         foreach ($tab_type_conges as $id_type_cong => $libelle) {
             $childTable .= '<th>' . $libelle . ' / ' . _('divers_an') . '</th>';
@@ -1343,7 +1337,7 @@ class Fonctions
         }
         $childTable .= '<th></th>';
         $childTable .= '<th></th>';
-        if($_SESSION['config']['admin_change_passwd']) {
+        if ($_SESSION['config']['admin_change_passwd']) {
             $childTable .= '<th></th>';
         }
         $childTable .= '</tr>';
@@ -1351,9 +1345,9 @@ class Fonctions
         $childTable .= '<tbody>';
 
         // Récuperation des informations des users:
-        $tab_info_users=array();
+        $tab_info_users = array();
         // si l'admin peut voir tous les users  OU si l'admin n'est pas responsable
-        if( $_SESSION['config']['admin_see_all'] || $_SESSION['userlogin']=="admin" || is_hr($_SESSION['userlogin']) ) {
+        if ($_SESSION['config']['admin_see_all'] || $_SESSION['userlogin'] == "admin" || is_hr($_SESSION['userlogin'])) {
             $tab_info_users = recup_infos_all_users();
         } else {
             $tab_info_users = recup_infos_all_users_du_resp($_SESSION['userlogin']);
@@ -1361,33 +1355,32 @@ class Fonctions
 
         $i = true;
         foreach ($tab_info_users as $current_login => $tab_current_infos) {
-            $admin_modif_user= '<a href="admin_index.php?onglet=modif_user&session=' . $session . '&u_login=' . $current_login . '" title="' . _('form_modif') . '"><i class="fa fa-pencil"></i></a>';
-            $admin_suppr_user = '<a href="admin_index.php?onglet=suppr_user&session=' . $session . '&u_login=' . $current_login . '" title="' . _('form_supprim') . '"><i class="fa fa-times-circle"></i></a>';
+            $admin_modif_user   = '<a href="admin_index.php?onglet=modif_user&session=' . $session . '&u_login=' . $current_login . '" title="' . _('form_modif') . '"><i class="fa fa-pencil"></i></a>';
+            $admin_suppr_user   = '<a href="admin_index.php?onglet=suppr_user&session=' . $session . '&u_login=' . $current_login . '" title="' . _('form_supprim') . '"><i class="fa fa-times-circle"></i></a>';
             $admin_chg_pwd_user = '<a href="admin_index.php?onglet=chg_pwd_user&session=' . $session . '&u_login=' . $current_login . '" title="' . _('form_password') . '"><i class="fa fa-key"></i></a>';
 
-
-            $childTable .= '<tr class="' . (($tab_current_infos['is_active']=='Y') ? 'actif' : 'inactif') . '">';
+            $childTable .= '<tr class="' . (($tab_current_infos['is_active'] == 'Y') ? 'actif' : 'inactif') . '">';
             $childTable .= '<td class="utilisateur"><strong>' . $tab_current_infos['nom'] . ' ' . $tab_current_infos['prenom'] . '</strong>';
             $childTable .= '<span class="login">' . $current_login . '</span>';
-            if($_SESSION['config']['where_to_find_user_email']=="dbconges") {
+            if ($_SESSION['config']['where_to_find_user_email'] == "dbconges") {
                 $childTable .= '<span class="mail">' . $tab_current_infos['email'] . '</span>';
             }
             // droit utilisateur
             $rights = array();
-            if($tab_current_infos['is_admin'] == 'Y') {
+            if ($tab_current_infos['is_admin'] == 'Y') {
                 $rights[] = 'administrateur';
             }
-            if($tab_current_infos['is_resp'] == 'Y') {
+            if ($tab_current_infos['is_resp'] == 'Y') {
                 $rights[] = 'responsable';
             }
-            if($tab_current_infos['is_hr'] == 'Y') {
+            if ($tab_current_infos['is_hr'] == 'Y') {
                 $rights[] = 'RH';
             }
-            if($tab_current_infos['see_all'] == 'Y') {
+            if ($tab_current_infos['see_all'] == 'Y') {
                 $rights[] = 'voit tout';
             }
 
-            if(count($rights) > 0) {
+            if (count($rights) > 0) {
                 $childTable .= '<span class="rights">' . implode(', ', $rights) . '</span>';
             }
 
@@ -1396,9 +1389,9 @@ class Fonctions
             $childTable .= '</td><td>' . $tab_current_infos['quotite'] . ' %</td>';
 
             //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-            $tab_conges=$tab_current_infos['conges'];
+            $tab_conges = $tab_current_infos['conges'];
 
-            foreach($tab_type_conges as $id_conges => $libelle) {
+            foreach ($tab_type_conges as $id_conges => $libelle) {
                 if (isset($tab_conges[$libelle])) {
                     $childTable .= '<td>' . $tab_conges[$libelle]['nb_an'] . '</td>';
                     $childTable .= '<td>' . $tab_conges[$libelle]['solde'] . '</td>';
@@ -1408,7 +1401,7 @@ class Fonctions
                 }
             }
 
-            foreach($tab_type_conges_exceptionnels as $id_conges => $libelle) {
+            foreach ($tab_type_conges_exceptionnels as $id_conges => $libelle) {
                 if (isset($tab_conges[$libelle])) {
                     $childTable .= '<td>' . $tab_conges[$libelle]['solde'] . '</td>';
                 } else {
@@ -1418,7 +1411,7 @@ class Fonctions
 
             $childTable .= '<td>' . $admin_modif_user . '</td>';
             $childTable .= '<td>' . $admin_suppr_user . '</td>';
-            if(($_SESSION['config']['admin_change_passwd']) && ($_SESSION['config']['how_to_connect_user'] == "dbconges")) {
+            if (($_SESSION['config']['admin_change_passwd']) && ($_SESSION['config']['how_to_connect_user'] == "dbconges")) {
                 $childTable .= '<td>' . $admin_chg_pwd_user . '</td>';
             }
             $childTable .= '</tr>';
@@ -1441,19 +1434,19 @@ class Fonctions
         $session  = session_id();
         $return   = '';
 
-        if( (strlen($new_pwd1)!=0) && (strlen($new_pwd2)!=0) && (strcmp($new_pwd1, $new_pwd2)==0) ) {
+        if ((strlen($new_pwd1) != 0) && (strlen($new_pwd2) != 0) && (strcmp($new_pwd1, $new_pwd2) == 0)) {
 
-            $passwd_md5=md5($new_pwd1);
-            $sql1 = 'UPDATE conges_users  SET u_passwd=\''.$passwd_md5.'\' WHERE u_login="'. \includes\SQL::quote($u_login_to_update).'"' ;
-            $result = \includes\SQL::query($sql1);
+            $passwd_md5 = md5($new_pwd1);
+            $sql1       = 'UPDATE conges_users  SET u_passwd=\'' . $passwd_md5 . '\' WHERE u_login="' . \includes\SQL::quote($u_login_to_update) . '"';
+            $result     = \includes\SQL::query($sql1);
 
-            if($result) {
+            if ($result) {
                 $return .= _('form_modif_ok') . ' !<br><br>';
             } else {
                 $return .= _('form_modif_not_ok') . ' !<br><br>';
             }
 
-            $comment_log = "admin_change_password_user : pour $u_login_to_update" ;
+            $comment_log = "admin_change_password_user : pour $u_login_to_update";
             log_action(0, "", $u_login_to_update, $comment_log);
 
             /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
@@ -1472,8 +1465,8 @@ class Fonctions
     public static function modifier($u_login, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /********************/
         /* Etat utilisateur */
@@ -1497,12 +1490,12 @@ class Fonctions
         $childTable .= '<tr align="center">';
 
         // Récupération des informations
-        $sql1 = 'SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_login = "'. \includes\SQL::quote($u_login).'"';
+        $sql1    = 'SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_login = "' . \includes\SQL::quote($u_login) . '"';
         $ReqLog1 = \includes\SQL::query($sql1);
 
         while ($resultat1 = $ReqLog1->fetch_array()) {
-            $text_pwd1="<input type=\"password\" name=\"new_pwd1\" size=\"10\" maxlength=\"30\" value=\"\" autocomplete=\"off\">" ;
-            $text_pwd2="<input type=\"password\" name=\"new_pwd2\" size=\"10\" maxlength=\"30\" value=\"\" autocomplete=\"off\">" ;
+            $text_pwd1 = "<input type=\"password\" name=\"new_pwd1\" size=\"10\" maxlength=\"30\" value=\"\" autocomplete=\"off\">";
+            $text_pwd2 = "<input type=\"password\" name=\"new_pwd2\" size=\"10\" maxlength=\"30\" value=\"\" autocomplete=\"off\">";
             $childTable .= '<td>' . $resultat1["u_login"] . '</td><td>' . $resultat1["u_nom"] . '</td><td>' . $resultat1["u_prenom"] . '</td><td>' . $text_pwd1 . '</td><td>' . $text_pwd2 . '</td>';
         }
         $childTable .= '<tr>';
@@ -1538,21 +1531,21 @@ class Fonctions
         // recup des parametres reçus :
         // SERVER
 
-        $u_login            = htmlentities(getpost_variable('u_login'), ENT_QUOTES | ENT_HTML401);
-        $u_login_to_update  = htmlentities(getpost_variable('u_login_to_update'), ENT_QUOTES | ENT_HTML401);
-        $new_pwd1           = htmlentities(getpost_variable('new_pwd1'), ENT_QUOTES | ENT_HTML401);
-        $new_pwd2           = htmlentities(getpost_variable('new_pwd2'), ENT_QUOTES | ENT_HTML401);
+        $u_login           = htmlentities(getpost_variable('u_login'), ENT_QUOTES | ENT_HTML401);
+        $u_login_to_update = htmlentities(getpost_variable('u_login_to_update'), ENT_QUOTES | ENT_HTML401);
+        $new_pwd1          = htmlentities(getpost_variable('new_pwd1'), ENT_QUOTES | ENT_HTML401);
+        $new_pwd2          = htmlentities(getpost_variable('new_pwd2'), ENT_QUOTES | ENT_HTML401);
 
-        if($u_login!="") {
+        if ($u_login != "") {
             $return = '<H1>' . _('admin_chg_passwd_titre') . ' : ' . $u_login . '</H1>';
             $return .= \admin\Fonctions::modifier($u_login, $onglet);
         } else {
-            if($u_login_to_update!="") {
+            if ($u_login_to_update != "") {
                 $return .= '<H1>' . _('admin_chg_passwd_titre') . ' : ' . $u_login_to_update . '</H1>';
                 $return .= \admin\Fonctions::commit_update($u_login_to_update, $new_pwd1, $new_pwd2);
             } else {
                 // renvoit sur la page principale .
-                redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-users', false);
+                redirect(ROOT_PATH . 'admin/admin_index.php?session=' . $session . '&onglet=admin-users', false);
             }
         }
         return $return;
@@ -1562,33 +1555,34 @@ class Fonctions
     public static function get_table_data($table)
     {
 
-        $chaine_data="";
+        $chaine_data = "";
 
         // suppression des donnéées de la table :
-        $chaine_delete='DELETE FROM `'. \includes\SQL::quote($table).'` ;'."\n";
-        $chaine_data=$chaine_data.$chaine_delete ;
+        $chaine_delete = 'DELETE FROM `' . \includes\SQL::quote($table) . '` ;' . "\n";
+        $chaine_data   = $chaine_data . $chaine_delete;
 
         // recup des donnéées de la table :
-        $sql_data='SELECT * FROM '. \includes\SQL::quote($table);
+        $sql_data    = 'SELECT * FROM ' . \includes\SQL::quote($table);
         $ReqLog_data = \includes\SQL::query($sql_data);
 
-        while ($resultat_data = $ReqLog_data->fetch_array())
-        {
-            $count_fields=count($resultat_data)/2;   // on divise par 2 car c'est un tableau indexé (donc compte key+valeur)
+        while ($resultat_data = $ReqLog_data->fetch_array()) {
+            $count_fields  = count($resultat_data) / 2; // on divise par 2 car c'est un tableau indexé (donc compte key+valeur)
             $chaine_insert = "INSERT INTO `$table` VALUES ( ";
-            for($i=0; $i<$count_fields; $i++)
-            {
-                if(isset($resultat_data[$i]))
-                    $chaine_insert = $chaine_insert."'".addslashes($resultat_data[$i])."'";
-                else
-                    $chaine_insert = $chaine_insert."NULL";
+            for ($i = 0; $i < $count_fields; $i++) {
+                if (isset($resultat_data[$i])) {
+                    $chaine_insert = $chaine_insert . "'" . addslashes($resultat_data[$i]) . "'";
+                } else {
+                    $chaine_insert = $chaine_insert . "NULL";
+                }
 
-                if($i!=$count_fields-1)
-                    $chaine_insert = $chaine_insert.", ";
+                if ($i != $count_fields - 1) {
+                    $chaine_insert = $chaine_insert . ", ";
+                }
+
             }
-            $chaine_insert = $chaine_insert." );\n";
+            $chaine_insert = $chaine_insert . " );\n";
 
-            $chaine_data=$chaine_data.$chaine_insert;
+            $chaine_data = $chaine_data . $chaine_insert;
         }
 
         return $chaine_data;
@@ -1597,96 +1591,110 @@ class Fonctions
     // recup de la structure d'une table sous forme de CREATE ...
     public static function get_table_structure($table)
     {
-        $chaine_drop="DROP TABLE IF EXISTS  `$table` ;\n";
+        $chaine_drop   = "DROP TABLE IF EXISTS  `$table` ;\n";
         $chaine_create = "CREATE TABLE `$table` ( ";
 
         // description des champs :
-        $sql_champs='SHOW FIELDS FROM '. \includes\SQL::quote($table);
-        $ReqLog_champs = \includes\SQL::query($sql_champs) ;
-        $count_champs=$ReqLog_champs->num_rows;
-        $i=0;
-        while ($resultat_champs = $ReqLog_champs->fetch_array())
-        {
-            $sql_field=$resultat_champs['Field'];
-            $sql_type=$resultat_champs['Type'];
-            $sql_null=$resultat_champs['Null'];
-            $sql_key=$resultat_champs['Key'];
-            $sql_default=$resultat_champs['Default'];
-            $sql_extra=$resultat_champs['Extra'];
+        $sql_champs    = 'SHOW FIELDS FROM ' . \includes\SQL::quote($table);
+        $ReqLog_champs = \includes\SQL::query($sql_champs);
+        $count_champs  = $ReqLog_champs->num_rows;
+        $i             = 0;
+        while ($resultat_champs = $ReqLog_champs->fetch_array()) {
+            $sql_field   = $resultat_champs['Field'];
+            $sql_type    = $resultat_champs['Type'];
+            $sql_null    = $resultat_champs['Null'];
+            $sql_key     = $resultat_champs['Key'];
+            $sql_default = $resultat_champs['Default'];
+            $sql_extra   = $resultat_champs['Extra'];
 
-            $chaine_create=$chaine_create." `$sql_field` $sql_type ";
-            if($sql_null != "YES")
-                $chaine_create=$chaine_create." NOT NULL ";
-            if(!empty($sql_default))
-            {
-                if($sql_default=="CURRENT_TIMESTAMP")
-                    $chaine_create=$chaine_create." default $sql_default ";        // pas de quotes !
-                else
-                    $chaine_create=$chaine_create." default '$sql_default' ";
+            $chaine_create = $chaine_create . " `$sql_field` $sql_type ";
+            if ($sql_null != "YES") {
+                $chaine_create = $chaine_create . " NOT NULL ";
             }
-            if(!empty($sql_extra))
-                $chaine_create=$chaine_create." $sql_extra ";
-            if($i<$count_champs-1)
-                $chaine_create=$chaine_create.",";
+
+            if (!empty($sql_default)) {
+                if ($sql_default == "CURRENT_TIMESTAMP") {
+                    $chaine_create = $chaine_create . " default $sql_default ";
+                }
+                // pas de quotes !
+                else {
+                    $chaine_create = $chaine_create . " default '$sql_default' ";
+                }
+
+            }
+            if (!empty($sql_extra)) {
+                $chaine_create = $chaine_create . " $sql_extra ";
+            }
+
+            if ($i < $count_champs - 1) {
+                $chaine_create = $chaine_create . ",";
+            }
+
             $i++;
         }
 
         // description des index :
-        $sql_index = 'SHOW KEYS FROM '. \includes\SQL::quote($table).'';
-        $ReqLog_index = \includes\SQL::query($sql_index) ;
-        $count_index=$ReqLog_index->num_rows;
-        $i=0;
+        $sql_index    = 'SHOW KEYS FROM ' . \includes\SQL::quote($table) . '';
+        $ReqLog_index = \includes\SQL::query($sql_index);
+        $count_index  = $ReqLog_index->num_rows;
+        $i            = 0;
 
         // il faut faire une liste pour prendre les PRIMARY, le nom de la colonne et
         // genérer un PRIMARY KEY ('key1'), PRIMARY KEY ('key2', ...)
         // puis on regarde ceux qui ne sont pas PRIMARY et on regarde s'ils sont UNIQUE ou pas et
         // on génére une liste= UNIQUE 'key1' ('key1') , 'key2' ('key2') , ....
         // ou une liste= KEY key1' ('key1') , 'key2' ('key2') , ....
-        $list_primary="";
-        $list_unique="";
-        $list_key="";
-        while ($resultat_index = $ReqLog_index->fetch_array())
-        {
-            $sql_key_name=$resultat_index['Key_name'];
-            $sql_column_name=$resultat_index['Column_name'];
-            $sql_non_unique=$resultat_index['Non_unique'];
+        $list_primary = "";
+        $list_unique  = "";
+        $list_key     = "";
+        while ($resultat_index = $ReqLog_index->fetch_array()) {
+            $sql_key_name    = $resultat_index['Key_name'];
+            $sql_column_name = $resultat_index['Column_name'];
+            $sql_non_unique  = $resultat_index['Non_unique'];
 
-            if($sql_key_name=="PRIMARY")
-            {
-                if($list_primary=="")
-                    $list_primary=" PRIMARY KEY (`$sql_column_name` ";
-                else
-                    $list_primary=$list_primary.", `$sql_column_name` ";
-            }
-            elseif($sql_non_unique== 0)
-            {
-                if($list_unique=="")
-                    $list_unique=" UNIQUE  `$sql_column_name` (`$sql_key_name`) ";
-                else
-                    $list_unique = $list_unique.", `$sql_column_name` (`$sql_key_name`) ";
-            }
-            else
-            {
-                if($list_key=="")
-                    $list_key=" KEY  `$sql_column_name` (`$sql_key_name`) ";
-                else
-                    $list_key=$list_key.", KEY `$sql_column_name` (`$sql_key_name`) ";
+            if ($sql_key_name == "PRIMARY") {
+                if ($list_primary == "") {
+                    $list_primary = " PRIMARY KEY (`$sql_column_name` ";
+                } else {
+                    $list_primary = $list_primary . ", `$sql_column_name` ";
+                }
+
+            } elseif ($sql_non_unique == 0) {
+                if ($list_unique == "") {
+                    $list_unique = " UNIQUE  `$sql_column_name` (`$sql_key_name`) ";
+                } else {
+                    $list_unique = $list_unique . ", `$sql_column_name` (`$sql_key_name`) ";
+                }
+
+            } else {
+                if ($list_key == "") {
+                    $list_key = " KEY  `$sql_column_name` (`$sql_key_name`) ";
+                } else {
+                    $list_key = $list_key . ", KEY `$sql_column_name` (`$sql_key_name`) ";
+                }
+
             }
         }
 
-        if($list_primary!="")
-            $list_primary=$list_primary." ) ";
+        if ($list_primary != "") {
+            $list_primary = $list_primary . " ) ";
+        }
 
-        if($list_primary!="")
-            $chaine_create=$chaine_create.",    ".$list_primary;
-        if($list_unique!="")
-            $chaine_create=$chaine_create.",    ".$list_unique;
-        if($list_key!="")
-            $chaine_create=$chaine_create.",    ".$list_key;
+        if ($list_primary != "") {
+            $chaine_create = $chaine_create . ",    " . $list_primary;
+        }
 
-        $chaine_create=$chaine_create." ) DEFAULT CHARSET=latin1;\n#\n";
+        if ($list_unique != "") {
+            $chaine_create = $chaine_create . ",    " . $list_unique;
+        }
 
-        return($chaine_drop.$chaine_create);
+        if ($list_key != "") {
+            $chaine_create = $chaine_create . ",    " . $list_key;
+        }
+
+        $chaine_create = $chaine_create . " ) DEFAULT CHARSET=latin1;\n#\n";
+
+        return ($chaine_drop . $chaine_create);
     }
 
     public static function restaure($fichier_restaure_name, $fichier_restaure_tmpname, $fichier_restaure_size, $fichier_restaure_error)
@@ -1699,14 +1707,14 @@ class Fonctions
 
         $return .= '<h1>' . _('admin_sauve_db_titre') . '</h1>';
 
-        if( ($fichier_restaure_error!=0)||($fichier_restaure_size==0) ) // s'il y a eu une erreur dans le telechargement OU taille==0
-            //(cf code erreur dans fichier features.file-upload.errors.html de la doc php)
+        if (($fichier_restaure_error != 0) || ($fichier_restaure_size == 0)) // s'il y a eu une erreur dans le telechargement OU taille==0
+        //(cf code erreur dans fichier features.file-upload.errors.html de la doc php)
         {
             //message d'erreur et renvoit sur la page précédente (choix fichier)
-            $return.= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
-            $table = new \App\Libraries\Structure\Table();
+            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+            $table      = new \App\Libraries\Structure\Table();
             $childTable = '<tr>';
-            $childTable .= '<th>' . _('admin_sauve_db_bad_file') . ' : <br>' . $fichier_restaure_name .'</th>';
+            $childTable .= '<th>' . _('admin_sauve_db_bad_file') . ' : <br>' . $fichier_restaure_name . '</th>';
             $childTable .= '</tr><tr>';
             $childTable .= '<td align="center">';
             $childTable .= '<input type="hidden" name="choix_action" value="restaure">';
@@ -1726,7 +1734,7 @@ class Fonctions
             $result = execute_sql_file($fichier_restaure_tmpname);
 
             $return .= '<form action="" method="POST">';
-            $table = new \App\Libraries\Structure\Table();
+            $table      = new \App\Libraries\Structure\Table();
             $childTable = '<tr>';
             $childTable .= '<th>' . _('admin_sauve_db_restaure_ok') . ' !</th>';
             $childTable .= '</tr>';
@@ -1759,7 +1767,7 @@ class Fonctions
 
         $return .= '<h1>' . _('admin_sauve_db_titre') . '</h1>';
         $return .= '<form enctype="multipart/form-data" action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
-        $table = new \App\Libraries\Structure\Table();
+        $table      = new \App\Libraries\Structure\Table();
         $childTable = '<tr>';
         $childTable .= '<th>' . _('admin_sauve_db_restaure') . '<br>' . _('admin_sauve_db_file_to_restore') . ' :</th>';
         $childTable .= '</tr>';
@@ -1803,30 +1811,30 @@ class Fonctions
         $return   = '';
 
         header("Pragma: no-cache");
-        header("Content-Type: text/x-delimtext; name=\"php_conges_".$type_sauvegarde.".sql\"");
-        header("Content-disposition: attachment; filename=php_conges_".$type_sauvegarde.".sql");
+        header("Content-Type: text/x-delimtext; name=\"php_conges_" . $type_sauvegarde . ".sql\"");
+        header("Content-disposition: attachment; filename=php_conges_" . $type_sauvegarde . ".sql");
 
         //
         // Build the sql script file...
         //
-        $maintenant=date("d-m-Y H:i:s");
+        $maintenant = date("d-m-Y H:i:s");
         $return .= "#\n";
         $return .= "# PHP_CONGES\n";
         $return .= "#\n# DATE : $maintenant\n";
         $return .= "#\n";
 
         //recup de la liste des tables
-        $sql1="SHOW TABLES";
-        $ReqLog = \includes\SQL::query($sql1) ;
+        $sql1   = "SHOW TABLES";
+        $ReqLog = \includes\SQL::query($sql1);
         while ($resultat = $ReqLog->fetch_array()) {
-            $table=$resultat[0] ;
+            $table = $resultat[0];
 
             $return .= "#\n#\n# TABLE: $table \n#\n";
-            if(($type_sauvegarde=="all") || ($type_sauvegarde=="structure") ) {
+            if (($type_sauvegarde == "all") || ($type_sauvegarde == "structure")) {
                 $return .= "# Struture : \n#\n";
                 $return .= \admin\Fonctions::get_table_structure($table);
             }
-            if(($type_sauvegarde=="all") || ($type_sauvegarde=="data") ) {
+            if (($type_sauvegarde == "all") || ($type_sauvegarde == "data")) {
                 $return .= "# Data : \n#\n";
                 $return .= \admin\Fonctions::get_table_data($table);
             }
@@ -1840,14 +1848,14 @@ class Fonctions
         $session  = session_id();
         $return   = '';
 
-        redirect(ROOT_PATH .'admin/admin_db_sauve.php?session='.$session.'&choix_action=sauvegarde&type_sauvegarde='.$type_sauvegarde.'&commit=ok', false);
+        redirect(ROOT_PATH . 'admin/admin_db_sauve.php?session=' . $session . '&choix_action=sauvegarde&type_sauvegarde=' . $type_sauvegarde . '&commit=ok', false);
 
         header_popup();
 
         $return .= '<h1>' . _('admin_sauve_db_titre') . '</h1>';
 
         $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
-        $table = new \App\Libraries\Structure\Table();
+        $table      = new \App\Libraries\Structure\Table();
         $childTable = '<tr>';
         $childTable .= '<th colspan="2">' . _('admin_sauve_db_save_ok') . ' ...</th>';
         $childTable .= '</tr><tr>';
@@ -1872,13 +1880,12 @@ class Fonctions
         $session  = session_id();
         $return   = '';
 
-
         header_popup();
 
         $return .= '<h1>' . _('admin_sauve_db_titre') . '</h1>';
 
         $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
-        $table = new \App\Libraries\Structure\Table();
+        $table      = new \App\Libraries\Structure\Table();
         $childTable = '<tr>';
         $childTable .= '<th colspan="2">' . _('admin_sauve_db_options') . '</th>';
         $childTable .= '</tr><tr>';
@@ -1925,7 +1932,7 @@ class Fonctions
         $return .= '<h1>' . _('admin_sauve_db_titre') . '</h1>';
 
         $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
-        $table = new \App\Libraries\Structure\Table();
+        $table      = new \App\Libraries\Structure\Table();
         $childTable = '<tr>';
         $childTable .= '<th colspan="2">' . _('admin_sauve_db_choisissez') . ' :</th>';
         $childTable .= '</tr>';
@@ -1974,7 +1981,6 @@ class Fonctions
         // verif des droits du user à afficher la page
         verif_droits_user($session, "is_admin");
 
-
         /*** initialisation des variables ***/
         /*************************************/
         // recup des parametres reçus :
@@ -1985,34 +1991,36 @@ class Fonctions
         $type_sauvegarde = getpost_variable('type_sauvegarde');
         $commit          = getpost_variable('commit');
 
-        $fichier_restaure_name="";
-        $fichier_restaure_tmpname="";
-        $fichier_restaure_size=0;
-        $fichier_restaure_error=4;
-        if(isset($_FILES['fichier_restaure'])) {
-            $fichier_restaure_name=$_FILES['fichier_restaure']['name'];
-            $fichier_restaure_size=$_FILES['fichier_restaure']['size'];
-            $fichier_restaure_tmpname=$_FILES['fichier_restaure']['tmp_name'];
-            $fichier_restaure_error=$_FILES['fichier_restaure']['error'];
+        $fichier_restaure_name    = "";
+        $fichier_restaure_tmpname = "";
+        $fichier_restaure_size    = 0;
+        $fichier_restaure_error   = 4;
+        if (isset($_FILES['fichier_restaure'])) {
+            $fichier_restaure_name    = $_FILES['fichier_restaure']['name'];
+            $fichier_restaure_size    = $_FILES['fichier_restaure']['size'];
+            $fichier_restaure_tmpname = $_FILES['fichier_restaure']['tmp_name'];
+            $fichier_restaure_error   = $_FILES['fichier_restaure']['error'];
         }
         /*************************************/
-        if($choix_action=="") {
+        if ($choix_action == "") {
             \admin\Fonctions::choix_save_restore();
-        } elseif($choix_action=="sauvegarde") {
-            if( (!isset($type_sauvegarde)) || ($type_sauvegarde=="") ) {
+        } elseif ($choix_action == "sauvegarde") {
+            if ((!isset($type_sauvegarde)) || ($type_sauvegarde == "")) {
                 \admin\Fonctions::choix_sauvegarde();
             } else {
-                if( (!isset($commit)) || ($commit=="") ) {
+                if ((!isset($commit)) || ($commit == "")) {
                     \admin\Fonctions::sauve($type_sauvegarde);
                 } else {
                     \admin\Fonctions::commit_sauvegarde($type_sauvegarde);
                 }
             }
-        } elseif($choix_action=="restaure") {
-            if( (!isset($fichier_restaure_name)) || ($fichier_restaure_name=="")||(!isset($fichier_restaure_tmpname)) || ($fichier_restaure_tmpname=="") )
+        } elseif ($choix_action == "restaure") {
+            if ((!isset($fichier_restaure_name)) || ($fichier_restaure_name == "") || (!isset($fichier_restaure_tmpname)) || ($fichier_restaure_tmpname == "")) {
                 \admin\Fonctions::choix_restaure();
-            else
+            } else {
                 \admin\Fonctions::restaure($fichier_restaure_name, $fichier_restaure_tmpname, $fichier_restaure_size, $fichier_restaure_error);
+            }
+
         } else {
             /* APPEL D'UNE AUTRE PAGE immediat */
             echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=admin_index.php?session=$session&onglet=admin-users\">";
@@ -2021,25 +2029,24 @@ class Fonctions
 
     public static function commit_update_groupe($group_to_update, $new_groupname, $new_comment, $new_double_valid)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
-        $return   = '';
-        $result   = TRUE;
-        $new_comment=addslashes($new_comment);
-        $return .= $group_to_update .  '---' . $new_groupname . '---' . $new_comment . '---' . $new_double_valid . '<br>';
+        $PHP_SELF    = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session     = session_id();
+        $return      = '';
+        $result      = true;
+        $new_comment = addslashes($new_comment);
+        $return .= $group_to_update . '---' . $new_groupname . '---' . $new_comment . '---' . $new_double_valid . '<br>';
 
         // UPDATE de la table conges_groupe
-        $sql1 = 'UPDATE conges_groupe  SET g_groupename=\''.$new_groupname.'\', g_comment=\''.$new_comment.'\' , g_double_valid=\''.$new_double_valid.'\' WHERE g_gid= "'. \includes\SQL::quote($group_to_update).'"'  ;
+        $sql1    = 'UPDATE conges_groupe  SET g_groupename=\'' . $new_groupname . '\', g_comment=\'' . $new_comment . '\' , g_double_valid=\'' . $new_double_valid . '\' WHERE g_gid= "' . \includes\SQL::quote($group_to_update) . '"';
         $result1 = \includes\SQL::query($sql1);
-        if($result1==FALSE) {
-            $result==FALSE;
+        if ($result1 == false) {
+            $result == false;
         }
-
 
         $comment_log = "modif_groupe ($group_to_update) : $new_groupname , $new_comment (double_valid = $new_double_valid)";
         log_action(0, "", "", $comment_log);
 
-        if($result) {
+        if ($result) {
             $return .= _('form_modif_ok') . ' !<br><br>';
         } else {
             $return .= _('form_modif_not_ok') . ' !<br><br>';
@@ -2057,7 +2064,7 @@ class Fonctions
         $return   = '';
 
         // Récupération des informations
-        $sql1 = 'SELECT g_groupename, g_comment, g_double_valid FROM conges_groupe WHERE g_gid = "'. \includes\SQL::quote($group).'"';
+        $sql1 = 'SELECT g_groupename, g_comment, g_double_valid FROM conges_groupe WHERE g_gid = "' . \includes\SQL::quote($group) . '"';
 
         // AFFICHAGE TABLEAU
         $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '&group_to_update=' . $group . '" method="POST">';
@@ -2067,52 +2074,51 @@ class Fonctions
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         $childTable = '<thead>';
         $childTable .= '<tr>';
         $childTable .= '<th>' . _('admin_groupes_groupe') . '</th>';
         $childTable .= '<th>' . _('admin_groupes_libelle') . ' / ' . _('divers_comment_maj_1') . '</th>';
-        if($_SESSION['config']['double_validation_conges']) {
+        if ($_SESSION['config']['double_validation_conges']) {
             $childTable .= '<th>' . _('admin_groupes_double_valid') . '</th>';
         }
         $childTable .= '</tr></thead><tbody>';
 
         $ReqLog1 = \includes\SQL::query($sql1);
         while ($resultat1 = $ReqLog1->fetch_array()) {
-            $sql_groupename=$resultat1["g_groupename"];
-            $sql_comment=$resultat1["g_comment"];
-            $sql_double_valid=$resultat1["g_double_valid"] ;
+            $sql_groupename   = $resultat1["g_groupename"];
+            $sql_comment      = $resultat1["g_comment"];
+            $sql_double_valid = $resultat1["g_double_valid"];
         }
-
 
         // AFICHAGE DE LA LIGNE DES VALEURS ACTUELLES A MODIFIER
         $childTable .= '<tr>';
         $childTable .= '<td>' . $sql_groupename . '</td>';
         $childTable .= '<td>' . $sql_comment . '</td>';
-        if($_SESSION['config']['double_validation_conges']) {
+        if ($_SESSION['config']['double_validation_conges']) {
             $childTable .= '<td>' . $sql_double_valid . '</td>';
         }
         $childTable .= '</tr>';
 
         // contruction des champs de saisie
-        $text_group="<input class=\"form-control\" type=\"text\" name=\"new_groupname\" size=\"30\" maxlength=\"50\" value=\"".$sql_groupename."\">" ;
-        $text_comment="<input class=\"form-control\" type=\"text\" name=\"new_comment\" size=\"50\" maxlength=\"200\" value=\"".$sql_comment."\">" ;
+        $text_group   = "<input class=\"form-control\" type=\"text\" name=\"new_groupname\" size=\"30\" maxlength=\"50\" value=\"" . $sql_groupename . "\">";
+        $text_comment = "<input class=\"form-control\" type=\"text\" name=\"new_comment\" size=\"50\" maxlength=\"200\" value=\"" . $sql_comment . "\">";
 
         // AFFICHAGE ligne de saisie
         $childTable .= '<tr>';
         $childTable .= '<td>' . $text_group . '</td>';
         $childTable .= '<td>' . $text_comment . '</td>';
-        if($_SESSION['config']['double_validation_conges']) {
-            $text_double_valid="<select class=\"form-control\" name=\"new_double_valid\" ><option value=\"N\" ";
-            if($sql_double_valid=="N") {
-                $text_double_valid=$text_double_valid."SELECTED";
+        if ($_SESSION['config']['double_validation_conges']) {
+            $text_double_valid = "<select class=\"form-control\" name=\"new_double_valid\" ><option value=\"N\" ";
+            if ($sql_double_valid == "N") {
+                $text_double_valid = $text_double_valid . "SELECTED";
             }
-            $text_double_valid=$text_double_valid.">N</option><option value=\"Y\" ";
-            if($sql_double_valid=="Y") {
-                $text_double_valid=$text_double_valid."SELECTED";
+            $text_double_valid = $text_double_valid . ">N</option><option value=\"Y\" ";
+            if ($sql_double_valid == "Y") {
+                $text_double_valid = $text_double_valid . "SELECTED";
             }
-            $text_double_valid=$text_double_valid.">Y</option></select>" ;
+            $text_double_valid = $text_double_valid . ">Y</option></select>";
             $childTable .= '<td>' . $text_double_valid . '</td>';
         }
         $childTable .= '</tr></tbody>';
@@ -2142,24 +2148,24 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
 
-        $group                 = getpost_variable('group');
-        $group_to_update     = getpost_variable('group_to_update');
-        $new_groupname         = getpost_variable('new_groupname');
-        $new_comment         = getpost_variable('new_comment');
-        $new_double_valid    = getpost_variable('new_double_valid');
-        $return = '';
+        $group            = getpost_variable('group');
+        $group_to_update  = getpost_variable('group_to_update');
+        $new_groupname    = getpost_variable('new_groupname');
+        $new_comment      = getpost_variable('new_comment');
+        $new_double_valid = getpost_variable('new_double_valid');
+        $return           = '';
         /*************************************/
 
         // TITRE
         $return .= '<h1>' . _('admin_modif_groupe_titre') . '</h1>';
 
-        if($group!="" ) {
+        if ($group != "") {
             $return .= \admin\Fonctions::modifier_groupe($group, $onglet);
-        } elseif($group_to_update!="") {
+        } elseif ($group_to_update != "") {
             $return .= \admin\Fonctions::commit_update_groupe($group_to_update, $new_groupname, $new_comment, $new_double_valid);
         } else {
             // renvoit sur la page principale .
-            redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-group', false);
+            redirect(ROOT_PATH . 'admin/admin_index.php?session=' . $session . '&onglet=admin-group', false);
         }
         return $return;
     }
@@ -2169,28 +2175,28 @@ class Fonctions
         $dataUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($u_login_to_update);
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $session  = session_id();
-        $erreurs = [];
+        $erreurs  = [];
 
-        $result=TRUE;
+        $result = true;
 
         // recup du tableau des types de conges (seulement les conges)
-        $tab_type_conges = recup_tableau_types_conges();
-        $tab_type_conges_excep=array();
+        $tab_type_conges       = recup_tableau_types_conges();
+        $tab_type_conges_excep = array();
         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-            $tab_type_conges_excep=recup_tableau_types_conges_exceptionnels();
+            $tab_type_conges_excep = recup_tableau_types_conges_exceptionnels();
         }
 
-        $valid_1=TRUE;
-        $valid_2=TRUE;
-        $valid_3=TRUE;
-        $valid_reliquat=TRUE;
-        $valid_4 = true;
+        $valid_1        = true;
+        $valid_2        = true;
+        $valid_3        = true;
+        $valid_reliquat = true;
+        $valid_4        = true;
 
         // verification de la validite de la saisie du nombre de jours annuels et du solde pour chaque type de conges
-        foreach($tab_type_conges as $id_conges => $libelle) {
-            $valid_1=$valid_1 && verif_saisie_decimal($tab_new_jours_an[$id_conges]);  //verif la bonne saisie du nombre d?cimal
-            $valid_2=$valid_2 && verif_saisie_decimal($tab_new_solde[$id_conges]);  //verif la bonne saisie du nombre d?cimal
-            $valid_reliquat=$valid_reliquat && verif_saisie_decimal($tab_new_reliquat[$id_conges]);  //verif la bonne saisie du nombre d?cimal
+        foreach ($tab_type_conges as $id_conges => $libelle) {
+            $valid_1        = $valid_1 && verif_saisie_decimal($tab_new_jours_an[$id_conges]); //verif la bonne saisie du nombre d?cimal
+            $valid_2        = $valid_2 && verif_saisie_decimal($tab_new_solde[$id_conges]); //verif la bonne saisie du nombre d?cimal
+            $valid_reliquat = $valid_reliquat && verif_saisie_decimal($tab_new_reliquat[$id_conges]); //verif la bonne saisie du nombre d?cimal
         }
         if (false === $valid_1) {
             $erreurs['Nombre jour annuel'] = _('nombre_incorrect');
@@ -2203,53 +2209,52 @@ class Fonctions
         }
 
         // si l'application gere les conges exceptionnels ET si des types de conges exceptionnels ont été définis
-        if (($_SESSION['config']['gestion_conges_exceptionnels'])&&(count($tab_type_conges_excep) > 0)) {
-            $valid_3=TRUE;
+        if (($_SESSION['config']['gestion_conges_exceptionnels']) && (count($tab_type_conges_excep) > 0)) {
+            $valid_3 = true;
             // vérification de la validité de la saisie du nombre de jours annuels et du solde pour chaque type de conges exceptionnels
-            foreach($tab_type_conges_excep as $id_conges => $libelle) {
-                $valid_3 = $valid_3 && verif_saisie_decimal($tab_new_solde[$id_conges]);  //verif la bonne saisie du nombre décimal
+            foreach ($tab_type_conges_excep as $id_conges => $libelle) {
+                $valid_3 = $valid_3 && verif_saisie_decimal($tab_new_solde[$id_conges]); //verif la bonne saisie du nombre décimal
             }
-        } else { // sinon on considère $valid_3 comme vrai
-            $valid_3=TRUE;
+        } else {
+            // sinon on considère $valid_3 comme vrai
+            $valid_3 = true;
         }
 
         if (false === $valid_3) {
             $erreurs['Solde congés exceptionnels'] = _('nombre_incorrect');
         }
 
-        if(!\admin\Fonctions::FormAddUserSoldeHeureOk($tab_new_user['solde_heure'])
+        if (!\admin\Fonctions::FormAddUserSoldeHeureOk($tab_new_user['solde_heure'])
             || !\admin\Fonctions::FormAddUserQuotiteOk($tab_new_user['quotite'])
             || !\admin\Fonctions::FormAddUserNameOk($tab_new_user['nom'])
-            || !\admin\Fonctions::FormAddUserNameOk($tab_new_user['prenom']))
-        {
-            $valid_4=FALSE;
+            || !\admin\Fonctions::FormAddUserNameOk($tab_new_user['prenom'])) {
+            $valid_4 = false;
         }
 
         // si aucune erreur de saisie n'a ete commise
-        if(($valid_1) && ($valid_2) && ($valid_3) && ($valid_4) && ($valid_reliquat) && $tab_new_user['login']!="") {
+        if (($valid_1) && ($valid_2) && ($valid_3) && ($valid_4) && ($valid_reliquat) && $tab_new_user['login'] != "") {
             // UPDATE de la table conges_users
-            $sql = 'UPDATE conges_users SET u_nom="'. \includes\SQL::quote($tab_new_user['nom']).'", u_prenom="'.\includes\SQL::quote($tab_new_user['prenom']).'", u_is_resp="'. \includes\SQL::quote($tab_new_user['is_resp']).'", u_resp_login=';
-            if($tab_new_user['resp_login'] == 'no_resp') {
-                $sql .='NULL , ';
+            $sql = 'UPDATE conges_users SET u_nom="' . \includes\SQL::quote($tab_new_user['nom']) . '", u_prenom="' . \includes\SQL::quote($tab_new_user['prenom']) . '", u_is_resp="' . \includes\SQL::quote($tab_new_user['is_resp']) . '", u_resp_login=';
+            if ($tab_new_user['resp_login'] == 'no_resp') {
+                $sql .= 'NULL , ';
             } else {
-                $sql .='"'.\includes\SQL::quote($tab_new_user['resp_login']).'",';
+                $sql .= '"' . \includes\SQL::quote($tab_new_user['resp_login']) . '",';
             }
-            $sql .= 'u_heure_solde='. \App\Helpers\Formatter::hour2Time($tab_new_user['solde_heure']).',u_is_admin="'. \includes\SQL::quote($tab_new_user['is_admin']).'",u_is_hr="'.\includes\SQL::quote($tab_new_user['is_hr']).'",u_is_active="'.\includes\SQL::quote($tab_new_user['is_active']).'",u_see_all="'.\includes\SQL::quote($tab_new_user['see_all']).'",u_login="'.\includes\SQL::quote($tab_new_user['login']).'",u_quotite="'.\includes\SQL::quote($tab_new_user['quotite']).'",u_email="'. \includes\SQL::quote($tab_new_user['email']).'" WHERE u_login="'.\includes\SQL::quote($u_login_to_update).'"' ;
+            $sql .= 'u_heure_solde=' . \App\Helpers\Formatter::hour2Time($tab_new_user['solde_heure']) . ',u_is_admin="' . \includes\SQL::quote($tab_new_user['is_admin']) . '",u_is_hr="' . \includes\SQL::quote($tab_new_user['is_hr']) . '",u_is_active="' . \includes\SQL::quote($tab_new_user['is_active']) . '",u_see_all="' . \includes\SQL::quote($tab_new_user['see_all']) . '",u_login="' . \includes\SQL::quote($tab_new_user['login']) . '",u_quotite="' . \includes\SQL::quote($tab_new_user['quotite']) . '",u_email="' . \includes\SQL::quote($tab_new_user['email']) . '" WHERE u_login="' . \includes\SQL::quote($u_login_to_update) . '"';
 
             \includes\SQL::query($sql);
 
-
             /*************************************/
             /* Mise a jour de la table conges_solde_user   */
-            foreach($tab_type_conges as $id_conges => $libelle) {
-                $sql = 'REPLACE INTO conges_solde_user SET su_nb_an=\''.strtr(round_to_half($tab_new_jours_an[$id_conges]),",",".").'\',su_solde=\''.strtr(round_to_half($tab_new_solde[$id_conges]),",",".").'\',su_reliquat=\''.strtr(round_to_half($tab_new_reliquat[$id_conges]),",",".").'\',su_login="'.\includes\SQL::quote($u_login_to_update).'",su_abs_id='.intval($id_conges).';';
+            foreach ($tab_type_conges as $id_conges => $libelle) {
+                $sql = 'REPLACE INTO conges_solde_user SET su_nb_an=\'' . strtr(round_to_half($tab_new_jours_an[$id_conges]), ",", ".") . '\',su_solde=\'' . strtr(round_to_half($tab_new_solde[$id_conges]), ",", ".") . '\',su_reliquat=\'' . strtr(round_to_half($tab_new_reliquat[$id_conges]), ",", ".") . '\',su_login="' . \includes\SQL::quote($u_login_to_update) . '",su_abs_id=' . intval($id_conges) . ';';
                 \includes\SQL::query($sql);
 
             }
 
             if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-                foreach($tab_type_conges_excep as $id_conges => $libelle) {
-                    $sql = 'REPLACE INTO conges_solde_user SET su_nb_an=0, su_solde=\''.strtr(round_to_half($tab_new_solde[$id_conges]),",",".").'\', su_reliquat=\''.strtr(round_to_half($tab_new_reliquat[$id_conges]),",",".").'\', su_login="'.\includes\SQL::quote($u_login_to_update).'", su_abs_id='.intval($id_conges).';';
+                foreach ($tab_type_conges_excep as $id_conges => $libelle) {
+                    $sql = 'REPLACE INTO conges_solde_user SET su_nb_an=0, su_solde=\'' . strtr(round_to_half($tab_new_solde[$id_conges]), ",", ".") . '\', su_reliquat=\'' . strtr(round_to_half($tab_new_reliquat[$id_conges]), ",", ".") . '\', su_login="' . \includes\SQL::quote($u_login_to_update) . '", su_abs_id=' . intval($id_conges) . ';';
                     \includes\SQL::query($sql);
                 }
             }
@@ -2258,42 +2263,42 @@ class Fonctions
 
             // Si changement du login, (on a dèja updaté la table users (mais pas les responsables !!!)) on update toutes les autres tables
             // (les grilles artt, les periodes de conges et les échanges de rtt, etc ....) avec le nouveau login
-            if($tab_new_user['login'] != $u_login_to_update) {
+            if ($tab_new_user['login'] != $u_login_to_update) {
                 // update table echange_rtt
-                $sql = 'UPDATE conges_echange_rtt SET e_login="'. \includes\SQL::quote($tab_new_user['login']).'" WHERE e_login="'. \includes\SQL::quote($u_login_to_update).'" ';
+                $sql = 'UPDATE conges_echange_rtt SET e_login="' . \includes\SQL::quote($tab_new_user['login']) . '" WHERE e_login="' . \includes\SQL::quote($u_login_to_update) . '" ';
                 \includes\SQL::query($sql);
 
                 // update table edition_papier
-                $sql = 'UPDATE conges_edition_papier SET ep_login="'. \includes\SQL::quote($tab_new_user['login']).'" WHERE ep_login="'. \includes\SQL::quote($u_login_to_update).'" ';
+                $sql = 'UPDATE conges_edition_papier SET ep_login="' . \includes\SQL::quote($tab_new_user['login']) . '" WHERE ep_login="' . \includes\SQL::quote($u_login_to_update) . '" ';
                 \includes\SQL::query($sql);
 
                 // update table groupe_grd_resp
-                $sql = 'UPDATE conges_groupe_grd_resp SET ggr_login= "'. \includes\SQL::quote($tab_new_user['login']).'" WHERE ggr_login="'.\includes\SQL::quote($u_login_to_update).'"  ';
+                $sql = 'UPDATE conges_groupe_grd_resp SET ggr_login= "' . \includes\SQL::quote($tab_new_user['login']) . '" WHERE ggr_login="' . \includes\SQL::quote($u_login_to_update) . '"  ';
                 \includes\SQL::query($sql);
 
                 // update table groupe_resp
-                $sql = 'UPDATE conges_groupe_resp SET gr_login="'. \includes\SQL::quote($tab_new_user['login']).'" WHERE gr_login="'. \includes\SQL::quote($u_login_to_update).'" ';
+                $sql = 'UPDATE conges_groupe_resp SET gr_login="' . \includes\SQL::quote($tab_new_user['login']) . '" WHERE gr_login="' . \includes\SQL::quote($u_login_to_update) . '" ';
                 \includes\SQL::query($sql);
 
                 // update table conges_groupe_users
-                $sql = 'UPDATE conges_groupe_users SET gu_login="'. \includes\SQL::quote($tab_new_user['login']).'" WHERE gu_login="'. \includes\SQL::quote($u_login_to_update).'" ';
+                $sql = 'UPDATE conges_groupe_users SET gu_login="' . \includes\SQL::quote($tab_new_user['login']) . '" WHERE gu_login="' . \includes\SQL::quote($u_login_to_update) . '" ';
                 \includes\SQL::query($sql);
 
                 // update table periode
-                $sql = 'UPDATE conges_periode SET p_login="'. \includes\SQL::quote($tab_new_user['login']).'" WHERE p_login="'. \includes\SQL::quote($u_login_to_update).'" ';
+                $sql = 'UPDATE conges_periode SET p_login="' . \includes\SQL::quote($tab_new_user['login']) . '" WHERE p_login="' . \includes\SQL::quote($u_login_to_update) . '" ';
                 \includes\SQL::query($sql);
 
                 // update table conges_solde_user
-                $sql = 'UPDATE conges_solde_user SET su_login="'. \includes\SQL::quote($tab_new_user['login']).'" WHERE su_login="'. \includes\SQL::quote($u_login_to_update).'" ' ;
+                $sql = 'UPDATE conges_solde_user SET su_login="' . \includes\SQL::quote($tab_new_user['login']) . '" WHERE su_login="' . \includes\SQL::quote($u_login_to_update) . '" ';
                 \includes\SQL::query($sql);
 
                 // update table conges_users
-                $sql = 'UPDATE conges_users SET u_resp_login="'. \includes\SQL::quote($tab_new_user['login']).'" WHERE u_resp_login="'. \includes\SQL::quote($u_login_to_update).'" ' ;
+                $sql = 'UPDATE conges_users SET u_resp_login="' . \includes\SQL::quote($tab_new_user['login']) . '" WHERE u_resp_login="' . \includes\SQL::quote($u_login_to_update) . '" ';
                 \includes\SQL::query($sql);
             }
 
-            if($tab_new_user['login'] != $u_login_to_update) {
-                $comment_log = "modif_user (old_login = $u_login_to_update)  new_login = ".$tab_new_user['login'];
+            if ($tab_new_user['login'] != $u_login_to_update) {
+                $comment_log = "modif_user (old_login = $u_login_to_update)  new_login = " . $tab_new_user['login'];
             } else {
                 $comment_log = "modif_user login = $u_login_to_update";
             }
@@ -2304,7 +2309,8 @@ class Fonctions
 
             return true;
 
-        } else { // en cas d'erreur de saisie
+        } else {
+            // en cas d'erreur de saisie
             // composition des erreurs
             $errors = '';
             if (!empty($erreurs)) {
@@ -2320,18 +2326,17 @@ class Fonctions
 
     public static function modifier_user($u_login, $onglet)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
-        $return   = '';
+        $PHP_SELF     = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session      = session_id();
+        $return       = '';
         $soldeHeureId = uniqid();
 
+        // recup du tableau des types de conges (seulement les conges)
+        $tab_type_conges = recup_tableau_types_conges();
 
         // recup du tableau des types de conges (seulement les conges)
-        $tab_type_conges=recup_tableau_types_conges();
-
-        // recup du tableau des types de conges (seulement les conges)
-        if ( $_SESSION['config']['gestion_conges_exceptionnels'] ) {
-            $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
+        if ($_SESSION['config']['gestion_conges_exceptionnels']) {
+            $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
         }
 
         // Récupération des informations
@@ -2348,7 +2353,7 @@ class Fonctions
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         $childTable = '<thead>';
         $childTable .= '<tr>';
@@ -2364,7 +2369,7 @@ class Fonctions
         $childTable .= '<th>' . _('admin_users_is_active') . '</th>';
         $childTable .= '<th>' . _('admin_users_see_all') . '</th>';
 
-        if($_SESSION['config']['where_to_find_user_email']=="dbconges") {
+        if ($_SESSION['config']['where_to_find_user_email'] == "dbconges") {
             $childTable .= '<th>' . _('admin_users_mail') . '</th>';
         }
         $childTable .= '</tr>';
@@ -2373,7 +2378,7 @@ class Fonctions
 
         // AFFICHAGE DE LA LIGNE DES VALEURS ACTUELLES A MODIFIER
         $childTable .= '<tr>';
-        $childTable .= '<td>' . $tab_user['nom']. '</td>';
+        $childTable .= '<td>' . $tab_user['nom'] . '</td>';
         $childTable .= '<td>' . $tab_user['prenom'] . '</td>';
         $childTable .= '<td>' . $tab_user['login'] . '</td>';
         $childTable .= '<td>' . $tab_user['quotite'] . '</td>';
@@ -2385,71 +2390,70 @@ class Fonctions
         $childTable .= '<td>' . $tab_user['is_active'] . '</td>';
         $childTable .= '<td>' . $tab_user['see_all'] . '</td>';
 
-        if($_SESSION['config']['where_to_find_user_email']=="dbconges") {
+        if ($_SESSION['config']['where_to_find_user_email'] == "dbconges") {
             $childTable .= '<td>' . $tab_user['email'] . '</td>';
         }
         $childTable .= '</tr>';
 
         // contruction des champs de saisie
-        if($_SESSION['config']['export_users_from_ldap']) {
-            $text_login="<input class=\"form-control\" type=\"text\" name=\"new_login\" size=\"10\" maxlength=\"98\" value=\"".$tab_user['login']."\" readonly>" ;
+        if ($_SESSION['config']['export_users_from_ldap']) {
+            $text_login = "<input class=\"form-control\" type=\"text\" name=\"new_login\" size=\"10\" maxlength=\"98\" value=\"" . $tab_user['login'] . "\" readonly>";
         } else {
-            $text_login="<input class=\"form-control\" type=\"text\" name=\"new_login\" size=\"10\" maxlength=\"98\" value=\"".$tab_user['login']."\">" ;
+            $text_login = "<input class=\"form-control\" type=\"text\" name=\"new_login\" size=\"10\" maxlength=\"98\" value=\"" . $tab_user['login'] . "\">";
         }
 
-        $text_nom="<input class=\"form-control\" type=\"text\" name=\"new_nom\" size=\"10\" maxlength=\"30\" value=\"".$tab_user['nom']."\">" ;
-        $text_prenom="<input class=\"form-control\" type=\"text\" name=\"new_prenom\" size=\"10\" maxlength=\"30\" value=\"".$tab_user['prenom']."\">" ;
-        $text_quotite="<input class=\"form-control\" type=\"text\" name=\"new_quotite\" size=\"3\" maxlength=\"3\" value=\"".$tab_user['quotite']."\">" ;
-        $text_solde_heure="<input class=\"form-control\" type=\"text\" name=\"new_solde_heure\" id=\"" . $soldeHeureId . "\"  size=\"6\" maxlength=\"6\" value=\"".  \App\Helpers\Formatter::timestamp2Duree($tab_user['solde_heure'])."\">" ;
-        if($tab_user['is_resp']=="Y") {
-            $text_is_resp="<select class=\"form-control\" name=\"new_is_resp\" id=\"is_resp_id\" ><option value=\"Y\">Y</option><option value=\"N\">N</option></select>" ;
+        $text_nom         = "<input class=\"form-control\" type=\"text\" name=\"new_nom\" size=\"10\" maxlength=\"30\" value=\"" . $tab_user['nom'] . "\">";
+        $text_prenom      = "<input class=\"form-control\" type=\"text\" name=\"new_prenom\" size=\"10\" maxlength=\"30\" value=\"" . $tab_user['prenom'] . "\">";
+        $text_quotite     = "<input class=\"form-control\" type=\"text\" name=\"new_quotite\" size=\"3\" maxlength=\"3\" value=\"" . $tab_user['quotite'] . "\">";
+        $text_solde_heure = "<input class=\"form-control\" type=\"text\" name=\"new_solde_heure\" id=\"" . $soldeHeureId . "\"  size=\"6\" maxlength=\"6\" value=\"" . \App\Helpers\Formatter::timestamp2Duree($tab_user['solde_heure']) . "\">";
+        if ($tab_user['is_resp'] == "Y") {
+            $text_is_resp = "<select class=\"form-control\" name=\"new_is_resp\" id=\"is_resp_id\" ><option value=\"Y\">Y</option><option value=\"N\">N</option></select>";
         } else {
-            $text_is_resp="<select class=\"form-control\" name=\"new_is_resp\" id=\"is_resp_id\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>" ;
+            $text_is_resp = "<select class=\"form-control\" name=\"new_is_resp\" id=\"is_resp_id\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>";
         }
 
-        if($tab_user['is_admin']=="Y") {
-            $text_is_admin="<select class=\"form-control\" name=\"new_is_admin\" ><option value=\"Y\">Y</option><option value=\"N\">N</option></select>" ;
+        if ($tab_user['is_admin'] == "Y") {
+            $text_is_admin = "<select class=\"form-control\" name=\"new_is_admin\" ><option value=\"Y\">Y</option><option value=\"N\">N</option></select>";
         } else {
-            $text_is_admin="<select class=\"form-control\" name=\"new_is_admin\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>" ;
+            $text_is_admin = "<select class=\"form-control\" name=\"new_is_admin\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>";
         }
 
-        if($tab_user['is_hr']=="Y") {
-            $text_is_hr="<select class=\"form-control\" name=\"new_is_hr\" ><option value=\"Y\">Y</option><option value=\"N\">N</option></select>" ;
+        if ($tab_user['is_hr'] == "Y") {
+            $text_is_hr = "<select class=\"form-control\" name=\"new_is_hr\" ><option value=\"Y\">Y</option><option value=\"N\">N</option></select>";
         } else {
-            $text_is_hr="<select class=\"form-control\" name=\"new_is_hr\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>" ;
+            $text_is_hr = "<select class=\"form-control\" name=\"new_is_hr\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>";
         }
 
-        if($tab_user['is_active']=="Y") {
-            $text_is_active="<select class=\"form-control\" name=\"new_is_active\" ><option value=\"Y\">Y</option><option value=\"N\">N</option></select>" ;
+        if ($tab_user['is_active'] == "Y") {
+            $text_is_active = "<select class=\"form-control\" name=\"new_is_active\" ><option value=\"Y\">Y</option><option value=\"N\">N</option></select>";
         } else {
-            $text_is_active="<select class=\"form-control\" name=\"new_is_active\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>" ;
+            $text_is_active = "<select class=\"form-control\" name=\"new_is_active\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>";
         }
 
-        if($tab_user['see_all']=="Y") {
-            $text_see_all="<select class=\"form-control\" name=\"new_see_all\" ><option value=\"Y\">Y</option><option value=\"N\">N</option></select>" ;
+        if ($tab_user['see_all'] == "Y") {
+            $text_see_all = "<select class=\"form-control\" name=\"new_see_all\" ><option value=\"Y\">Y</option><option value=\"N\">N</option></select>";
         } else {
-            $text_see_all="<select class=\"form-control\" name=\"new_see_all\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>" ;
+            $text_see_all = "<select class=\"form-control\" name=\"new_see_all\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>";
         }
 
-        if($_SESSION['config']['where_to_find_user_email']=="dbconges") {
-            $text_email="<input class=\"form-control\" type=\"text\" name=\"new_email\" size=\"10\" maxlength=\"99\" value=\"".$tab_user['email']."\">" ;
+        if ($_SESSION['config']['where_to_find_user_email'] == "dbconges") {
+            $text_email = "<input class=\"form-control\" type=\"text\" name=\"new_email\" size=\"10\" maxlength=\"99\" value=\"" . $tab_user['email'] . "\">";
         }
 
-
-        $text_resp_login="<select class=\"form-control\" name=\"new_resp_login\" id=\"resp_login_id\" ><option value=\"no_resp\">". _('admin_users_no_resp') ."</option>" ;
+        $text_resp_login = "<select class=\"form-control\" name=\"new_resp_login\" id=\"resp_login_id\" ><option value=\"no_resp\">" . _('admin_users_no_resp') . "</option>";
         // construction des options du SELECT pour new_resp_login
-        $sql2 = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_is_resp = \"Y\" ORDER BY u_nom,u_prenom"  ;
+        $sql2    = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_is_resp = \"Y\" ORDER BY u_nom,u_prenom";
         $ReqLog2 = \includes\SQL::query($sql2);
 
-        while ($resultat2 = $ReqLog2->fetch_array()){
-            if($resultat2["u_login"]==$tab_user['resp_login'] ) {
-                $text_resp_login=$text_resp_login."<option value=\"".$resultat2["u_login"]."\" selected>".$resultat2["u_nom"]." ".$resultat2["u_prenom"]."</option>";
+        while ($resultat2 = $ReqLog2->fetch_array()) {
+            if ($resultat2["u_login"] == $tab_user['resp_login']) {
+                $text_resp_login = $text_resp_login . "<option value=\"" . $resultat2["u_login"] . "\" selected>" . $resultat2["u_nom"] . " " . $resultat2["u_prenom"] . "</option>";
             } else {
-                $text_resp_login=$text_resp_login."<option value=\"".$resultat2["u_login"]."\">".$resultat2["u_nom"]." ".$resultat2["u_prenom"]."</option>";
+                $text_resp_login = $text_resp_login . "<option value=\"" . $resultat2["u_login"] . "\">" . $resultat2["u_nom"] . " " . $resultat2["u_prenom"] . "</option>";
             }
         }
 
-        $text_resp_login=$text_resp_login."</select>" ;
+        $text_resp_login = $text_resp_login . "</select>";
 
         // AFFICHAGE ligne de saisie
         $childTable .= '<tr class="update-line">';
@@ -2464,7 +2468,7 @@ class Fonctions
         $childTable .= '<td>' . $text_is_hr . '</td>';
         $childTable .= '<td>' . $text_is_active . '</td>';
         $childTable .= '<td>' . $text_see_all . '</td>';
-        if($_SESSION['config']['where_to_find_user_email']=="dbconges") {
+        if ($_SESSION['config']['where_to_find_user_email'] == "dbconges") {
             $childTable .= '<td>' . $text_email . '</td>';
         }
         $childTable .= '</tr></tbody>';
@@ -2483,30 +2487,30 @@ class Fonctions
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         $childTable = '<thead>';
         $childTable .= '<tr>';
         $childTable .= '<th></th>';
         $childTable .= '<th colspan="2">' . _('admin_modif_nb_jours_an') . ' </th>';
         $childTable .= '<th colspan="2">' . _('divers_solde') . '</th>';
-        if( $_SESSION['config']['autorise_reliquats_exercice'] ) {
+        if ($_SESSION['config']['autorise_reliquats_exercice']) {
             $childTable .= '<th colspan="2">' . _('divers_reliquat') . '</th>';
         }
         $childTable .= '</tr></thead><tbody>';
 
         $i = true;
-        foreach($tab_type_conges as $id_type_cong => $libelle) {
-            $childTable .= '<tr class="' . ($i? 'i' : 'p') . '">';
+        foreach ($tab_type_conges as $id_type_cong => $libelle) {
+            $childTable .= '<tr class="' . ($i ? 'i' : 'p') . '">';
             $childTable .= '<td>' . $libelle . '</td>';
             // jours / an
 
             if (isset($tab_user['conges'][$libelle])) {
                 $childTable .= '<td>' . $tab_user['conges'][$libelle]['nb_an'] . '</td>';
-                $text_jours_an="<input class=\"form-control\" type=\"text\" name=\"tab_new_jours_an[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"".$tab_user['conges'][$libelle]['nb_an']."\">" ;
+                $text_jours_an = "<input class=\"form-control\" type=\"text\" name=\"tab_new_jours_an[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"" . $tab_user['conges'][$libelle]['nb_an'] . "\">";
             } else {
                 $childTable .= '<td>0</td>';
-                $text_jours_an='<input class=\"form-control\" type="text" name="tab_new_jours_an['.$id_type_cong.']" size="5" maxlength="5" value="0">' ;
+                $text_jours_an = '<input class=\"form-control\" type="text" name="tab_new_jours_an[' . $id_type_cong . ']" size="5" maxlength="5" value="0">';
             }
 
             $childTable .= '<td>' . $text_jours_an . '</td>';
@@ -2514,24 +2518,24 @@ class Fonctions
             // solde
             if (isset($tab_user['conges'][$libelle])) {
                 $childTable .= '<td>' . $tab_user['conges'][$libelle]['solde'] . '</td>';
-                $text_solde_jours="<input class=\"form-control\" type=\"text\" name=\"tab_new_solde[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"".$tab_user['conges'][$libelle]['solde']."\">" ;
+                $text_solde_jours = "<input class=\"form-control\" type=\"text\" name=\"tab_new_solde[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"" . $tab_user['conges'][$libelle]['solde'] . "\">";
             } else {
                 $childTable .= '<td>0</td>';
-                $text_solde_jours='<input class=\"form-control\" type="text" name="tab_new_solde['.$id_type_cong.']" size="5" maxlength="5" value="0">' ;
+                $text_solde_jours = '<input class=\"form-control\" type="text" name="tab_new_solde[' . $id_type_cong . ']" size="5" maxlength="5" value="0">';
             }
 
             $childTable .= '<td>' . $text_solde_jours . '</td>';
 
             // reliquat
             // si on ne les utilise pas, on initialise qd meme le tableau (<input type=\"hidden\") ...
-            if($_SESSION['config']['autorise_reliquats_exercice']) {
+            if ($_SESSION['config']['autorise_reliquats_exercice']) {
                 if (isset($tab_user['conges'][$libelle])) {
                     $childTable .= '<td>' . $tab_user['conges'][$libelle]['reliquat'] . '</td>';
-                    $text_reliquats_jours="<input class=\"form-control\" type=\"text\" name=\"tab_new_reliquat[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"".$tab_user['conges'][$libelle]['reliquat']."\">" ;
+                    $text_reliquats_jours = "<input class=\"form-control\" type=\"text\" name=\"tab_new_reliquat[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"" . $tab_user['conges'][$libelle]['reliquat'] . "\">";
 
                 } else {
                     $childTable .= '<td>0</td>';
-                    $text_reliquats_jours='<input class=\"form-control\" type="text" name="tab_new_reliquat['.$id_type_cong.']" size="5" maxlength="5" value="0">' ;
+                    $text_reliquats_jours = '<input class=\"form-control\" type="text" name="tab_new_reliquat[' . $id_type_cong . ']" size="5" maxlength="5" value="0">';
                 }
                 $childTable .= '<td>' . $text_reliquats_jours . '</td>';
             } else {
@@ -2543,7 +2547,7 @@ class Fonctions
 
         // recup du tableau des types de conges (seulement les conges)
         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-            foreach($tab_type_conges_exceptionnels as $id_type_cong_exp => $libelle) {
+            foreach ($tab_type_conges_exceptionnels as $id_type_cong_exp => $libelle) {
                 $childTable .= '<tr class="' . ($i ? 'i' : 'p') . '">';
                 $childTable .= '<td>' . $libelle . '</td>';
                 // jours / an
@@ -2551,13 +2555,13 @@ class Fonctions
                 $childTable .= '<td>0</td>';
                 // solde
                 $childTable .= '<td>' . $tab_user['conges'][$libelle]['solde'] . '</td>';
-                $text_solde_jours="<input class=\"form-control\" type=\"text\" name=\"tab_new_solde[$id_type_cong_exp]\" size=\"5\" maxlength=\"5\" value=\"".$tab_user['conges'][$libelle]['solde']."\">" ;
+                $text_solde_jours = "<input class=\"form-control\" type=\"text\" name=\"tab_new_solde[$id_type_cong_exp]\" size=\"5\" maxlength=\"5\" value=\"" . $tab_user['conges'][$libelle]['solde'] . "\">";
                 $childTable .= '<td>' . $text_solde_jours . '</td>';
                 // reliquat
                 // si on ne les utilise pas, on initialise qd meme le tableau (<input type=\"hidden\") ...
-                if($_SESSION['config']['autorise_reliquats_exercice']) {
+                if ($_SESSION['config']['autorise_reliquats_exercice']) {
                     $childTable .= '<td>' . $tab_user['conges'][$libelle]['reliquat'] . '</td>';
-                    $text_reliquats_jours="<input class=\"form-control\" type=\"text\" name=\"tab_new_reliquat[$id_type_cong_exp]\" size=\"5\" maxlength=\"5\" value=\"".$tab_user['conges'][$libelle]['reliquat']."\">" ;
+                    $text_reliquats_jours = "<input class=\"form-control\" type=\"text\" name=\"tab_new_reliquat[$id_type_cong_exp]\" size=\"5\" maxlength=\"5\" value=\"" . $tab_user['conges'][$libelle]['reliquat'] . "\">";
                     $childTable .= '<td>' . $text_reliquats_jours . '</td>';
                 } else {
                     $childTable .= '<input type="hidden" name="tab_new_reliquat[' . $id_type_cong_exp . ']" value="0">';
@@ -2598,55 +2602,54 @@ class Fonctions
     public static function modifUserModule($session, $onglet)
     {
         $u_login              = htmlentities(getpost_variable('u_login'));
-        $u_login_to_update    = htmlentities(getpost_variable('u_login_to_update')) ;
-        $tab_checkbox_sem_imp = htmlentities(getpost_variable('tab_checkbox_sem_imp')) ;
-        $tab_checkbox_sem_p   = htmlentities(getpost_variable('tab_checkbox_sem_p')) ;
-        $return = '';
+        $u_login_to_update    = htmlentities(getpost_variable('u_login_to_update'));
+        $tab_checkbox_sem_imp = htmlentities(getpost_variable('tab_checkbox_sem_imp'));
+        $tab_checkbox_sem_p   = htmlentities(getpost_variable('tab_checkbox_sem_p'));
+        $return               = '';
 
         // TITRE
-        if($u_login!="") {
+        if ($u_login != "") {
             $login_titre = $u_login;
-        } elseif($u_login_to_update!="") {
+        } elseif ($u_login_to_update != "") {
             $login_titre = $u_login_to_update;
         }
 
         $return .= '<h1>' . _('admin_modif_user_titre') . ' : <strong>' . $login_titre . '</strong></h1>';
 
-
-        if($u_login!="") {
+        if ($u_login != "") {
             $return .= \admin\Fonctions::modifier_user($u_login, $onglet);
-        } elseif($u_login_to_update!="") {
-            $tab_new_jours_an   = getpost_variable('tab_new_jours_an') ;
-            $tab_new_solde      = getpost_variable('tab_new_solde') ;
-            $tab_new_reliquat   = getpost_variable('tab_new_reliquat') ;
+        } elseif ($u_login_to_update != "") {
+            $tab_new_jours_an = getpost_variable('tab_new_jours_an');
+            $tab_new_solde    = getpost_variable('tab_new_solde');
+            $tab_new_reliquat = getpost_variable('tab_new_reliquat');
 
-            $tab_new_user['login']      = htmlentities(getpost_variable('new_login'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user['nom']    = htmlentities(getpost_variable('new_nom'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user['prenom']     = htmlentities(getpost_variable('new_prenom'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user['quotite']    = htmlentities(getpost_variable('new_quotite'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user['solde_heure']    = htmlentities(getpost_variable('new_solde_heure'), ENT_QUOTES | ENT_HTML401);;
-            $tab_new_user['is_resp']    = htmlentities(getpost_variable('new_is_resp'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user['resp_login'] = htmlentities(getpost_variable('new_resp_login'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user['is_admin']   = htmlentities(getpost_variable('new_is_admin'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user['is_hr']      = htmlentities(getpost_variable('new_is_hr'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user['is_active']  = getpost_variable('new_is_active') ;
-            $tab_new_user['see_all']    = getpost_variable('new_see_all') ;
-            $tab_new_user['email']      = getpost_variable('new_email') ;
-            $tab_new_user['jour']       = getpost_variable('new_jour') ;
-            $tab_new_user['mois']       = getpost_variable('new_mois') ;
-            $tab_new_user['year']       = getpost_variable('new_year') ;
-            $echo  = '';
+            $tab_new_user['login']       = htmlentities(getpost_variable('new_login'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user['nom']         = htmlentities(getpost_variable('new_nom'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user['prenom']      = htmlentities(getpost_variable('new_prenom'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user['quotite']     = htmlentities(getpost_variable('new_quotite'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user['solde_heure'] = htmlentities(getpost_variable('new_solde_heure'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user['is_resp']     = htmlentities(getpost_variable('new_is_resp'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user['resp_login']  = htmlentities(getpost_variable('new_resp_login'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user['is_admin']    = htmlentities(getpost_variable('new_is_admin'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user['is_hr']       = htmlentities(getpost_variable('new_is_hr'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user['is_active']   = getpost_variable('new_is_active');
+            $tab_new_user['see_all']     = getpost_variable('new_see_all');
+            $tab_new_user['email']       = getpost_variable('new_email');
+            $tab_new_user['jour']        = getpost_variable('new_jour');
+            $tab_new_user['mois']        = getpost_variable('new_mois');
+            $tab_new_user['year']        = getpost_variable('new_year');
+            $echo                        = '';
 
             $ok = \admin\Fonctions::commit_update_user($u_login_to_update, $tab_new_user, $tab_new_jours_an, $tab_new_solde, $tab_new_reliquat, $echo);
             if ($ok) {
-                redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-users', false);
+                redirect(ROOT_PATH . 'admin/admin_index.php?session=' . $session . '&onglet=admin-users', false);
                 exit;
             } else {
                 $return .= $echo;
             }
         } else {
             // renvoit sur la page principale .
-            redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-users', false);
+            redirect(ROOT_PATH . 'admin/admin_index.php?session=' . $session . '&onglet=admin-users', false);
             exit;
         }
         return $return;
@@ -2655,27 +2658,27 @@ class Fonctions
     public static function suppression_group($group_to_delete)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
-        $sql1 = 'DELETE FROM conges_groupe WHERE g_gid = '.\includes\SQL::quote($group_to_delete);
+        $sql1   = 'DELETE FROM conges_groupe WHERE g_gid = ' . \includes\SQL::quote($group_to_delete);
         $result = \includes\SQL::query($sql1);
 
-        $sql2 = 'DELETE FROM conges_groupe_users WHERE gu_gid = '.\includes\SQL::quote($group_to_delete);
+        $sql2    = 'DELETE FROM conges_groupe_users WHERE gu_gid = ' . \includes\SQL::quote($group_to_delete);
         $result2 = \includes\SQL::query($sql2);
 
-        $sql3 = 'DELETE FROM conges_groupe_resp WHERE gr_gid = '.\includes\SQL::quote($group_to_delete);
+        $sql3    = 'DELETE FROM conges_groupe_resp WHERE gr_gid = ' . \includes\SQL::quote($group_to_delete);
         $result3 = \includes\SQL::query($sql3);
 
-        if($_SESSION['config']['double_validation_conges']) {
-            $sql4 = 'DELETE FROM conges_groupe_grd_resp WHERE ggr_gid = '.\includes\SQL::quote($group_to_delete);
+        if ($_SESSION['config']['double_validation_conges']) {
+            $sql4    = 'DELETE FROM conges_groupe_grd_resp WHERE ggr_gid = ' . \includes\SQL::quote($group_to_delete);
             $result4 = \includes\SQL::query($sql4);
         }
 
         $comment_log = "suppression_groupe ($group_to_delete)";
         log_action(0, "", "", $comment_log);
 
-        if($result) {
+        if ($result) {
             $return .= _('form_modif_ok') . ' !<br><br>';
         } else {
             $return .= _('form_modif_not_ok') . ' !<br><br>';
@@ -2696,35 +2699,35 @@ class Fonctions
         /* Groupe en cours */
         /*******************/
         // Récupération des informations
-        $sql1 = 'SELECT g_groupename, g_comment, g_double_valid FROM conges_groupe WHERE g_gid = "'.\includes\SQL::quote($group).'"';
+        $sql1    = 'SELECT g_groupename, g_comment, g_double_valid FROM conges_groupe WHERE g_gid = "' . \includes\SQL::quote($group) . '"';
         $ReqLog1 = \includes\SQL::query($sql1);
 
         // AFFICHAGE TABLEAU
 
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet.'&group_to_delete=' . $group . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '&group_to_delete=' . $group . '" method="POST">';
         $table = new \App\Libraries\Structure\Table();
         $table->addClasses([
             'table',
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         $childTable = '<thead>';
         $childTable .= '<tr>';
         $childTable .= '<th><b>' . _('admin_groupes_groupe') . '</b></th>';
         $childTable .= '<th><b>' . _('admin_groupes_libelle') . ' / ' . _('divers_comment_maj_1') . '</b></th>';
-        if($_SESSION['config']['double_validation_conges']) {
+        if ($_SESSION['config']['double_validation_conges']) {
             $childTable .= '<th><b>' . _('admin_groupes_double_valid') . '</b></th>';
         }
         $childTable .= '</tr></thead><tbody><tr>';
         while ($resultat1 = $ReqLog1->fetch_array()) {
-            $sql_groupname=$resultat1["g_groupename"];
-            $sql_comment=$resultat1["g_comment"];
-            $sql_double_valid=$resultat1["g_double_valid"] ;
+            $sql_groupname    = $resultat1["g_groupename"];
+            $sql_comment      = $resultat1["g_comment"];
+            $sql_double_valid = $resultat1["g_double_valid"];
             $childTable .= '<td>&nbsp;' . $sql_groupname . '&nbsp;</td>';
             $childTable .= '<td>&nbsp;' . $sql_comment . '&nbsp;</td>';
-            if($_SESSION['config']['double_validation_conges']) {
+            if ($_SESSION['config']['double_validation_conges']) {
                 $childTable .= '<td>' . $sql_double_valid . '</td>';
             }
         }
@@ -2753,21 +2756,21 @@ class Fonctions
      */
     public static function supprimerGroupeModule($session, $onglet)
     {
-        $group = getpost_variable('group');
+        $group           = getpost_variable('group');
         $group_to_delete = getpost_variable('group_to_delete');
-        $return = '';
+        $return          = '';
         /*************************************/
 
         // TITRE
         $return .= '<h1>' . _('admin_suppr_groupe_titre') . '</h1>';
 
-        if($group!="") {
+        if ($group != "") {
             $return .= \admin\Fonctions::confirmer($group, $onglet);
-        } elseif($group_to_delete!="") {
+        } elseif ($group_to_delete != "") {
             $return .= \admin\Fonctions::suppression_group($group_to_delete);
         } else {
             // renvoit sur la page principale .
-            redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-group', false);
+            redirect(ROOT_PATH . 'admin/admin_index.php?session=' . $session . '&onglet=admin-group', false);
         }
         return $return;
     }
@@ -2778,29 +2781,28 @@ class Fonctions
         $session  = session_id();
         $return   = '';
 
-        $sql1 = 'DELETE FROM conges_users WHERE u_login = "'. \includes\SQL::quote($u_login_to_delete).'"';
+        $sql1   = 'DELETE FROM conges_users WHERE u_login = "' . \includes\SQL::quote($u_login_to_delete) . '"';
         $result = \includes\SQL::query($sql1);
 
-        $sql2 = 'DELETE FROM conges_periode WHERE p_login = "'. \includes\SQL::quote($u_login_to_delete).'"';
+        $sql2    = 'DELETE FROM conges_periode WHERE p_login = "' . \includes\SQL::quote($u_login_to_delete) . '"';
         $result2 = \includes\SQL::query($sql2);
 
-        $sql4 = 'DELETE FROM conges_echange_rtt WHERE e_login = "'. \includes\SQL::quote($u_login_to_delete).'"';
+        $sql4    = 'DELETE FROM conges_echange_rtt WHERE e_login = "' . \includes\SQL::quote($u_login_to_delete) . '"';
         $result4 = \includes\SQL::query($sql4);
 
-        $sql5 = 'DELETE FROM conges_groupe_resp WHERE gr_login = "'. \includes\SQL::quote($u_login_to_delete).'"';
+        $sql5    = 'DELETE FROM conges_groupe_resp WHERE gr_login = "' . \includes\SQL::quote($u_login_to_delete) . '"';
         $result5 = \includes\SQL::query($sql5);
 
-        $sql6 = 'DELETE FROM conges_groupe_users WHERE gu_login = "'. \includes\SQL::quote($u_login_to_delete).'"';
+        $sql6    = 'DELETE FROM conges_groupe_users WHERE gu_login = "' . \includes\SQL::quote($u_login_to_delete) . '"';
         $result6 = \includes\SQL::query($sql6);
 
-        $sql7 = 'DELETE FROM conges_solde_user WHERE su_login = "'.\includes\SQL::quote($u_login_to_delete).'"';
+        $sql7    = 'DELETE FROM conges_solde_user WHERE su_login = "' . \includes\SQL::quote($u_login_to_delete) . '"';
         $result7 = \includes\SQL::query($sql7);
-
 
         $comment_log = "suppression_user ($u_login_to_delete)";
         log_action(0, "", $u_login_to_delete, $comment_log);
 
-        if($result) {
+        if ($result) {
             $return .= _('form_modif_ok') . ' !<br><br>';
         } else {
             $return .= _('form_modif_not_ok') . ' !<br><br>';
@@ -2825,19 +2827,19 @@ class Fonctions
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         $childTable = '<thead>';
         $childTable .= '<tr>';
         $childTable .= '<th>' . _('divers_login_maj_1') . '</th>';
-        $childTable .= '<th>'. _('divers_nom_maj_1') . '</th>';
+        $childTable .= '<th>' . _('divers_nom_maj_1') . '</th>';
         $childTable .= '<th>' . _('divers_prenom_maj_1') . '</th>';
         $childTable .= '</tr>';
         $childTable .= '</thead>';
         $childTable .= '<tbody>';
 
         // Récupération des informations
-        $sql1 = 'SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_login = "'. \includes\SQL::quote($u_login).'"';
+        $sql1    = 'SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_login = "' . \includes\SQL::quote($u_login) . '"';
         $ReqLog1 = \includes\SQL::query($sql1);
 
         $return .= '<tr>';
@@ -2875,29 +2877,28 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
 
-        $u_login = getpost_variable('u_login') ;
-        $u_login_to_delete = getpost_variable('u_login_to_delete') ;
+        $u_login           = getpost_variable('u_login');
+        $u_login_to_delete = getpost_variable('u_login_to_delete');
         /*************************************/
 
         // TITRE
-        if($u_login!="") {
+        if ($u_login != "") {
             $login_titre = $u_login;
-        } elseif($u_login_to_delete!="") {
+        } elseif ($u_login_to_delete != "") {
             $login_titre = $u_login_to_delete;
         }
 
         $return .= '<h1>' . _('admin_suppr_user_titre') . ' : <strong>' . $login_titre . '</strong></h1>';
 
-
-        if($u_login!="") {
+        if ($u_login != "") {
             $return .= \admin\Fonctions::confirmer_suppression($u_login, $onglet);
-        } elseif($u_login_to_delete!="") {
+        } elseif ($u_login_to_delete != "") {
             echo \admin\Fonctions::suppression($u_login_to_delete);
-            redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-users', false);
+            redirect(ROOT_PATH . 'admin/admin_index.php?session=' . $session . '&onglet=admin-users', false);
             exit;
         } else {
             // renvoit sur la page principale .
-            redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-users', false);
+            redirect(ROOT_PATH . 'admin/admin_index.php?session=' . $session . '&onglet=admin-users', false);
             exit;
         }
         return $return;
@@ -2907,13 +2908,13 @@ class Fonctions
     {
         // cnx à l'annuaire ldap :
         $ds = \ldap_connect($_SESSION['config']['ldap_server']);
-        if($_SESSION['config']['ldap_protocol_version'] != 0) {
-            ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, $_SESSION['config']['ldap_protocol_version']) ;
-			// Support Active Directory
-			ldap_set_option($ds, LDAP_OPT_REFERRALS, 0);
+        if ($_SESSION['config']['ldap_protocol_version'] != 0) {
+            ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, $_SESSION['config']['ldap_protocol_version']);
+            // Support Active Directory
+            ldap_set_option($ds, LDAP_OPT_REFERRALS, 0);
         }
         if ($_SESSION['config']['ldap_user'] == "") {
-            $bound = ldap_bind($ds);  // connexion anonyme au serveur
+            $bound = ldap_bind($ds); // connexion anonyme au serveur
         } else {
             $bound = ldap_bind($ds, $_SESSION['config']['ldap_user'], $_SESSION['config']['ldap_pass']);
         }
@@ -2922,20 +2923,20 @@ class Fonctions
         if ($_SESSION['config']['ldap_filtre_complet'] != "") {
             $filter = $_SESSION['config']['ldap_filtre_complet'];
         } else {
-            $filter = "(&(".$_SESSION['config']['ldap_nomaff']."=*)(".$_SESSION['config']['ldap_filtre']."=".$_SESSION['config']['ldap_filrech']."))";
+            $filter = "(&(" . $_SESSION['config']['ldap_nomaff'] . "=*)(" . $_SESSION['config']['ldap_filtre'] . "=" . $_SESSION['config']['ldap_filrech'] . "))";
         }
 
         $sr   = ldap_search($ds, $_SESSION['config']['searchdn'], $filter);
-        $data = ldap_get_entries($ds,$sr);
+        $data = ldap_get_entries($ds, $sr);
 
         foreach ($data as $info) {
-            $ldap_libelle_login=$_SESSION['config']['ldap_login'];
-            $ldap_libelle_nom=$_SESSION['config']['ldap_nom'];
-            $ldap_libelle_prenom=$_SESSION['config']['ldap_prenom'];
-            $login = $info[$ldap_libelle_login][0];
+            $ldap_libelle_login  = $_SESSION['config']['ldap_login'];
+            $ldap_libelle_nom    = $_SESSION['config']['ldap_nom'];
+            $ldap_libelle_prenom = $_SESSION['config']['ldap_prenom'];
+            $login               = $info[$ldap_libelle_login][0];
             // concaténation NOM Prénom
             // utf8_decode permet de supprimer les caractères accentués mal interprêtés...
-            $nom = ( isset($info[$ldap_libelle_nom]) ? strtoupper($info[$ldap_libelle_nom][0]): '' )." ". (isset($info[$ldap_libelle_prenom])?$info[$ldap_libelle_prenom][0]:'');
+            $nom = (isset($info[$ldap_libelle_nom]) ? strtoupper($info[$ldap_libelle_nom][0]) : '') . " " . (isset($info[$ldap_libelle_prenom]) ? $info[$ldap_libelle_prenom][0] : '');
             array_push($tab_ldap, $nom);
             array_push($tab_login, $login);
         }
@@ -2951,7 +2952,7 @@ class Fonctions
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
 
         // affichage TITRE
@@ -2971,47 +2972,47 @@ class Fonctions
         // affichage des groupes
 
         //on rempli un tableau de tous les groupes avec le nom et libellé (tableau de tableau à 3 cellules)
-        $tab_groups=array();
-        $sql_g = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename "  ;
-        $ReqLog_g = \includes\SQL::query($sql_g);
+        $tab_groups = array();
+        $sql_g      = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename ";
+        $ReqLog_g   = \includes\SQL::query($sql_g);
 
-        while($resultat_g=$ReqLog_g->fetch_array()) {
-            $tab_gg=array();
-            $tab_gg["gid"]=$resultat_g["g_gid"];
-            $tab_gg["groupename"]=$resultat_g["g_groupename"];
-            $tab_gg["comment"]=$resultat_g["g_comment"];
-            $tab_groups[]=$tab_gg;
+        while ($resultat_g = $ReqLog_g->fetch_array()) {
+            $tab_gg               = array();
+            $tab_gg["gid"]        = $resultat_g["g_gid"];
+            $tab_gg["groupename"] = $resultat_g["g_groupename"];
+            $tab_gg["comment"]    = $resultat_g["g_comment"];
+            $tab_groups[]         = $tab_gg;
         }
 
-        $tab_user="";
+        $tab_user = "";
         // si le user est connu
         // on rempli un autre tableau des groupes du user
-        if($choix_user!="") {
-            $tab_user=array();
-            $sql_gu = 'SELECT gu_gid FROM conges_groupe_users WHERE gu_login="'.\includes\SQL::quote($choix_user).'" ORDER BY gu_gid ';
+        if ($choix_user != "") {
+            $tab_user  = array();
+            $sql_gu    = 'SELECT gu_gid FROM conges_groupe_users WHERE gu_login="' . \includes\SQL::quote($choix_user) . '" ORDER BY gu_gid ';
             $ReqLog_gu = \includes\SQL::query($sql_gu);
 
-            while($resultat_gu=$ReqLog_gu->fetch_array()) {
-                $tab_user[]=$resultat_gu["gu_gid"];
+            while ($resultat_gu = $ReqLog_gu->fetch_array()) {
+                $tab_user[] = $resultat_gu["gu_gid"];
             }
         }
 
         // ensuite on affiche tous les groupes avec une case cochée si existe le gid dans le 2ieme tableau
         $count = count($tab_groups);
         for ($i = 0; $i < $count; $i++) {
-            $gid=$tab_groups[$i]["gid"] ;
-            $group=$tab_groups[$i]["groupename"] ;
-            $libelle=$tab_groups[$i]["comment"] ;
+            $gid     = $tab_groups[$i]["gid"];
+            $group   = $tab_groups[$i]["groupename"];
+            $libelle = $tab_groups[$i]["comment"];
 
-            if ( ($tab_user!="") && (in_array ($gid, $tab_user)) ){
-                $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_user_groups[$gid]\" value=\"$gid\" checked>";
-                $class="histo-big";
+            if (($tab_user != "") && (in_array($gid, $tab_user))) {
+                $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_user_groups[$gid]\" value=\"$gid\" checked>";
+                $class         = "histo-big";
             } else {
-                $case_a_cocher="<input type=\"checkbox\" name=\"checkbox_user_groups[$gid]\" value=\"$gid\">";
-                $class="histo";
+                $case_a_cocher = "<input type=\"checkbox\" name=\"checkbox_user_groups[$gid]\" value=\"$gid\">";
+                $class         = "histo";
             }
 
-            $childTable .= '<tr class="'.(!($i%2) ? 'i' : 'p').'">';
+            $childTable .= '<tr class="' . (!($i % 2) ? 'i' : 'p') . '">';
             $childTable .= '<td>' . $case_a_cocher . '</td>';
             $childTable .= '<td class="' . $class . '">&nbsp;' . $group . '&nbsp</td>';
             $childTable .= '<td class="' . $class . '">&nbsp;' . $libelle . '&nbsp;</td>';
@@ -3029,15 +3030,15 @@ class Fonctions
     public static function affiche_formulaire_ajout_user(&$tab_new_user, &$tab_new_jours_an, &$tab_new_solde, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // recup du tableau des types de conges (seulement les conges)
-        $tab_type_conges=recup_tableau_types_conges();
+        $tab_type_conges = recup_tableau_types_conges();
 
         // recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
-        if ($_SESSION['config']['gestion_conges_exceptionnels']){
-            $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
+        if ($_SESSION['config']['gestion_conges_exceptionnels']) {
+            $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
         }
 
         /*********************/
@@ -3057,11 +3058,11 @@ class Fonctions
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         $childTable = '<thead>';
         $childTable .= '<tr>';
-        if ($_SESSION['config']['export_users_from_ldap'] ) {
+        if ($_SESSION['config']['export_users_from_ldap']) {
             $childTable .= '<th>' . _('divers_nom_maj_1') . ' ' . _('divers_prenom_maj_1') . '</th>';
         } else {
             $childTable .= '<th>' . _('divers_login_maj_1') . '</th>';
@@ -3075,7 +3076,7 @@ class Fonctions
         $childTable .= '<th>' . _('admin_new_users_is_admin') . '</th>';
         $childTable .= '<th>' . _('admin_new_users_is_hr') . '</th>';
         $childTable .= '<th>' . _('admin_new_users_see_all') . '</th>';
-        if ( !$_SESSION['config']['export_users_from_ldap'] ) {
+        if (!$_SESSION['config']['export_users_from_ldap']) {
             $childTable .= '<th>' . _('admin_users_mail') . '</th>';
         }
         if ($_SESSION['config']['how_to_connect_user'] == "dbconges") {
@@ -3085,51 +3086,49 @@ class Fonctions
         $childTable .= '</tr></thead><tbody>';
         $soldeHeureId = uniqid();
 
-
-        $text_nom="<input class=\"form-control\" type=\"text\" name=\"new_nom\" size=\"10\" maxlength=\"30\" value=\"".$tab_new_user['nom']."\">" ;
-        $text_prenom="<input class=\"form-control\" type=\"text\" name=\"new_prenom\" size=\"10\" maxlength=\"30\" value=\"".$tab_new_user['prenom']."\">" ;
-        if( (!isset($tab_new_user['quotite'])) || ($tab_new_user['quotite']=="") ) {
-            $tab_new_user['quotite']=100;
+        $text_nom    = "<input class=\"form-control\" type=\"text\" name=\"new_nom\" size=\"10\" maxlength=\"30\" value=\"" . $tab_new_user['nom'] . "\">";
+        $text_prenom = "<input class=\"form-control\" type=\"text\" name=\"new_prenom\" size=\"10\" maxlength=\"30\" value=\"" . $tab_new_user['prenom'] . "\">";
+        if ((!isset($tab_new_user['quotite'])) || ($tab_new_user['quotite'] == "")) {
+            $tab_new_user['quotite'] = 100;
         }
-        $text_quotite="<input class=\"form-control\" type=\"text\" name=\"new_quotite\" size=\"3\" maxlength=\"3\" value=\"".$tab_new_user['quotite']."\">" ;
-        $text_solde_heure="<input class=\"form-control\" type=\"text\" name=\"new_solde_heure\" id=\"" . $soldeHeureId . "\" size=\"6\" maxlength=\"6\" value=\"".$tab_new_user['solde_heure']."\">" ;
-        $text_is_resp="<select class=\"form-control\" name=\"new_is_resp\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>" ;
+        $text_quotite     = "<input class=\"form-control\" type=\"text\" name=\"new_quotite\" size=\"3\" maxlength=\"3\" value=\"" . $tab_new_user['quotite'] . "\">";
+        $text_solde_heure = "<input class=\"form-control\" type=\"text\" name=\"new_solde_heure\" id=\"" . $soldeHeureId . "\" size=\"6\" maxlength=\"6\" value=\"" . $tab_new_user['solde_heure'] . "\">";
+        $text_is_resp     = "<select class=\"form-control\" name=\"new_is_resp\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>";
 
         // PREPARATION DES OPTIONS DU SELECT du resp_login
-        $text_resp_login="<select class=\"form-control\" name=\"new_resp_login\" id=\"resp_login_id\" ><option value=\"no_resp\">". _('admin_users_no_resp') ."</option>" ;
+        $text_resp_login = "<select class=\"form-control\" name=\"new_resp_login\" id=\"resp_login_id\" ><option value=\"no_resp\">" . _('admin_users_no_resp') . "</option>";
 
-        if( $_SESSION['config']['admin_see_all'] || $_SESSION['userlogin']=="admin" || is_hr($_SESSION['userlogin'])) {
-            $sql2 = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_is_resp = \"Y\" ORDER BY u_nom, u_prenom"  ;
+        if ($_SESSION['config']['admin_see_all'] || $_SESSION['userlogin'] == "admin" || is_hr($_SESSION['userlogin'])) {
+            $sql2 = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_is_resp = \"Y\" ORDER BY u_nom, u_prenom";
         } else {
-            $sql2 = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_is_resp = \"Y\" AND u_login=\"".$_SESSION['userlogin']."\" ORDER BY u_nom, u_prenom" ;
+            $sql2 = "SELECT u_login, u_nom, u_prenom FROM conges_users WHERE u_is_resp = \"Y\" AND u_login=\"" . $_SESSION['userlogin'] . "\" ORDER BY u_nom, u_prenom";
         }
 
         $ReqLog2 = \includes\SQL::query($sql2);
 
         while ($resultat2 = $ReqLog2->fetch_array()) {
-            $current_resp_login=$resultat2["u_login"];
-            if($tab_new_user['resp_login']==$current_resp_login) {
-                $text_resp_login=$text_resp_login."<option value=\"$current_resp_login\" selected>".$resultat2["u_nom"]." ".$resultat2["u_prenom"]."</option>";
+            $current_resp_login = $resultat2["u_login"];
+            if ($tab_new_user['resp_login'] == $current_resp_login) {
+                $text_resp_login = $text_resp_login . "<option value=\"$current_resp_login\" selected>" . $resultat2["u_nom"] . " " . $resultat2["u_prenom"] . "</option>";
             } else {
-                $text_resp_login=$text_resp_login."<option value=\"$current_resp_login\">".$resultat2["u_nom"]." ".$resultat2["u_prenom"]."</option>";
+                $text_resp_login = $text_resp_login . "<option value=\"$current_resp_login\">" . $resultat2["u_nom"] . " " . $resultat2["u_prenom"] . "</option>";
             }
         }
-        $text_resp_login=$text_resp_login."</select>" ;
+        $text_resp_login = $text_resp_login . "</select>";
 
-        $text_is_admin="<select class=\"form-control\" name=\"new_is_admin\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>" ;
-        $text_is_hr="<select class=\"form-control\" name=\"new_is_hr\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>" ;
-        $text_see_all="<select class=\"form-control\" name=\"new_see_all\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>" ;
-        $text_email="<input class=\"form-control\" type=\"text\" name=\"new_email\" size=\"10\" maxlength=\"99\" value=\"".$tab_new_user['email']."\">" ;
-        $text_password1="<input class=\"form-control\" type=\"password\" name=\"new_password1\" size=\"10\" maxlength=\"15\" value=\"\" autocomplete=\"off\" >" ;
-        $text_password2="<input class=\"form-control\" type=\"password\" name=\"new_password2\" size=\"10\" maxlength=\"15\" value=\"\" autocomplete=\"off\" >" ;
-        $text_login="<input class=\"form-control\" type=\"text\" name=\"new_login\" size=\"10\" maxlength=\"98\" value=\"".$tab_new_user['login']."\">" ;
-
+        $text_is_admin  = "<select class=\"form-control\" name=\"new_is_admin\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>";
+        $text_is_hr     = "<select class=\"form-control\" name=\"new_is_hr\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>";
+        $text_see_all   = "<select class=\"form-control\" name=\"new_see_all\" ><option value=\"N\">N</option><option value=\"Y\">Y</option></select>";
+        $text_email     = "<input class=\"form-control\" type=\"text\" name=\"new_email\" size=\"10\" maxlength=\"99\" value=\"" . $tab_new_user['email'] . "\">";
+        $text_password1 = "<input class=\"form-control\" type=\"password\" name=\"new_password1\" size=\"10\" maxlength=\"15\" value=\"\" autocomplete=\"off\" >";
+        $text_password2 = "<input class=\"form-control\" type=\"password\" name=\"new_password2\" size=\"10\" maxlength=\"15\" value=\"\" autocomplete=\"off\" >";
+        $text_login     = "<input class=\"form-control\" type=\"text\" name=\"new_login\" size=\"10\" maxlength=\"98\" value=\"" . $tab_new_user['login'] . "\">";
 
         // AFFICHAGE DE LA LIGNE DE SAISIE D'UN NOUVEAU USER
 
         $childTable .= '<tr class="update-line">';
         // Aj. D.Chabaud - Université d'Auvergne - Sept. 2005
-        if ($_SESSION['config']['export_users_from_ldap'] ) {
+        if ($_SESSION['config']['export_users_from_ldap']) {
             // Récupération de la liste des utilisateurs via un ldap :
 
             // on crée 2 tableaux (1 avec les noms + prénoms, 1 avec les login)
@@ -3142,7 +3141,7 @@ class Fonctions
             array_multisort($tab_ldap, $tab_login); // on trie les utilisateurs par le nom
 
             $lst_users = "<select multiple size=9 name=new_ldap_user[]><option>------------------</option>\n";
-            $i = 0;
+            $i         = 0;
 
             foreach ($tab_login as $login) {
                 $lst_users .= "<option value=$tab_login[$i]>$tab_ldap[$i]</option>\n";
@@ -3163,7 +3162,7 @@ class Fonctions
         $childTable .= '<td>' . $text_is_admin . '</td>';
         $childTable .= '<td>' . $text_is_hr . '</td>';
         $childTable .= '<td>' . $text_see_all . '</td>';
-        if ( !$_SESSION['config']['export_users_from_ldap'] ) {
+        if (!$_SESSION['config']['export_users_from_ldap']) {
             $childTable .= '<td>' . $text_email . '</td>';
         }
         if ($_SESSION['config']['how_to_connect_user'] == "dbconges") {
@@ -3178,7 +3177,6 @@ class Fonctions
         $return .= ob_get_clean();
         $return .= '<br><hr />';
 
-
         /****************************************/
         //tableau des conges annuels et soldes
         $table = new \App\Libraries\Structure\Table();
@@ -3187,7 +3185,7 @@ class Fonctions
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         // ligne de titres
         $childTable = '<thead>';
@@ -3201,25 +3199,25 @@ class Fonctions
 
         $i = true;
         // ligne de saisie des valeurs
-        foreach($tab_type_conges as $id_type_cong => $libelle) {
-            $childTable .= '<tr class="'.($i?'i':'p').'">';
-            $value_jours_an = ( isset($tab_new_jours_an[$id_type_cong]) ? $tab_new_jours_an[$id_type_cong] : 0 );
-            $value_solde_jours = ( isset($tab_new_solde[$id_type_cong]) ? $tab_new_solde[$id_type_cong] : 0 );
-            $text_jours_an="<input class=\"form-control\" type=\"text\" name=\"tab_new_jours_an[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"$value_jours_an\">" ;
-            $text_solde_jours="<input class=\"form-control\" type=\"text\" name=\"tab_new_solde[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"$value_solde_jours\">" ;
+        foreach ($tab_type_conges as $id_type_cong => $libelle) {
+            $childTable .= '<tr class="' . ($i ? 'i' : 'p') . '">';
+            $value_jours_an    = (isset($tab_new_jours_an[$id_type_cong]) ? $tab_new_jours_an[$id_type_cong] : 0);
+            $value_solde_jours = (isset($tab_new_solde[$id_type_cong]) ? $tab_new_solde[$id_type_cong] : 0);
+            $text_jours_an     = "<input class=\"form-control\" type=\"text\" name=\"tab_new_jours_an[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"$value_jours_an\">";
+            $text_solde_jours  = "<input class=\"form-control\" type=\"text\" name=\"tab_new_solde[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"$value_solde_jours\">";
             $childTable .= '<td>' . $libelle . '</td>';
-            $childTable .= '<td>' . $text_jours_an.  '</td>';
+            $childTable .= '<td>' . $text_jours_an . '</td>';
             $childTable .= '<td>' . $text_solde_jours . '</td>';
             $childTable .= '</tr>';
             $i = !$i;
         }
         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-            foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
-                $childTable .= '<tr class="'.($i?'i':'p').'">';
-                $value_solde_jours = ( isset($tab_new_solde[$id_type_cong]) ? $tab_new_solde[$id_type_cong] : 0 );
-                $text_jours_an="<input type=\"hidden\" name=\"tab_new_jours_an[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"0\"> &nbsp; " ;
-                $text_solde_jours="<input class=\"form-control\" type=\"text\" name=\"tab_new_solde[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"$value_solde_jours\">" ;
-                $childTable .= '<td>'.  $libelle . '</td>';
+            foreach ($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
+                $childTable .= '<tr class="' . ($i ? 'i' : 'p') . '">';
+                $value_solde_jours = (isset($tab_new_solde[$id_type_cong]) ? $tab_new_solde[$id_type_cong] : 0);
+                $text_jours_an     = "<input type=\"hidden\" name=\"tab_new_jours_an[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"0\"> &nbsp; ";
+                $text_solde_jours  = "<input class=\"form-control\" type=\"text\" name=\"tab_new_solde[$id_type_cong]\" size=\"5\" maxlength=\"5\" value=\"$value_solde_jours\">";
+                $childTable .= '<td>' . $libelle . '</td>';
                 $childTable .= '<td>' . $text_jours_an . '</td>';
                 $childTable .= '<td>' . $text_solde_jours . '</td>';
                 $childTable .= '</tr>';
@@ -3234,10 +3232,9 @@ class Fonctions
         $return .= '<br>';
 
         // si gestion des groupes :  affichage des groupe pour y affecter le user
-        if($_SESSION['config']['gestion_groupes'])
-        {
+        if ($_SESSION['config']['gestion_groupes']) {
             $return .= '<br>';
-            if( $_SESSION['config']['admin_see_all'] || $_SESSION['userlogin']=="admin" ||  is_hr($_SESSION['userlogin']) ) {
+            if ($_SESSION['config']['admin_see_all'] || $_SESSION['userlogin'] == "admin" || is_hr($_SESSION['userlogin'])) {
                 $return .= \admin\Fonctions::affiche_tableau_affectation_user_groupes2("");
             } else {
                 $return .= \admin\Fonctions::affiche_tableau_affectation_user_groupes2($_SESSION['userlogin']);
@@ -3258,34 +3255,34 @@ class Fonctions
         $session  = session_id();
         $return   = '';
 
-        foreach($tab_new_jours_an as $id_cong => $jours_an) {
-            $valid=verif_saisie_decimal($tab_new_jours_an[$id_cong]);    //verif la bonne saisie du nombre décimal
-            $valid=verif_saisie_decimal($tab_new_solde[$id_cong]);    //verif la bonne saisie du nombre décimal
+        foreach ($tab_new_jours_an as $id_cong => $jours_an) {
+            $valid = verif_saisie_decimal($tab_new_jours_an[$id_cong]); //verif la bonne saisie du nombre décimal
+            $valid = verif_saisie_decimal($tab_new_solde[$id_cong]); //verif la bonne saisie du nombre décimal
         }
 
         // verif des parametres reçus :
         // si on travaille avec la base dbconges, on teste tout, mais si on travaille avec ldap, on ne teste pas les champs qui viennent de ldap ...
-        if(!\admin\Fonctions::test_form_add_user($tab_new_user)) {
+        if (!\admin\Fonctions::test_form_add_user($tab_new_user)) {
             $return .= '<h3><font color="red">' . _('admin_verif_param_invalides') . '</font></h3>';
             // affichage des param :
             $return .= htmlentities($tab_new_user['login']) . '---' . htmlentities($tab_new_user['nom']) . '---' . htmlentities($tab_new_user['prenom']) . '---' . htmlentities($tab_new_user['quotite']) . '---' . htmlentities($tab_new_user['is_resp']) . '---' . htmlentities($tab_new_user['resp_login']) . '<br>';
-            foreach($tab_new_jours_an as $id_cong => $jours_an) {
+            foreach ($tab_new_jours_an as $id_cong => $jours_an) {
                 $return .= $tab_new_jours_an[$id_cong] . '---' . $tab_new_solde[$id_cong] . '<br>';
             }
 
-            $return .= '<form action="' . $PHP_SELF . '?session=' . $session .  '&onglet=ajout-user" method="POST">';
+            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout-user" method="POST">';
             $return .= '<input type="hidden" name="new_login" value="' . $tab_new_user['login'] . '">';
             $return .= '<input type="hidden" name="new_nom" value="' . $tab_new_user['nom'] . '">';
             $return .= '<input type="hidden" name="new_prenom" value="' . $tab_new_user['prenom'] . '">';
-            $return .= '<input type="hidden" name="new_is_resp" value="'  . $tab_new_user['is_resp'] . '">';
+            $return .= '<input type="hidden" name="new_is_resp" value="' . $tab_new_user['is_resp'] . '">';
             $return .= '<input type="hidden" name="new_resp_login" value="' . $tab_new_user['resp_login'] . '">';
-            $return .= '<input type="hidden" name="new_is_admin" value="'  . $tab_new_user['is_admin'] . '">';
+            $return .= '<input type="hidden" name="new_is_admin" value="' . $tab_new_user['is_admin'] . '">';
             $return .= '<input type="hidden" name="new_is_hr" value="' . $tab_new_user['is_hr'] . '">';
             $return .= '<input type="hidden" name="new_see_all" value="' . $tab_new_user['see_all'] . '">';
             $return .= '<input type="hidden" name="new_quotite" value="' . $tab_new_user['quotite'] . '">';
             $return .= '<input type="hidden" name="new_heure_solde" value="' . $tab_new_user['solde_heure'] . '">';
             $return .= '<input type="hidden" name="new_email" value="' . $tab_new_user['email'] . '">';
-            foreach($tab_new_jours_an as $id_cong => $jours_an) {
+            foreach ($tab_new_jours_an as $id_cong => $jours_an) {
                 $return .= '<input type="hidden" name="tab_new_jours_an[$id_cong]" value="' . $tab_new_jours_an[$id_cong] . '">';
                 $return .= '<input type="hidden" name="tab_new_solde[' . $id_cong . ']" value="' . $tab_new_solde[$id_cong] . '">';
             }
@@ -3297,11 +3294,11 @@ class Fonctions
             return true;
         } else {
             // verif si le login demandé n'existe pas déjà ....
-            $sql_verif='SELECT u_login FROM conges_users WHERE u_login="'.\includes\SQL::quote($tab_new_user['login']).'"';
+            $sql_verif    = 'SELECT u_login FROM conges_users WHERE u_login="' . \includes\SQL::quote($tab_new_user['login']) . '"';
             $ReqLog_verif = \includes\SQL::query($sql_verif);
 
             $num_verif = $ReqLog_verif->num_rows;
-            if ($num_verif!=0) {
+            if ($num_verif != 0) {
                 $return .= '<h3><font color="red">' . _('admin_verif_login_exist') . '</font></h3>';
                 $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout-user" method="POST">';
                 $return .= '<input type="hidden" name="new_login" value="' . $tab_new_user['login'] . '">';
@@ -3315,7 +3312,7 @@ class Fonctions
                 $return .= '<input type="hidden" name="new_heure_solde" value="' . $tab_new_user['solde_heure'] . '">';
                 $return .= '<input type="hidden" name="new_email" value="' . $tab_new_user['email'] . '">';
 
-                foreach($tab_new_jours_an as $id_cong => $jours_an) {
+                foreach ($tab_new_jours_an as $id_cong => $jours_an) {
                     $return .= '<input type="hidden" name="tab_new_jours_an[' . $id_cong . ']" value="' . $tab_new_jours_an[$id_cong] . '">';
                     $return .= '<input type="hidden" name="tab_new_solde[' . $id_cong . ']" value="' . $tab_new_solde[$id_cong] . '">';
                 }
@@ -3325,7 +3322,7 @@ class Fonctions
                 $return .= '</form>';
 
                 return true;
-            } elseif($_SESSION['config']['where_to_find_user_email'] == "dbconges" && strrchr($tab_new_user['email'], "@")==FALSE) {
+            } elseif ($_SESSION['config']['where_to_find_user_email'] == "dbconges" && strrchr($tab_new_user['email'], "@") == false) {
                 $return .= '<h3>' . _('admin_verif_bad_mail') . '</h3>';
                 $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout-user" method="POST">';
                 $return .= '<input type="hidden" name="new_login" value="' . $tab_new_user['login'] . '">';
@@ -3339,7 +3336,7 @@ class Fonctions
                 $return .= '<input type="hidden" name="new_heure_solde" value="' . $tab_new_user['solde_heure'] . '">';
                 $return .= '<input type="hidden" name="new_email" value="' . $tab_new_user['email'] . '">';
 
-                foreach($tab_new_jours_an as $id_cong => $jours_an) {
+                foreach ($tab_new_jours_an as $id_cong => $jours_an) {
                     $return .= '<input type="hidden" name="tab_new_jours_an[' . $id_cong . ']" value="' . $tab_new_jours_an[$id_cong] . '">';
                     $return .= '<input type="hidden" name="tab_new_solde[' . $id_cong . ']" value="' . $tab_new_solde[$id_cong] . '">';
                 }
@@ -3355,58 +3352,63 @@ class Fonctions
         }
     }
 
-    public static function test_form_add_user($tab_new_user) {
-        if($_SESSION['config']['export_users_from_ldap']) {
+    public static function test_form_add_user($tab_new_user)
+    {
+        if ($_SESSION['config']['export_users_from_ldap']) {
             return \admin\Fonctions::FormAddUserLoginOk($tab_new_user['login']) && \admin\Fonctions::FormAddUserQuotiteOk($tab_new_user['quotite']) && \admin\Fonctions::FormAddUserSoldeHeureOk($tab_new_user['solde_heure']);
         } else {
-            return \admin\Fonctions::FormAddUserLoginOk($tab_new_user['login']) && \admin\Fonctions::FormAddUserQuotiteOk($tab_new_user['quotite'])  && \admin\Fonctions::FormAddUserSoldeHeureOk($tab_new_user['solde_heure']) && \admin\Fonctions::FormAddUserNameOk($tab_new_user['nom']) && \admin\Fonctions::FormAddUserNameOk($tab_new_user['prenom']) && \admin\Fonctions::FormAddUserpasswdOk($tab_new_user['password1'],$tab_new_user['password2']);
+            return \admin\Fonctions::FormAddUserLoginOk($tab_new_user['login']) && \admin\Fonctions::FormAddUserQuotiteOk($tab_new_user['quotite']) && \admin\Fonctions::FormAddUserSoldeHeureOk($tab_new_user['solde_heure']) && \admin\Fonctions::FormAddUserNameOk($tab_new_user['nom']) && \admin\Fonctions::FormAddUserNameOk($tab_new_user['prenom']) && \admin\Fonctions::FormAddUserpasswdOk($tab_new_user['password1'], $tab_new_user['password2']);
         }
     }
 
-    public static function FormAddUserSoldeHeureOk($solde_heure){
+    public static function FormAddUserSoldeHeureOk($solde_heure)
+    {
         if (empty($solde_heure)) {
             return false;
         }
         return \App\Helpers\Formatter::isHourFormat($solde_heure);
     }
 
-    public static function FormAddUserLoginOk($login) {
+    public static function FormAddUserLoginOk($login)
+    {
         return preg_match('/^[a-z.\d_-]{2,30}$/i', $login);
     }
 
-    public static function FormAddUserQuotiteOk($quot) {
-        return !(strlen($quot)==0 || $quot>100);
+    public static function FormAddUserQuotiteOk($quot)
+    {
+        return !(strlen($quot) == 0 || $quot > 100);
     }
 
-    public static function FormAddUserNameOk($name) {
+    public static function FormAddUserNameOk($name)
+    {
         return preg_match('/^[a-z\d\sàáâãäåçèéêëìíîïðòóôõöùúûüýÿ-]{2,20}$/i', $name);
     }
 
-    public static function FormAddUserpasswdOk($password1,$password2) {
-        if($_SESSION['config']['how_to_connect_user']=='dbconges')
-        {
-            return !(strlen($password1)==0 || strlen($password2)==0 || strcmp($password1, $password2)!=0);
+    public static function FormAddUserpasswdOk($password1, $password2)
+    {
+        if ($_SESSION['config']['how_to_connect_user'] == 'dbconges') {
+            return !(strlen($password1) == 0 || strlen($password2) == 0 || strcmp($password1, $password2) != 0);
         } else {
-            return (strlen($password1)==0 && strlen($password2)==0);
+            return (strlen($password1) == 0 && strlen($password2) == 0);
         }
     }
 
     public static function ajout_user(&$tab_new_user, &$tab_new_jours_an, &$tab_new_solde, $checkbox_user_groups)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
-        $return   = '';
+        $PHP_SELF   = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session    = session_id();
+        $return     = '';
         $verifFalse = '';
 
         // si pas d'erreur de saisie :
-        if(\admin\Fonctions::verif_new_param($tab_new_user, $tab_new_jours_an, $tab_new_solde, $verifFalse)==0) {
-            $return .= $tab_new_user['login'] . ' --- ' . $tab_new_user['nom'] .  ' --- ' . $tab_new_user['prenom'] . ' --- ' . $tab_new_user['quotite'];
+        if (\admin\Fonctions::verif_new_param($tab_new_user, $tab_new_jours_an, $tab_new_solde, $verifFalse) == 0) {
+            $return .= $tab_new_user['login'] . ' --- ' . $tab_new_user['nom'] . ' --- ' . $tab_new_user['prenom'] . ' --- ' . $tab_new_user['quotite'];
             $return .= ' --- ' . $tab_new_user['is_resp'] . ' --- ' . $tab_new_user['resp_login'] . ' --- ' . $tab_new_user['is_admin'] . ' --- ' . $tab_new_user['is_hr'] . ' --- ' . $tab_new_user['see_all'] . ' --- ' . $tab_new_user['email'] . '<br>';
 
-            foreach($tab_new_jours_an as $id_cong => $jours_an) {
+            foreach ($tab_new_jours_an as $id_cong => $jours_an) {
                 $return .= $tab_new_jours_an[$id_cong] . ' --- ' . $tab_new_solde[$id_cong] . '<br>';
             }
-            $new_date_deb_grille=$tab_new_user['new_year']."-".$tab_new_user['new_mois']."-".$tab_new_user['new_jour'];
+            $new_date_deb_grille = $tab_new_user['new_year'] . "-" . $tab_new_user['new_mois'] . "-" . $tab_new_user['new_jour'];
             $return .= $new_date_deb_grille . '<br>';
 
             /*****************************/
@@ -3418,58 +3420,57 @@ class Fonctions
             }
 
             $sql1 = "INSERT INTO conges_users SET ";
-            $sql1=$sql1."u_login='".$tab_new_user['login']."', ";
-            $sql1=$sql1."u_nom='".addslashes($tab_new_user['nom'])."', ";
-            $sql1=$sql1."u_prenom='".addslashes($tab_new_user['prenom'])."', ";
-            $sql1=$sql1."u_is_resp='".$tab_new_user['is_resp']."', ";
+            $sql1 = $sql1 . "u_login='" . $tab_new_user['login'] . "', ";
+            $sql1 = $sql1 . "u_nom='" . addslashes($tab_new_user['nom']) . "', ";
+            $sql1 = $sql1 . "u_prenom='" . addslashes($tab_new_user['prenom']) . "', ";
+            $sql1 = $sql1 . "u_is_resp='" . $tab_new_user['is_resp'] . "', ";
 
-            if($tab_new_user['resp_login'] == 'no_resp') {
-                $sql1=$sql1."u_resp_login= NULL , ";
+            if ($tab_new_user['resp_login'] == 'no_resp') {
+                $sql1 = $sql1 . "u_resp_login= NULL , ";
             } else {
-                $sql1=$sql1."u_resp_login='". $tab_new_user['resp_login']."', ";
+                $sql1 = $sql1 . "u_resp_login='" . $tab_new_user['resp_login'] . "', ";
             }
             $seeAll = ($tab_new_user['is_admin'] || $tab_new_user['is_hr'])
-                ? 'Y'
-                : 'N';
+            ? 'Y'
+            : 'N';
 
-            $sql1=$sql1."u_is_admin='".$tab_new_user['is_admin']."', ";
-            $sql1=$sql1."u_is_hr='".$tab_new_user['is_hr']."', ";
-            $sql1=$sql1."u_see_all='". $seeAll . "', ";
-            $sql1=$sql1."u_passwd='$motdepasse', ";
-            $sql1=$sql1."u_quotite=".$tab_new_user['quotite'].",";
-            $sql1=$sql1."u_heure_solde=".  \App\Helpers\Formatter::hour2Time($tab_new_user['solde_heure']).",";
-            $sql1=$sql1." u_email='".$tab_new_user['email']."' ";
+            $sql1    = $sql1 . "u_is_admin='" . $tab_new_user['is_admin'] . "', ";
+            $sql1    = $sql1 . "u_is_hr='" . $tab_new_user['is_hr'] . "', ";
+            $sql1    = $sql1 . "u_see_all='" . $seeAll . "', ";
+            $sql1    = $sql1 . "u_passwd='$motdepasse', ";
+            $sql1    = $sql1 . "u_quotite=" . $tab_new_user['quotite'] . ",";
+            $sql1    = $sql1 . "u_heure_solde=" . \App\Helpers\Formatter::hour2Time($tab_new_user['solde_heure']) . ",";
+            $sql1    = $sql1 . " u_email='" . $tab_new_user['email'] . "' ";
             $result1 = \includes\SQL::query($sql1);
-
 
             /**********************************/
             /* INSERT dans conges_solde_user  */
-            foreach($tab_new_jours_an as $id_cong => $jours_an) {
-                $sql3 = "INSERT INTO conges_solde_user (su_login, su_abs_id, su_nb_an, su_solde, su_reliquat) ";
-                $sql3 = $sql3. "VALUES ('".$tab_new_user['login']."' , $id_cong, ".$tab_new_jours_an[$id_cong].", ".$tab_new_solde[$id_cong].", 0) " ;
+            foreach ($tab_new_jours_an as $id_cong => $jours_an) {
+                $sql3    = "INSERT INTO conges_solde_user (su_login, su_abs_id, su_nb_an, su_solde, su_reliquat) ";
+                $sql3    = $sql3 . "VALUES ('" . $tab_new_user['login'] . "' , $id_cong, " . $tab_new_jours_an[$id_cong] . ", " . $tab_new_solde[$id_cong] . ", 0) ";
                 $result3 = \includes\SQL::query($sql3);
             }
 
             /***********************************/
             /* ajout du user dans ses groupes  */
-            $result4=TRUE;
-            if( ($_SESSION['config']['gestion_groupes']) && ($checkbox_user_groups!="") ) {
-                $result4= \admin\Fonctions::commit_modif_user_groups($tab_new_user['login'], $checkbox_user_groups);
+            $result4 = true;
+            if (($_SESSION['config']['gestion_groupes']) && ($checkbox_user_groups != "")) {
+                $result4 = \admin\Fonctions::commit_modif_user_groups($tab_new_user['login'], $checkbox_user_groups);
             }
 
             /*****************************/
-            if($result1 && $result3 && $result4) {
+            if ($result1 && $result3 && $result4) {
                 $return .= _('form_modif_ok') . '<br><br>';
             } else {
                 $return .= _('form_modif_not_ok') . '<br><br>';
             }
 
-            $comment_log = "ajout_user : ".$tab_new_user['login']." / ".addslashes($tab_new_user['nom'])." ".addslashes($tab_new_user['prenom'])." (".$tab_new_user['quotite']." %)" ;
+            $comment_log = "ajout_user : " . $tab_new_user['login'] . " / " . addslashes($tab_new_user['nom']) . " " . addslashes($tab_new_user['prenom']) . " (" . $tab_new_user['quotite'] . " %)";
             log_action(0, "", $tab_new_user['login'], $comment_log);
 
             /* APPEL D'UNE AUTRE PAGE */
             $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-users" method="POST">';
-            $return .= '<input type="submit" value="' . _('form_retour') .'">';
+            $return .= '<input type="submit" value="' . _('form_retour') . '">';
             $return .= '</form>';
         } else {
             $return .= $verifFalse;
@@ -3480,20 +3481,18 @@ class Fonctions
     public static function commit_modif_user_groups($choix_user, &$checkbox_user_groups)
     {
 
-        $result_insert=FALSE;
+        $result_insert = false;
         // on supprime tous les anciens groupes du user, puis on ajoute tous ceux qui sont dans la tableau checkbox (si il n'est pas vide)
-        $sql_del = 'DELETE FROM conges_groupe_users WHERE gu_login=\''. \includes\SQL::quote($choix_user).'\'';
+        $sql_del    = 'DELETE FROM conges_groupe_users WHERE gu_login=\'' . \includes\SQL::quote($choix_user) . '\'';
         $ReqLog_del = \includes\SQL::query($sql_del);
 
-        if( ($checkbox_user_groups!="") && (count ($checkbox_user_groups)!=0) )
-        {
-            foreach($checkbox_user_groups as $gid => $value)
-            {
-                $sql_insert = "INSERT INTO conges_groupe_users SET gu_gid=$gid, gu_login='$choix_user' "  ;
+        if (($checkbox_user_groups != "") && (count($checkbox_user_groups) != 0)) {
+            foreach ($checkbox_user_groups as $gid => $value) {
+                $sql_insert    = "INSERT INTO conges_groupe_users SET gu_gid=$gid, gu_login='$choix_user' ";
                 $result_insert = \includes\SQL::query($sql_insert);
             }
         } else {
-            $result_insert=TRUE;
+            $result_insert = true;
         }
         return $result_insert;
     }
@@ -3517,14 +3516,14 @@ class Fonctions
             $index = 0;
             // On lance une boucle pour selectionner tous les items
             // traitements : $login contient les valeurs successives
-            foreach($_POST['new_ldap_user'] as $login) {
+            foreach ($_POST['new_ldap_user'] as $login) {
                 $tab_login[$index] = $login;
                 $index++;
                 // cnx à l'annuaire ldap :
                 $ds = ldap_connect($_SESSION['config']['ldap_server']);
                 ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, 3);
-			    // Support Active Directory
-			    ldap_set_option($ds, LDAP_OPT_REFERRALS, 0);
+                // Support Active Directory
+                ldap_set_option($ds, LDAP_OPT_REFERRALS, 0);
                 if ($_SESSION['config']['ldap_user'] == "") {
                     $bound = ldap_bind($ds);
                 } else {
@@ -3532,55 +3531,55 @@ class Fonctions
                 }
 
                 // recherche des entrées :
-                $filter = "(".$_SESSION['config']['ldap_login']."=".$login.")";
+                $filter = "(" . $_SESSION['config']['ldap_login'] . "=" . $login . ")";
 
                 $sr   = ldap_search($ds, $_SESSION['config']['searchdn'], $filter);
-                $data = ldap_get_entries($ds,$sr);
+                $data = ldap_get_entries($ds, $sr);
 
                 foreach ($data as $info) {
                     $tab_new_user[$login]['login']  = $login;
-                    $ldap_libelle_prenom        =$_SESSION['config']['ldap_prenom'];
+                    $ldap_libelle_prenom            = $_SESSION['config']['ldap_prenom'];
                     $ldap_libelle_nom               = $_SESSION['config']['ldap_nom'];
                     $tab_new_user[$login]['prenom'] = utf8_decode($info[$ldap_libelle_prenom][0]);
                     $tab_new_user[$login]['nom']    = utf8_decode($info[$ldap_libelle_nom][0]);
 
-                    $ldap_libelle_mail              = $_SESSION['config']['ldap_mail'];
-                    $tab_new_user[$login]['email']  = $info[$ldap_libelle_mail][0] ;
+                    $ldap_libelle_mail             = $_SESSION['config']['ldap_mail'];
+                    $tab_new_user[$login]['email'] = $info[$ldap_libelle_mail][0];
                 }
 
-                $tab_new_user[$login]['quotite']    = htmlentities(getpost_variable('new_quotite'), ENT_QUOTES | ENT_HTML401);
-                $tab_new_user[$login]['solde_heure']= htmlentities(getpost_variable('new_solde_heure'), ENT_QUOTES | ENT_HTML401);
-                $tab_new_user[$login]['is_resp']    = htmlentities(getpost_variable('new_is_resp'), ENT_QUOTES | ENT_HTML401);
-                $tab_new_user[$login]['resp_login'] = htmlentities(getpost_variable('new_resp_login'), ENT_QUOTES | ENT_HTML401);
-                $tab_new_user[$login]['is_admin']   = htmlentities(getpost_variable('new_is_admin'), ENT_QUOTES | ENT_HTML401);
-                $tab_new_user[$login]['is_hr']      = htmlentities(getpost_variable('new_is_hr'), ENT_QUOTES | ENT_HTML401);
-                $tab_new_user[$login]['see_all']    = getpost_variable('new_see_all');
+                $tab_new_user[$login]['quotite']     = htmlentities(getpost_variable('new_quotite'), ENT_QUOTES | ENT_HTML401);
+                $tab_new_user[$login]['solde_heure'] = htmlentities(getpost_variable('new_solde_heure'), ENT_QUOTES | ENT_HTML401);
+                $tab_new_user[$login]['is_resp']     = htmlentities(getpost_variable('new_is_resp'), ENT_QUOTES | ENT_HTML401);
+                $tab_new_user[$login]['resp_login']  = htmlentities(getpost_variable('new_resp_login'), ENT_QUOTES | ENT_HTML401);
+                $tab_new_user[$login]['is_admin']    = htmlentities(getpost_variable('new_is_admin'), ENT_QUOTES | ENT_HTML401);
+                $tab_new_user[$login]['is_hr']       = htmlentities(getpost_variable('new_is_hr'), ENT_QUOTES | ENT_HTML401);
+                $tab_new_user[$login]['see_all']     = getpost_variable('new_see_all');
 
                 if ($_SESSION['config']['how_to_connect_user'] == "dbconges") {
                     $tab_new_user[$login]['password1'] = getpost_variable('new_password1');
                     $tab_new_user[$login]['password2'] = getpost_variable('new_password2');
                 }
                 $tab_new_jours_an                 = getpost_variable('tab_new_jours_an');
-                $tab_new_solde                    = getpost_variable('tab_new_solde') ;
+                $tab_new_solde                    = getpost_variable('tab_new_solde');
                 $tab_new_user[$login]['new_jour'] = getpost_variable('new_jour');
                 $tab_new_user[$login]['new_mois'] = getpost_variable('new_mois');
                 $tab_new_user[$login]['new_year'] = getpost_variable('new_year');
             }
         } else {
-            $tab_new_user[0]['login']      = htmlentities(getpost_variable('new_login'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user[0]['nom']        = htmlentities(getpost_variable('new_nom'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user[0]['prenom']     = htmlentities(getpost_variable('new_prenom'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user[0]['quotite']    = getpost_variable('new_quotite');
-            $tab_new_user[0]['is_resp']    = htmlentities(getpost_variable('new_is_resp'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user[0]['solde_heure']= htmlentities(getpost_variable('new_solde_heure'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user[0]['resp_login'] = htmlentities(getpost_variable('new_resp_login'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user[0]['is_admin']   = htmlentities(getpost_variable('new_is_admin'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user[0]['is_hr']      = htmlentities(getpost_variable('new_is_hr'), ENT_QUOTES | ENT_HTML401);
-            $tab_new_user[0]['see_all']    = getpost_variable('new_see_all');
+            $tab_new_user[0]['login']       = htmlentities(getpost_variable('new_login'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user[0]['nom']         = htmlentities(getpost_variable('new_nom'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user[0]['prenom']      = htmlentities(getpost_variable('new_prenom'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user[0]['quotite']     = getpost_variable('new_quotite');
+            $tab_new_user[0]['is_resp']     = htmlentities(getpost_variable('new_is_resp'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user[0]['solde_heure'] = htmlentities(getpost_variable('new_solde_heure'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user[0]['resp_login']  = htmlentities(getpost_variable('new_resp_login'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user[0]['is_admin']    = htmlentities(getpost_variable('new_is_admin'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user[0]['is_hr']       = htmlentities(getpost_variable('new_is_hr'), ENT_QUOTES | ENT_HTML401);
+            $tab_new_user[0]['see_all']     = getpost_variable('new_see_all');
 
             if ($_SESSION['config']['how_to_connect_user'] == "dbconges") {
-                $tab_new_user[0]['password1']    = getpost_variable('new_password1');
-                $tab_new_user[0]['password2']    = getpost_variable('new_password2');
+                $tab_new_user[0]['password1'] = getpost_variable('new_password1');
+                $tab_new_user[0]['password2'] = getpost_variable('new_password2');
             }
             $tab_new_user[0]['email']    = htmlentities(getpost_variable('new_email'), ENT_QUOTES | ENT_HTML401);
             $tab_new_jours_an            = getpost_variable('tab_new_jours_an');
@@ -3590,13 +3589,13 @@ class Fonctions
             $tab_new_user[0]['new_year'] = getpost_variable('new_year');
         }
 
-        $checkbox_user_groups = getpost_variable('checkbox_user_groups') ;
+        $checkbox_user_groups = getpost_variable('checkbox_user_groups');
         /* FIN de la recup des parametres    */
         /*************************************/
 
-        if($saisie_user=="ok") {
-            if($_SESSION['config']['export_users_from_ldap']) {
-                foreach($tab_login as $login) {
+        if ($saisie_user == "ok") {
+            if ($_SESSION['config']['export_users_from_ldap']) {
+                foreach ($tab_login as $login) {
                     $return .= \admin\Fonctions::ajout_user($tab_new_user[$login], $tab_new_jours_an, $tab_new_solde, $checkbox_user_groups);
                 }
             } else {

--- a/admin/admin_admin-group-responsables.php
+++ b/admin/admin_admin-group-responsables.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \admin\Fonctions::groupeResponsableModule($onglet);

--- a/admin/admin_admin-group-users.php
+++ b/admin/admin_admin-group-users.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \admin\Fonctions::groupUserModule($onglet);

--- a/admin/admin_admin-group.php
+++ b/admin/admin_admin-group.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \admin\Fonctions::groupeModule($onglet);

--- a/admin/admin_admin-users.php
+++ b/admin/admin_admin-users.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \admin\Fonctions::userModule($session);

--- a/admin/admin_ajout-user.php
+++ b/admin/admin_ajout-user.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \admin\Fonctions::ajoutUtilisateurModule($onglet);

--- a/admin/admin_chg_pwd_user.php
+++ b/admin/admin_chg_pwd_user.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \admin\Fonctions::changeMotDePasseUserModule($onglet, $session);

--- a/admin/admin_db_sauve.php
+++ b/admin/admin_db_sauve.php
@@ -3,10 +3,10 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-include_once ROOT_PATH .'fonctions_conges.php' ;
-include_once INCLUDE_PATH .'fonction.php';
-include_once INCLUDE_PATH .'session.php';
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+include_once INCLUDE_PATH . 'session.php';
 
 \admin\Fonctions::saveRestoreModule($session);

--- a/admin/admin_index.php
+++ b/admin/admin_index.php
@@ -3,17 +3,15 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-include_once ROOT_PATH .'fonctions_conges.php' ;
-include_once INCLUDE_PATH .'fonction.php';
-include_once INCLUDE_PATH .'session.php';
-include_once ROOT_PATH .'fonctions_calcul.php';
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+include_once INCLUDE_PATH . 'session.php';
+include_once ROOT_PATH . 'fonctions_calcul.php';
 
 // verif des droits du user à afficher la page
 verif_droits_user($session, 'is_admin');
-
-
 
 /*************************************/
 // recup des parametres reçus :
@@ -22,62 +20,63 @@ $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 // GET / POST
 $onglet = htmlentities(getpost_variable('onglet', 'admin-users'), ENT_QUOTES | ENT_HTML401);
 
-
 /*********************************/
 /*   COMPOSITION DES ONGLETS...  */
 /*********************************/
 
 $onglets = array();
 
+$onglets['admin-users'] = _('admin_onglet_gestion_user');
+$onglets['ajout-user']  = _('admin_onglet_add_user');
 
-$onglets['admin-users']    = _('admin_onglet_gestion_user');
-$onglets['ajout-user']    = _('admin_onglet_add_user');
-
-if( $_SESSION['config']['gestion_groupes'] ) {
-    if( $_SESSION['config']['admin_see_all'] || $_SESSION['userlogin']=="admin" || is_hr($_SESSION['userlogin']) )
+if ($_SESSION['config']['gestion_groupes']) {
+    if ($_SESSION['config']['admin_see_all'] || $_SESSION['userlogin'] == "admin" || is_hr($_SESSION['userlogin'])) {
         $onglets['admin-group'] = _('admin_onglet_gestion_groupe');
+    }
+
     $onglets['admin-group-users'] = _('admin_onglet_groupe_user');
-    if( $_SESSION['config']['admin_see_all'] || $_SESSION['userlogin']=="admin" || is_hr($_SESSION['userlogin']) )
+    if ($_SESSION['config']['admin_see_all'] || $_SESSION['userlogin'] == "admin" || is_hr($_SESSION['userlogin'])) {
         $onglets['admin-group-responsables'] = _('admin_onglet_groupe_resp');
+    }
+
 }
 
-if ( !isset($onglets[ $onglet ]) && !in_array($onglet, array('chg_pwd_user', 'modif_group', 'modif_user', 'suppr_group','suppr_user')))
+if (!isset($onglets[$onglet]) && !in_array($onglet, array('chg_pwd_user', 'modif_group', 'modif_user', 'suppr_group', 'suppr_user'))) {
     $onglet = 'admin-users';
+}
 
 /*********************************/
 /*   COMPOSITION DU HEADER...    */
 /*********************************/
 
-   $add_css = '<style>#onglet_menu .onglet{ width: '. (str_replace(',', '.', 100 / count($onglets) )).'% ;}</style>';
-header_menu('', 'Libertempo : '._('button_admin_mode'),$add_css);
+$add_css = '<style>#onglet_menu .onglet{ width: ' . (str_replace(',', '.', 100 / count($onglets))) . '% ;}</style>';
+header_menu('', 'Libertempo : ' . _('button_admin_mode'), $add_css);
 
 /*********************************/
 /*   AFFICHAGE DES ONGLETS...  */
 /*********************************/
 
 echo '<div id="onglet_menu">';
-foreach($onglets as $key => $title) {
-    echo '<div class="onglet '.($onglet == $key ? ' active': '').'" >
-        <a href="'.$PHP_SELF.'?session='.$session.'&onglet='.$key.'">'. $title .'</a>
+foreach ($onglets as $key => $title) {
+    echo '<div class="onglet ' . ($onglet == $key ? ' active' : '') . '" >
+        <a href="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $key . '">' . $title . '</a>
     </div>';
 }
 echo '</div>';
-
 
 /*********************************/
 /*   AFFICHAGE DE L'ONGLET ...    */
 /*********************************/
 
-
 /** initialisation des tableaux des types de conges/absences  **/
 // recup du tableau des types de conges (seulement les conges)
-$tab_type_cong=recup_tableau_types_conges();
+$tab_type_cong = recup_tableau_types_conges();
 
 // recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
-$tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
+$tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
 
-echo '<div class="'.$onglet.' main-content">';
-    include_once ROOT_PATH . 'admin/admin_'.$onglet.'.php';
+echo '<div class="' . $onglet . ' main-content">';
+include_once ROOT_PATH . 'admin/admin_' . $onglet . '.php';
 echo '</div>';
 
 /*********************************/

--- a/admin/admin_modif_group.php
+++ b/admin/admin_modif_group.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \admin\Fonctions::modifGroupeModule($session, $onglet);

--- a/admin/admin_modif_user.php
+++ b/admin/admin_modif_user.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \admin\Fonctions::modifUserModule($session, $onglet);

--- a/admin/admin_suppr_group.php
+++ b/admin/admin_suppr_group.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \admin\Fonctions::supprimerGroupeModule($session, $onglet);

--- a/admin/admin_suppr_user.php
+++ b/admin/admin_suppr_user.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \admin\Fonctions::supprimerUtilisateurModule($session, $onglet);

--- a/calcul_nb_jours_pris.php
+++ b/calcul_nb_jours_pris.php
@@ -3,56 +3,51 @@
 define('ROOT_PATH', '');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-include_once ROOT_PATH . 'fonctions_conges.php' ;
+include_once ROOT_PATH . 'fonctions_conges.php';
 include_once INCLUDE_PATH . 'fonction.php';
 include_once INCLUDE_PATH . 'session.php';
 include_once ROOT_PATH . 'fonctions_calcul.php';
 
 /*** initialisation des variables ***/
-$session=session_id();
-$user="";
-$date_debut="";
-$date_fin="";
-$p_num="";
+$session    = session_id();
+$user       = "";
+$date_debut = "";
+$date_fin   = "";
+$p_num      = "";
 
 /*************************************/
 // recup des parametres reçus :
 // SERVER
 $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 // GET  / POST
-$user       = getpost_variable('user') ;
-$date_debut = getpost_variable('date_debut') ;
-$date_fin   = getpost_variable('date_fin') ;
-$opt_debut  = getpost_variable('opt_debut') ;
-$opt_fin    = getpost_variable('opt_fin') ;
-$p_num	    = getpost_variable('p_num') ;
+$user       = getpost_variable('user');
+$date_debut = getpost_variable('date_debut');
+$date_fin   = getpost_variable('date_fin');
+$opt_debut  = getpost_variable('opt_debut');
+$opt_fin    = getpost_variable('opt_fin');
+$p_num      = getpost_variable('p_num');
 /*************************************/
 
-if( ($user!="") && ($date_debut!="") && ($date_fin!="") && ($opt_debut!="") && ($opt_fin!="") )
-	affichage($user, $date_debut, $date_fin, $opt_debut, $opt_fin, $p_num);
+if (($user != "") && ($date_debut != "") && ($date_fin != "") && ($opt_debut != "") && ($opt_fin != "")) {
+    affichage($user, $date_debut, $date_fin, $opt_debut, $opt_fin, $p_num);
+}
 
 /**********  FONCTIONS  ****************************************/
 
-function affichage($user, $date_debut, $date_fin, $opt_debut, $opt_fin, $p_num="")
+function affichage($user, $date_debut, $date_fin, $opt_debut, $opt_fin, $p_num = "")
 {
-	$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-	$session=session_id();
-	$comment="&nbsp;" ;
+    $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+    $session  = session_id();
+    $comment  = "&nbsp;";
 
-
-
-	// calcul :
-	$nb_jours=compter($user, $p_num, $date_debut, $date_fin, $opt_debut, $opt_fin, $comment);
-	$tab['nb'] = $nb_jours;
-	$tab['comm'] = $comment;
-	if(!$_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-	{
-		$tab['nb'] = "";
-	}
-		echo json_encode($tab);
+    // calcul :
+    $nb_jours    = compter($user, $p_num, $date_debut, $date_fin, $opt_debut, $opt_fin, $comment);
+    $tab['nb']   = $nb_jours;
+    $tab['comm'] = $comment;
+    if (!$_SESSION['config']['rempli_auto_champ_nb_jours_pris']) {
+        $tab['nb'] = "";
+    }
+    echo json_encode($tab);
 }
-
-
-

--- a/calendrier.php
+++ b/calendrier.php
@@ -2,12 +2,12 @@
 define('ROOT_PATH', '');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 $session = htmlentities($session, ENT_QUOTES | ENT_HTML401);
 
-include_once ROOT_PATH .'fonctions_conges.php';
-include_once INCLUDE_PATH .'fonction.php';
-header_menu('', 'Libertempo : '._('calendrier_titre'));
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+header_menu('', 'Libertempo : ' . _('calendrier_titre'));
 
 echo (new \App\ProtoControllers\Calendrier())->get();
 

--- a/cfg/config_CAS_new.php
+++ b/cfg/config_CAS_new.php
@@ -1,35 +1,34 @@
 <?php
 /**
-**	@author Benjamin Husson
-**
-**	-------------------------Fichier de configuration du serveur CAS-------------------------
-**
-**	CAS pour Système d'Authentification  Centralisé http://www.yale.edu/tp/cas/
-** 
-**  Pre-requis pour l'utilisation du mode d'authentification CAS (utilisation de la librairie phpcas et de ses dépendances)
-**	http://esup-phpcas.sourceforge.net/requirements.html
-**
-**	Pour utiliser le système d'authentification CAS le paramêtre de configuration de php_conges "how_to_connect_user"
-**	doit être positionné a "CAS"
-**	
-** 	ATTENTION : Un utilisateur ne peut se connecter en utilisant CAS uniquement si le login utilisé par CAS 
-**	est identique au champ u_login de la table conges_users de la bdd.
-**	REMARQUE : CAS s'appuyant souvent sur un annuaire LDAP, l'utilisation de CAS ne rentre pas en conflit avec l'utilisation de LDAP 
-**	pour gerer la création d'utilisateurs en mode Admin.
-**	(il est même recommandé d'utiliser l'authentification CAS en parrallele avec la création d'utilisateurs en mode ldap.)
-**	De cette façon les logins associés aux utilisateurs de php_conges seront identique à ceux utilisés par CAS.
-**
-**	Fichier de configuration du système d'authentification CAS. 
-**	
-**	$config_CAS_host = hostName				adresse du serveur CAS
-**	$config_CAS_portNumber = PortNumber		numero de port sur lequel tourne le service (par défaut 443)
-**	$config_CAS_URI = "" 					vide par défaut, c'est la sous adresse pour le service CAS
-**/
+ **    @author Benjamin Husson
+ **
+ **    -------------------------Fichier de configuration du serveur CAS-------------------------
+ **
+ **    CAS pour Système d'Authentification  Centralisé http://www.yale.edu/tp/cas/
+ **
+ **  Pre-requis pour l'utilisation du mode d'authentification CAS (utilisation de la librairie phpcas et de ses dépendances)
+ **    http://esup-phpcas.sourceforge.net/requirements.html
+ **
+ **    Pour utiliser le système d'authentification CAS le paramêtre de configuration de php_conges "how_to_connect_user"
+ **    doit être positionné a "CAS"
+ **
+ **     ATTENTION : Un utilisateur ne peut se connecter en utilisant CAS uniquement si le login utilisé par CAS
+ **    est identique au champ u_login de la table conges_users de la bdd.
+ **    REMARQUE : CAS s'appuyant souvent sur un annuaire LDAP, l'utilisation de CAS ne rentre pas en conflit avec l'utilisation de LDAP
+ **    pour gerer la création d'utilisateurs en mode Admin.
+ **    (il est même recommandé d'utiliser l'authentification CAS en parrallele avec la création d'utilisateurs en mode ldap.)
+ **    De cette façon les logins associés aux utilisateurs de php_conges seront identique à ceux utilisés par CAS.
+ **
+ **    Fichier de configuration du système d'authentification CAS.
+ **
+ **    $config_CAS_host = hostName                adresse du serveur CAS
+ **    $config_CAS_portNumber = PortNumber        numero de port sur lequel tourne le service (par défaut 443)
+ **    $config_CAS_URI = ""                     vide par défaut, c'est la sous adresse pour le service CAS
+ **/
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
-
-$config_CAS_host = "localhost";		//adresse http
-$config_CAS_portNumber = 443; 	//entier
-$config_CAS_URI = "";		//chemin relatif (peut être vide)
-$config_CAS_CACERT = ""; //indispensable en production
+$config_CAS_host       = "localhost"; //adresse http
+$config_CAS_portNumber = 443; //entier
+$config_CAS_URI        = ""; //chemin relatif (peut être vide)
+$config_CAS_CACERT     = ""; //indispensable en production

--- a/cfg/config_SMTP_new.php
+++ b/cfg/config_SMTP_new.php
@@ -1,16 +1,14 @@
 <?php
 
 //Config SMTP
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
-
-$config_SMTP_host = "";		//adresse serveur smtp
-$config_SMTP_port = 25; 	//port smtp
-$config_SMTP_sec  = "";		//ssl, tls ou vide
-$config_SMTP_user = "";		//nom utilisateur (peut être vide)
-$config_SMTP_pwd = "";		//mot de passe (peut être vide)
+$config_SMTP_host = ""; //adresse serveur smtp
+$config_SMTP_port = 25; //port smtp
+$config_SMTP_sec  = ""; //ssl, tls ou vide
+$config_SMTP_user = ""; //nom utilisateur (peut être vide)
+$config_SMTP_pwd  = ""; //mot de passe (peut être vide)
 
 // uncomment this if you want receive mails when a SQL error is found.
 //if (!defined( 'ERROR_MAIL_REPORT' ))
-// define('ERROR_MAIL_REPORT',	'your@mail.adress');
-
+// define('ERROR_MAIL_REPORT',    'your@mail.adress');

--- a/cfg/config_ldap_new.php
+++ b/cfg/config_ldap_new.php
@@ -1,13 +1,13 @@
 <?php
 
 /*****************************************************************/
-/*			PARAMATRAGE LDAP
-Ce fichier est utilisisé par PHP_CONGES SEULEMENT SI vous avez activé les options 
+/*            PARAMATRAGE LDAP
+Ce fichier est utilisisé par PHP_CONGES SEULEMENT SI vous avez activé les options
 concernants le ldap dans la configuration de php_conges :
-	where_to_find_user_email="ldap" ;
-	how_to_connect_user="ldap";
+where_to_find_user_email="ldap" ;
+how_to_connect_user="ldap";
 
-=> vous devez configurer ce fichier pour que les requêtes LDAP 
+=> vous devez configurer ce fichier pour que les requêtes LDAP
 s'effectuent sans problème.
 
 /!\ quelques notions de LDAP sont nécessaires à la bonne compréhension
@@ -19,65 +19,62 @@ Nous n'utiliserons pas tous les champs de l'annuaire. Voici la liste des champs
 utilisés (et pour vous aider 2 exemples de paramétrage pour ActiveDirectory2008 et OpenLDAP)
 
 - $config_ldap_server : nom de votre serveur ayant le ldap (ou adresse IP).
-	Pour info, fonctionne aussi en ldaps.
-	ex : 	   $config_ldap_server = "http://nom_de_mon_serveur";
-	(en ldaps) $config_ldap_server = "https://nom_de_mon_serveur";
+Pour info, fonctionne aussi en ldaps.
+ex :        $config_ldap_server = "http://nom_de_mon_serveur";
+(en ldaps) $config_ldap_server = "https://nom_de_mon_serveur";
 
 - Vous pouvez également définir un serveur de "backup" (serveur secondaire de domaine) :
-	$config_ldap_bupsvr = "http://serveur2"; 
-	Si vous n'en avez pas, laisser le champ vide.
+$config_ldap_bupsvr = "http://serveur2";
+Si vous n'en avez pas, laisser le champ vide.
 
 - $config_ldap_protocol_version : numéro de version du protocole LDAP utilisé par votre serveur.
-	Les serveur LDAP récents (notamment OpenLDAP 2.x.x) utilisent la version 3 du protocole.
-	Pour les serveur utilisant une version antérieure du protocole, cette option doit rester à 0;
-	$config_ldap_protocol_version = 0 ;
+Les serveur LDAP récents (notamment OpenLDAP 2.x.x) utilisent la version 3 du protocole.
+Pour les serveur utilisant une version antérieure du protocole, cette option doit rester à 0;
+$config_ldap_protocol_version = 0 ;
 
 ---------------------------------------------------------------------------------------
 - $config_basedn : quelle est la racine de votre domaine ?
-	ex : $config_basedn = "dc=mon_domaine,dc=fr";
-	Si vous avez un domaine toto.com, vous avez configuré sous un AD2003 un
-	sous-domaine (uniquement pour vos besoins internes) 'administration',
-	$config_basedn sera alors "dc=administration,dc=toto,dc=com"
-
+ex : $config_basedn = "dc=mon_domaine,dc=fr";
+Si vous avez un domaine toto.com, vous avez configuré sous un AD2003 un
+sous-domaine (uniquement pour vos besoins internes) 'administration',
+$config_basedn sera alors "dc=administration,dc=toto,dc=com"
 
 - $config_ldap_user : s'il faut s'identifier pour accéder au ldap, rentrer un login ici.
-	Pour un AD2008, c'est obligatoire et il est conseillé d'ajouter le nom de domaine avant le login. Il est aussi conseillé 
-	de créer un utilisateur qui ne servira qu'à cela (et ainsi évitera de mettre en clair
-	le mot de passe d'un utilisateur existant), et interdire l'accès aux PC de cet utilisateur.
-	(cf votre documentation (ou votre bible) ;-) Windows Server...)
-	Ex (AD, utilisateur "ldap") : $config_ldap_user   = "CN=ldap,dc=administration,dc=toto,dc=com" ;
+Pour un AD2008, c'est obligatoire et il est conseillé d'ajouter le nom de domaine avant le login. Il est aussi conseillé
+de créer un utilisateur qui ne servira qu'à cela (et ainsi évitera de mettre en clair
+le mot de passe d'un utilisateur existant), et interdire l'accès aux PC de cet utilisateur.
+(cf votre documentation (ou votre bible) ;-) Windows Server...)
+Ex (AD, utilisateur "ldap") : $config_ldap_user   = "CN=ldap,dc=administration,dc=toto,dc=com" ;
 
 - $config_ldap_pass : le mot de passe associé au compte ci-dessus...
 
 On peut laisser ces deux champ vides si la connexion au ldap anonyme est autorisée.
 
-
 - $config_searchdn : permet d'indiquer le point d'entrée dans l'arborescence du LDAP.
-	En effet, sous un AD, par exemple, vous avez "MesOrdinateurs", "MesUtilisateurs", "MesGroupes"... 
-	Il est inutile de rechercher dans tout l'arbre.
-	Ex (AD) : $config_searchdn = "ou=MesUtilisateurs,dc=administration,dc=toto,dc=com";
-	(pour un OpenLdap 	   = "ou=people,dc=mon_domaine,dc=fr"		) 
+En effet, sous un AD, par exemple, vous avez "MesOrdinateurs", "MesUtilisateurs", "MesGroupes"...
+Il est inutile de rechercher dans tout l'arbre.
+Ex (AD) : $config_searchdn = "ou=MesUtilisateurs,dc=administration,dc=toto,dc=com";
+(pour un OpenLdap        = "ou=people,dc=mon_domaine,dc=fr"        )
 
-
-Les champs suivants vont nous permettre d'extraire du ldap les données qui nous intéresse : 
+Les champs suivants vont nous permettre d'extraire du ldap les données qui nous intéresse :
 En effet, même standardisé, d'un ldap à l'autre le nommage des champs vont être différents.
 Nous prendrons 2 exemples "les + courants", Active Directory et OpenLDAP.
 Pour Novell, IBM, ... : cf doc de votre ldap !
 
 - $config_ldap_prenom : dans quel champ est indiqué le prénom de la personne ?
-	AD ou OpenLDAP : "givenname"
+AD ou OpenLDAP : "givenname"
 
 - $config_ldap_nom : dans quel champ est indiqué le nom ?
-	AD ou OpenLDAP : "sn"
+AD ou OpenLDAP : "sn"
 
 - $config_ldap_mail : quel champ possède le mail de la personne ?
-	AD ou OpenLDAP : "mail"
+AD ou OpenLDAP : "mail"
 
 - $config_ldap_login : quel champ possède l'identifiant de l'utilisateur ?
-	AD : "samaccountname", OpenLdap : "uid"
+AD : "samaccountname", OpenLdap : "uid"
 
 - $config_ldap_nomaff : quel champ du ldap affiche le nom et le prénom (dans le même champ) ?
-	AD ou OpenLDAP : "displayName"
+AD ou OpenLDAP : "displayName"
 
 ---------------------------------------------------------------------------------------
 Ce qui suit sert uniquement dans le mode Administrateur pour lister les utilisateurs de
@@ -87,64 +84,60 @@ prénom, mot de passe, mail, ...).
 On va devoir définir des critères de recherche :
 - $config_ldap_filtre : sur quel filtre (quel champ du ldap) ?
 - $config_ldap_filrec : critère de recherche.
-	Ex : si on veut les "users" (permet de lister que les personnes) d'AD, il faut :
-	$config_ldap_filtre = "objectclass";
-	$config_ldap_filrech= "user";
+Ex : si on veut les "users" (permet de lister que les personnes) d'AD, il faut :
+$config_ldap_filtre = "objectclass";
+$config_ldap_filrech= "user";
 
-	Vous pouvez aller plus loin suivant la façon dont vous avez renseigné le LDAP.
-	Ex pour une université, nous avons le champ "supannAffectation" qui permet
-	d'affecter les personnes aux composantes, on renseignera donc :
-	$config_ldap_filtre = "supannAffectation";
-	$config_ldap_filrech= "Scienc*";
+Vous pouvez aller plus loin suivant la façon dont vous avez renseigné le LDAP.
+Ex pour une université, nous avons le champ "supannAffectation" qui permet
+d'affecter les personnes aux composantes, on renseignera donc :
+$config_ldap_filtre = "supannAffectation";
+$config_ldap_filrech= "Scienc*";
 
-	On recherche donc toutes les personnes dont l'affectation commencent par 'Scienc'
-	(noter ici l'utilisation du caractère joker *)
+On recherche donc toutes les personnes dont l'affectation commencent par 'Scienc'
+(noter ici l'utilisation du caractère joker *)
 
 Vous pouvez aller ENCORE plus loin en définissant vous-même le filtre complet de recherche :
 $config_ldap_filtre_complet
 
 /!\ Laisser ce champ vide si vous ne souhaitez pas l'utiliser !
 
-	Et vous pouvez définir vos propres requêtes ldap (en utilisant le langage associé).
-	Reprenons l'exemple de notre université qui veut que tous les congés personnels de scienc*
-	et de droit soient gérés par l'application.
-	$config_ldap_filtre_complet = "(&(displayName=*)(|(supannAffectation=Scienc*)(supannAffectation=DROIT)))"; 
+Et vous pouvez définir vos propres requêtes ldap (en utilisant le langage associé).
+Reprenons l'exemple de notre université qui veut que tous les congés personnels de scienc*
+et de droit soient gérés par l'application.
+$config_ldap_filtre_complet = "(&(displayName=*)(|(supannAffectation=Scienc*)(supannAffectation=DROIT)))";
 
-	Je recherche tous les (utilisateurs) displayName=* ET
-			(dont l'affectation 'supannAffectation' commence par Scien*
-			   OU l'affectation 'supannAffectation' est DROIT)
+Je recherche tous les (utilisateurs) displayName=* ET
+(dont l'affectation 'supannAffectation' commence par Scien*
+OU l'affectation 'supannAffectation' est DROIT)
 
 /********************************************************************/
 
 // Voici ci-dessous 2 configs "pré-remplies" qui peuvent vous aider.
 // (décommenter celle qui vous intéresse)
 
-
 /**********  config Active Directory  ********/
 /*-------------------------------------------*/
 
+defined('_PHP_CONGES') or die('Restricted access');
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+$config_ldap_server           = "ldap://mon_serveur";
+$config_ldap_protocol_version = 0; // 3 si version 3 , 0 sinon !
+$config_ldap_bupsvr           = "";
+$config_basedn                = "dc=mon_domaine,dc=fr";
+$config_ldap_user             = "CN=user_ldap,dc=mon_domaine,dc=com";
+$config_ldap_pass             = "user_ldap_pass";
+$config_searchdn              = "ou=MesUtilisateurs,dc=mon_domaine,dc=com";
 
-$config_ldap_server = "ldap://mon_serveur";
-$config_ldap_protocol_version = 0 ;   // 3 si version 3 , 0 sinon !
-$config_ldap_bupsvr = "";
-$config_basedn      = "dc=mon_domaine,dc=fr";
-$config_ldap_user   = "CN=user_ldap,dc=mon_domaine,dc=com" ;
-$config_ldap_pass   = "user_ldap_pass";
-$config_searchdn    = "ou=MesUtilisateurs,dc=mon_domaine,dc=com";
+$config_ldap_prenom  = "givenname";
+$config_ldap_nom     = "sn";
+$config_ldap_mail    = "mail";
+$config_ldap_login   = "samaccountname";
+$config_ldap_nomaff  = "displayName";
+$config_ldap_filtre  = "objectclass";
+$config_ldap_filrech = "user";
 
-$config_ldap_prenom = "givenname"; 
-$config_ldap_nom    = "sn";
-$config_ldap_mail   = "mail";
-$config_ldap_login  = "samaccountname";
-$config_ldap_nomaff = "displayName";
-$config_ldap_filtre = "objectclass";
-$config_ldap_filrech= "user";
-
-$config_ldap_filtre_complet = "";   
-
-
+$config_ldap_filtre_complet = "";
 
 /********** Config OpenLDAP (en ldaps, anonyme autorisé) **********/
 /*----------------------------------------------------------------*/
@@ -157,7 +150,7 @@ $config_ldap_user   = "";
 $config_ldap_pass   = "";
 $config_searchdn    = "ou=people,dc=mon_domaine,dc=com";
 
-$config_ldap_prenom = "givenname"; 
+$config_ldap_prenom = "givenname";
 $config_ldap_nom    = "sn";
 $config_ldap_mail   = "mail";
 $config_ldap_login  = "uid";
@@ -165,7 +158,5 @@ $config_ldap_nomaff = "displayName";
 $config_ldap_filtre = "mon_filtre_de_recherche";
 $config_ldap_filrech= "mon_critère_de_recherche";
 
-$config_ldap_filtre_complet = "";   
-*/
-
-
+$config_ldap_filtre_complet = "";
+ */

--- a/cfg/dbconnect_new.php
+++ b/cfg/dbconnect_new.php
@@ -6,9 +6,9 @@
 //---------------------------------------
 // MySql :
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
 $mysql_serveur  = "localhost";
 $mysql_user     = "dbconges";
 $mysql_pass     = "motdepasse";
-$mysql_database =  "db_conges";
+$mysql_database = "db_conges";

--- a/check_file_coding_standard.php
+++ b/check_file_coding_standard.php
@@ -1,175 +1,194 @@
 <?php
 
-	$non_utf8 = array();
-	$non_unix = array();
-	$has_mysql = array();
-	$has_short_tag = array();
-	
-	foreach (find_all_php('./') as $file)
-	{
-		set_time_limit(30);
-		$tmp = file_get_contents($file);
-		
-		if (is_utf_8($tmp) !== true)
-			$non_utf8[] = $file;
-			
-		if (strpos($tmp,"\r") !== false)
-			$non_unix[] = $file;
-			
-		if (use_mysql($tmp) !== false)
-			$has_mysql[] = $file;
-			
-		if (use_short_tag($tmp) !== false)
-			$has_short_tag[] = $file;
-		
-		//remplace les \r\n par \n
-		//$tmp = str_replace("\r\n","\n",$tmp);
-		
-		// file_put_contents($file,$tmp);
-	}
-	
-	echo "\n".'Liste des fichiers non UNIX (\r) :'."\n";
-	foreach($non_unix as $file)
-		echo "\t".$file."\n";
-		
-	echo "\n".'Liste des fichiers utilisant mysql et non mysqli :'."\n";
-	foreach($has_mysql as $file)
-		echo "\t".$file."\n";
-		
-	echo "\n".'Liste des fichiers non UTF-8 :'."\n";
-	foreach($non_utf8 as $file)
-		echo "\t".$file."\n";
-		
-	echo "\n".'Liste des fichiers avec short tag php :'."\n";
-	foreach($has_short_tag as $file)
-		echo "\t".$file."\n";
+$non_utf8      = array();
+$non_unix      = array();
+$has_mysql     = array();
+$has_short_tag = array();
 
-	function is_utf_8($str)
-	{
-		// Created with
-		// http://www.ietf.org/rfc/rfc3629.txt
-		// http://abcdrfc.free.fr/rfc-vf/pdf/rfc3629.pdf
-		
-		static $no_utf8_bytes = array(0xc0,0xc1,0xf5,0xf6,0xf7,0xf8,
-								0xf9,0xfa,0xfb,0xfc,0xfd,0xfe,0xff);
-								
-		// WARNING, start file with a BOM != NON UTF-8
-		// So a correct UTF-8 can start with a BOM but is this case is not a BOM
-		// Is this case is a ZERO WIDTH NO-BREAK SPACE, aka a non breackable space
-		// BUT if we found it at start of file, this MIGHT be a signature for UCS encoding
-		// BUT keep in mind is MIGHT. KEEP ALSO in mind that start a file with
-		// a non-breackable space is little space :-)
-		
-		// Let's check if he start with a BOM ( U+FEFF or 0xEF 0xBB 0xBF)
-		if(ord($str[0]) == 0xef && ord($str[1]) == 0xbb && ord($str[2]) == 0xbf)
-			return false; //return 'rejected, file start with BOM sequence';
-		
-		$i = 0;
-		//foreach all bytes when they have more
-		while(isset($str[$i]))
-		{
-			$tmp = ord($str[$i]);
-			$o = $i;
-			
-			//unicode char in int val ( for exemple $u_val = 0x25F => U+25F)
-			$u_val = 0;
-			
-			// lets check is not invalid utf8 !
-			if (in_array($tmp, $no_utf8_bytes))
-				return false; //return 'rejected, invalid bytes, forbiden is all file';
-			
-			
-			// one bytes for one char
-			$d = 1; // decalage or nb bytes
-			if (( $tmp & bindec('10000000') ) == bindec('00000000')) {
-				$u_val = $tmp & bindec('01111111');
-			}
-			else {
-				// it's two, three or four bytes for one char ?
-				do{
-					$d ++;
-					$c1 = $tmp >> (7-$d);
-					$c2 = 0xff >> (8-$d) << 1;
-				}while( $d < 4 && $c1 != $c2);
-				
-				if ($c1 == $c2) {
-					$m = 0xff >> (7-$d) << (7-$d);
-					$u_val = $tmp & $m;
-				}
-				else
-					return false; //return 'rejected, is not expected to find other value or more than 4 bytes';
-			}
-			
-			// move to the next new URF-8 char
-			$i += $d;
-			
-			// Not lets check the other bytes if they don't respect format
-			while( ++$o < $i) {
-			
-				// Is the end of file ???? We expected more bytes ... error !
-				if (!isset($str[$o]))
-					return false; //return 'End of file reach but we expected more chars';
-					
-				$tmp = ord($str[$o]);
-				$u_val = $u_val << 1;
-				$u_val += $tmp & bindec('00111111') ;
-			
-				// lets check is not invalid utf8 too !
-				if (in_array($tmp, $no_utf8_bytes))
-					return 'rejected, invalid bytes, forbiden is all file';
-				
-				// lets check is it's valid rfc3629
-				if (( $tmp & bindec('11000000') ) != bindec('10000000') )
-					return false; //return 'This byte don\'t repesct rcf format for 2,3 or 4 bytes';
-			}
-			
-			// now check if it's not between U+D800 and U+DFFF
-			if ($u_val >= 0xD800 && $u_val <= 0xDFFF)
-				return false; //return 'rejected because between D800 and DFFF if forbiden (UTF-16)';
-			
-		}
-		
-		return true; // Yeah ! We don't found invalid bytes or sequence ... So it's declared valid !
-	}
+foreach (find_all_php('./') as $file) {
+    set_time_limit(30);
+    $tmp = file_get_contents($file);
 
-	function use_short_tag($str)
-	{
-		return (strstr($str,'\<? ') !== false);
-	}
+    if (is_utf_8($tmp) !== true) {
+        $non_utf8[] = $file;
+    }
 
-	function use_mysql($str)
-	{
-		static $mysql_words = array('mysql_affected_rows', 'mysql_client_encoding', 'mysql_close', 'mysql_connect',
-								'mysql_create_db', 'mysql_data_seek', 'mysql_db_name', 'mysql_db_query',
-								'mysql_drop_db', 'mysql_errno', 'mysql_error', 'mysql_escape_string',
-								'mysql_fetch_array', 'mysql_fetch_assoc', 'mysql_fetch_field',
-								'mysql_fetch_lengths', 'mysql_fetch_object', 'mysql_fetch_row',
-								'mysql_field_flags', 'mysql_field_len', 'mysql_field_name', 'mysql_field_seek',
-								'mysql_field_table', 'mysql_field_type', 'mysql_free_result',
-								'mysql_get_client_info', 'mysql_get_host_info', 'mysql_get_proto_info',
-								'mysql_get_server_info', 'mysql_info', 'mysql_insert_id', 'mysql_list_dbs',
-								'mysql_list_fields', 'mysql_list_processes', 'mysql_list_tables',
-								'mysql_num_fields', 'mysql_num_rows', 'mysql_pconnect', 'mysql_ping',
-								'mysql_query', 'mysql_real_escape_string', 'mysql_result', 'mysql_select_db',
-								'mysql_set_charset', 'mysql_stat', 'mysql_tablename', 'mysql_thread_id',
-								'mysql_unbuffered_query','$mysql_link',);
-		
-		foreach ($mysql_words as $tmp)
-		{
-			if (strstr($str,$tmp) !== false)
-				return true;
-		}
-		return false;
-	}
+    if (strpos($tmp, "\r") !== false) {
+        $non_unix[] = $file;
+    }
 
-	function find_all_php($dir, $i = 1)
-	{
-		if ($i == 20)
-			return;
-		$result = glob($dir.'*.php');
-		foreach(glob($dir.'*', GLOB_ONLYDIR | GLOB_MARK ) as $sub_dir)
-			$result = array_merge($result , (array)find_all_php($sub_dir , $i+1));
-		return $result;
-	}
-	
+    if (use_mysql($tmp) !== false) {
+        $has_mysql[] = $file;
+    }
 
+    if (use_short_tag($tmp) !== false) {
+        $has_short_tag[] = $file;
+    }
+
+    //remplace les \r\n par \n
+    //$tmp = str_replace("\r\n","\n",$tmp);
+
+    // file_put_contents($file,$tmp);
+}
+
+echo "\n" . 'Liste des fichiers non UNIX (\r) :' . "\n";
+foreach ($non_unix as $file) {
+    echo "\t" . $file . "\n";
+}
+
+echo "\n" . 'Liste des fichiers utilisant mysql et non mysqli :' . "\n";
+foreach ($has_mysql as $file) {
+    echo "\t" . $file . "\n";
+}
+
+echo "\n" . 'Liste des fichiers non UTF-8 :' . "\n";
+foreach ($non_utf8 as $file) {
+    echo "\t" . $file . "\n";
+}
+
+echo "\n" . 'Liste des fichiers avec short tag php :' . "\n";
+foreach ($has_short_tag as $file) {
+    echo "\t" . $file . "\n";
+}
+
+function is_utf_8($str)
+{
+    // Created with
+    // http://www.ietf.org/rfc/rfc3629.txt
+    // http://abcdrfc.free.fr/rfc-vf/pdf/rfc3629.pdf
+
+    static $no_utf8_bytes = array(0xc0, 0xc1, 0xf5, 0xf6, 0xf7, 0xf8,
+        0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff);
+
+    // WARNING, start file with a BOM != NON UTF-8
+    // So a correct UTF-8 can start with a BOM but is this case is not a BOM
+    // Is this case is a ZERO WIDTH NO-BREAK SPACE, aka a non breackable space
+    // BUT if we found it at start of file, this MIGHT be a signature for UCS encoding
+    // BUT keep in mind is MIGHT. KEEP ALSO in mind that start a file with
+    // a non-breackable space is little space :-)
+
+    // Let's check if he start with a BOM ( U+FEFF or 0xEF 0xBB 0xBF)
+    if (ord($str[0]) == 0xef && ord($str[1]) == 0xbb && ord($str[2]) == 0xbf) {
+        return false;
+    }
+    //return 'rejected, file start with BOM sequence';
+
+    $i = 0;
+    //foreach all bytes when they have more
+    while (isset($str[$i])) {
+        $tmp = ord($str[$i]);
+        $o   = $i;
+
+        //unicode char in int val ( for exemple $u_val = 0x25F => U+25F)
+        $u_val = 0;
+
+        // lets check is not invalid utf8 !
+        if (in_array($tmp, $no_utf8_bytes)) {
+            return false;
+        }
+        //return 'rejected, invalid bytes, forbiden is all file';
+
+        // one bytes for one char
+        $d = 1; // decalage or nb bytes
+        if (($tmp & bindec('10000000')) == bindec('00000000')) {
+            $u_val = $tmp & bindec('01111111');
+        } else {
+            // it's two, three or four bytes for one char ?
+            do {
+                $d++;
+                $c1 = $tmp >> (7 - $d);
+                $c2 = 0xff >> (8 - $d) << 1;
+            } while ($d < 4 && $c1 != $c2);
+
+            if ($c1 == $c2) {
+                $m     = 0xff >> (7 - $d) << (7 - $d);
+                $u_val = $tmp & $m;
+            } else {
+                return false;
+            }
+            //return 'rejected, is not expected to find other value or more than 4 bytes';
+        }
+
+        // move to the next new URF-8 char
+        $i += $d;
+
+        // Not lets check the other bytes if they don't respect format
+        while (++$o < $i) {
+
+            // Is the end of file ???? We expected more bytes ... error !
+            if (!isset($str[$o])) {
+                return false;
+            }
+            //return 'End of file reach but we expected more chars';
+
+            $tmp   = ord($str[$o]);
+            $u_val = $u_val << 1;
+            $u_val += $tmp & bindec('00111111');
+
+            // lets check is not invalid utf8 too !
+            if (in_array($tmp, $no_utf8_bytes)) {
+                return 'rejected, invalid bytes, forbiden is all file';
+            }
+
+            // lets check is it's valid rfc3629
+            if (($tmp & bindec('11000000')) != bindec('10000000')) {
+                return false;
+            }
+            //return 'This byte don\'t repesct rcf format for 2,3 or 4 bytes';
+        }
+
+        // now check if it's not between U+D800 and U+DFFF
+        if ($u_val >= 0xD800 && $u_val <= 0xDFFF) {
+            return false;
+        }
+        //return 'rejected because between D800 and DFFF if forbiden (UTF-16)';
+
+    }
+
+    return true; // Yeah ! We don't found invalid bytes or sequence ... So it's declared valid !
+}
+
+function use_short_tag($str)
+{
+    return (strstr($str, '\<? ') !== false);
+}
+
+function use_mysql($str)
+{
+    static $mysql_words = array('mysql_affected_rows', 'mysql_client_encoding', 'mysql_close', 'mysql_connect',
+        'mysql_create_db', 'mysql_data_seek', 'mysql_db_name', 'mysql_db_query',
+        'mysql_drop_db', 'mysql_errno', 'mysql_error', 'mysql_escape_string',
+        'mysql_fetch_array', 'mysql_fetch_assoc', 'mysql_fetch_field',
+        'mysql_fetch_lengths', 'mysql_fetch_object', 'mysql_fetch_row',
+        'mysql_field_flags', 'mysql_field_len', 'mysql_field_name', 'mysql_field_seek',
+        'mysql_field_table', 'mysql_field_type', 'mysql_free_result',
+        'mysql_get_client_info', 'mysql_get_host_info', 'mysql_get_proto_info',
+        'mysql_get_server_info', 'mysql_info', 'mysql_insert_id', 'mysql_list_dbs',
+        'mysql_list_fields', 'mysql_list_processes', 'mysql_list_tables',
+        'mysql_num_fields', 'mysql_num_rows', 'mysql_pconnect', 'mysql_ping',
+        'mysql_query', 'mysql_real_escape_string', 'mysql_result', 'mysql_select_db',
+        'mysql_set_charset', 'mysql_stat', 'mysql_tablename', 'mysql_thread_id',
+        'mysql_unbuffered_query', '$mysql_link');
+
+    foreach ($mysql_words as $tmp) {
+        if (strstr($str, $tmp) !== false) {
+            return true;
+        }
+
+    }
+    return false;
+}
+
+function find_all_php($dir, $i = 1)
+{
+    if ($i == 20) {
+        return;
+    }
+
+    $result = glob($dir . '*.php');
+    foreach (glob($dir . '*', GLOB_ONLYDIR | GLOB_MARK) as $sub_dir) {
+        $result = array_merge($result, (array) find_all_php($sub_dir, $i + 1));
+    }
+
+    return $result;
+}

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -10,9 +10,9 @@ class Fonctions
     public static function commit_vider_table_logs($session)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
-        $sql_delete="TRUNCATE TABLE conges_logs ";
+        $sql_delete    = "TRUNCATE TABLE conges_logs ";
         $ReqLog_delete = \includes\SQL::query($sql_delete);
 
         // ecriture de cette action dans les logs
@@ -20,18 +20,17 @@ class Fonctions
         log_action(0, "", "", $comment_log);
 
         $return .= '<span class="messages">' . _('form_modif_ok') . '</span><br>';
-        if($session=="") {
-            redirect( ROOT_PATH . 'config/index.php?onglet=logs');
-        }
-        else {
-            redirect( ROOT_PATH . 'config/index.php?session=' . $session . '&onglet=logs');
+        if ($session == "") {
+            redirect(ROOT_PATH . 'config/index.php?onglet=logs');
+        } else {
+            redirect(ROOT_PATH . 'config/index.php?session=' . $session . '&onglet=logs');
         }
     }
 
     public static function confirmer_vider_table_logs($session)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
         $return .= '<center>';
         $return .= '<br><h2>' . _('confirm_vider_logs') . '</h2><br>';
@@ -48,29 +47,29 @@ class Fonctions
     public static function affichage($login_par, $session)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
         //requête qui récupère les logs
         $sql1 = "SELECT log_user_login_par, log_user_login_pour, log_etat, log_comment, log_date FROM conges_logs ";
-        if($login_par!="") {
-            $sql1 = $sql1." WHERE log_user_login_par = '$login_par' ";
+        if ($login_par != "") {
+            $sql1 = $sql1 . " WHERE log_user_login_par = '$login_par' ";
         }
-        $sql1 = $sql1." ORDER BY log_date";
+        $sql1 = $sql1 . " ORDER BY log_date";
 
         $ReqLog1 = \includes\SQL::query($sql1);
 
-        if($ReqLog1->num_rows !=0) {
+        if ($ReqLog1->num_rows != 0) {
             $return .= '<br>';
             $table = new \App\Libraries\Structure\Table();
             $table->addClasses([
                 'table',
                 'table-hover',
                 'table-striped',
-                'table-condensed'
+                'table-condensed',
             ]);
 
             $childTable = '<tr><td class="histo" colspan="5">' . _('voir_les_logs_par') . '</td>';
-            if($login_par!="") {
+            if ($login_par != "") {
                 $childTable .= '<tr><td class="histo" colspan="5">' . _('voir_tous_les_logs') . '<a href="' . $PHP_SELF . '?session=' . $session . '&onglet=logs">' . _('voir_tous_les_logs') . '</a></td>';
             }
             $childTable .= '<tr><td class="histo" colspan="5">&nbsp;</td>';
@@ -86,11 +85,11 @@ class Fonctions
 
             // affichage des logs
             while ($data = $ReqLog1->fetch_array()) {
-                $log_login_par = $data['log_user_login_par'];
-                $log_login_pour = $data['log_user_login_pour'];
-                $log_log_etat = $data['log_etat'];
+                $log_login_par   = $data['log_user_login_par'];
+                $log_login_pour  = $data['log_user_login_pour'];
+                $log_log_etat    = $data['log_etat'];
                 $log_log_comment = $data['log_comment'];
-                $log_log_date = $data['log_date'];
+                $log_log_date    = $data['log_date'];
 
                 $childTable .= '<tr>';
                 $childTable .= '<td>' . $log_log_date . '</td>';
@@ -105,7 +104,7 @@ class Fonctions
             ob_start();
             $table->render();
             $return .= ob_get_clean();
-            if($session=="") {
+            if ($session == "") {
                 $return .= '<form action="' . $PHP_SELF . '?onglet=logs" method="POST">';
             } else {
                 $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=logs" method="POST">';
@@ -144,17 +143,16 @@ class Fonctions
         // SERVER
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
-        $action         = htmlentities(getpost_variable('action', ""), ENT_QUOTES | ENT_HTML401);
-        $login_par      = htmlentities(getpost_variable('login_par', ""), ENT_QUOTES | ENT_HTML401);
+        $action    = htmlentities(getpost_variable('action', ""), ENT_QUOTES | ENT_HTML401);
+        $login_par = htmlentities(getpost_variable('login_par', ""), ENT_QUOTES | ENT_HTML401);
 
         /*************************************/
 
         // header_menu('CONGES : Configuration', $_SESSION['config']['titre_admin_index']);
 
-
-        if($action=="suppr_logs") {
+        if ($action == "suppr_logs") {
             $return .= \config\Fonctions::confirmer_vider_table_logs($session);
-        } elseif($action=="commit_suppr_logs") {
+        } elseif ($action == "commit_suppr_logs") {
             \config\Fonctions::commit_vider_table_logs($session);
         } else {
             $return .= \config\Fonctions::affichage($login_par, $session);
@@ -166,21 +164,20 @@ class Fonctions
     public static function commit_modif($tab_new_values, $session)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
-        if($session=="") {
+        if ($session == "") {
             $URL = "$PHP_SELF?onglet=mail";
         } else {
             $URL = "$PHP_SELF?session=$session&onglet=mail";
         }
 
-
         // update de la table
-        foreach($tab_new_values as $nom_mail => $tab_mail) {
-            $subject = htmlspecialchars(addslashes($tab_mail['subject']));
-            $body = htmlspecialchars(addslashes($tab_mail['body']));
-            $req_update='UPDATE conges_mail SET mail_subject=\''.$subject.'\', mail_body=\''.$body.'\' WHERE mail_nom="'. \includes\SQL::quote($nom_mail).'" ';
-            $result1 = \includes\SQL::query($req_update);
+        foreach ($tab_new_values as $nom_mail => $tab_mail) {
+            $subject    = htmlspecialchars(addslashes($tab_mail['subject']));
+            $body       = htmlspecialchars(addslashes($tab_mail['body']));
+            $req_update = 'UPDATE conges_mail SET mail_subject=\'' . $subject . '\', mail_body=\'' . $body . '\' WHERE mail_nom="' . \includes\SQL::quote($nom_mail) . '" ';
+            $result1    = \includes\SQL::query($req_update);
         }
         $return .= '<span class="messages">' . _('form_modif_ok') . '</span><br>';
 
@@ -194,18 +191,18 @@ class Fonctions
     public static function test_config($tab_new_values, $session)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
-        if($session=="") {
+        if ($session == "") {
             $URL = "$PHP_SELF?onglet=mail";
         } else {
             $URL = "$PHP_SELF?session=$session&onglet=mail";
         }
 
         // update de la table
-        $mail_array             = find_email_adress_for_user($_SESSION['userlogin']);
-        $mail_sender_name       = $mail_array[0];
-        $mail_sender_addr       = $mail_array[1];
+        $mail_array       = find_email_adress_for_user($_SESSION['userlogin']);
+        $mail_sender_name = $mail_array[0];
+        $mail_sender_addr = $mail_array[1];
         constuct_and_send_mail("valid_conges", "Test email", $mail_sender_addr, $mail_sender_name, $mail_sender_addr, "test");
         //  echo "<p>Mail sent</p>"; exit(0);
 
@@ -221,9 +218,9 @@ class Fonctions
     public static function affichage_config_mail($tab_new_values, $session)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
-        if($session=="") {
+        if ($session == "") {
             $URL = "$PHP_SELF?onglet=mail";
         } else {
             $URL = "$PHP_SELF?session=$session&onglet=mail";
@@ -237,7 +234,7 @@ class Fonctions
         // affichage de la liste des type d'absence existants
 
         //requête qui récupère les informations de la table conges_type_absence
-        $sql1 = "SELECT * FROM conges_mail ";
+        $sql1    = "SELECT * FROM conges_mail ";
         $ReqLog1 = \includes\SQL::query($sql1);
 
         $return .= '<form method="POST" action="' . $URL . '">';
@@ -248,13 +245,13 @@ class Fonctions
 
         $return .= '<form action="' . $URL . '" method="POST">';
         while ($data = $ReqLog1->fetch_array()) {
-            $mail_nom = stripslashes($data['mail_nom']);
+            $mail_nom     = stripslashes($data['mail_nom']);
             $mail_subject = stripslashes($data['mail_subject']);
-            $mail_body = stripslashes($data['mail_body']);
+            $mail_body    = stripslashes($data['mail_body']);
 
-            $legend =$mail_nom ;
-            $key = $mail_nom."_comment";
-            $comment =  _($key)  ;
+            $legend  = $mail_nom;
+            $key     = $mail_nom . "_comment";
+            $comment = _($key);
 
             $return .= '<br>';
             $table = new \App\Libraries\Structure\Table();
@@ -262,7 +259,7 @@ class Fonctions
             $subTable = new \App\Libraries\Structure\Table();
             $table->addChild($subTable);
             $childSubTable = '<tr>';
-            $childSubTable .= '<td class="config" valign="top"><b>' .  _('config_mail_subject') . '</b></td>';
+            $childSubTable .= '<td class="config" valign="top"><b>' . _('config_mail_subject') . '</b></td>';
             $childSubTable .= '<td class="config"><input class="form-control" type="text" size="80" name="tab_new_values[' . $mail_nom . '][subject]" value="' . $mail_subject . '"></td>';
             $childSubTable .= '</tr>';
             $childSubTable .= '<tr>';
@@ -311,21 +308,20 @@ class Fonctions
         verif_droits_user($session, "is_admin");
         $return = '';
 
-
         /*** initialisation des variables ***/
         /*************************************/
         // recup des parametres reçus :
         // SERVER
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
-        $action = getpost_variable('action') ;
+        $action         = getpost_variable('action');
         $tab_new_values = getpost_variable('tab_new_values');
         /*********************************/
 
-        if($action=="modif") {
+        if ($action == "modif") {
             $return .= \config\Fonctions::commit_modif($tab_new_values, $session);
         }
-        if($action=="test") {
+        if ($action == "test") {
             $return .= \config\Fonctions::test_config($tab_new_values, $session);
         }
 
@@ -337,11 +333,11 @@ class Fonctions
     // recup l'id de la derniere absence (le max puisque c'est un auto incrément)
     public static function get_last_absence_id()
     {
-        $req_1="SELECT MAX(ta_id) FROM conges_type_absence ";
+        $req_1 = "SELECT MAX(ta_id) FROM conges_type_absence ";
         $res_1 = \includes\SQL::query($req_1);
         $row_1 = $res_1->fetch_row();
-        if(!$row_1) {
-            return 0;     // si la table est vide, on renvoit 0
+        if (!$row_1) {
+            return 0; // si la table est vide, on renvoit 0
         } else {
             return $row_1[0];
         }
@@ -354,19 +350,19 @@ class Fonctions
     public static function get_tab_from_mysql_enum_field($table, $column)
     {
 
-        $tab=array();
+        $tab      = array();
         $req_enum = "DESCRIBE $table $column";
         $res_enum = \includes\SQL::query($req_enum);
 
         while ($row_enum = $res_enum->fetch_array()) {
-            $sql_type=$row_enum['Type'];
+            $sql_type = $row_enum['Type'];
             // exemple : enum('autre','labo','fonction','personne','web', ....
             $liste_enum = strstr($sql_type, '(');
-            $liste_enum = substr($liste_enum, 1);    // on vire le premier caractere
-            $liste_enum = substr($liste_enum, 0, strlen($liste_enum)-1);    // on vire le dernier caractere
-            $option = strtok($liste_enum,"','");
+            $liste_enum = substr($liste_enum, 1); // on vire le premier caractere
+            $liste_enum = substr($liste_enum, 0, strlen($liste_enum) - 1); // on vire le dernier caractere
+            $option     = strtok($liste_enum, "','");
             while ($option) {
-                $tab[]=$option;
+                $tab[]  = $option;
                 $option = strtok("','");
             }
         }
@@ -377,36 +373,35 @@ class Fonctions
     public static function commit_ajout(&$tab_new_values, $session)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
-        if($session=="") {
+        if ($session == "") {
             $URL = "$PHP_SELF?onglet=type_absence";
         } else {
             $URL = "$PHP_SELF?session=$session&onglet=type_absence";
         }
-        $tab_new_values['libelle'] = htmlentities($tab_new_values['libelle'], ENT_QUOTES | ENT_HTML401);
+        $tab_new_values['libelle']       = htmlentities($tab_new_values['libelle'], ENT_QUOTES | ENT_HTML401);
         $tab_new_values['short_libelle'] = htmlentities($tab_new_values['short_libelle']);
-        $tab_new_values['type'] = htmlentities($tab_new_values['type'], ENT_QUOTES | ENT_HTML401);
+        $tab_new_values['type']          = htmlentities($tab_new_values['type'], ENT_QUOTES | ENT_HTML401);
 
         // verif de la saisie
-        $erreur=FALSE ;
+        $erreur = false;
         // verif si pas de " ' , . ; % ?
-        if( (preg_match('/.*[?%;.,"\'].*$/', $tab_new_values['libelle'])) || (preg_match('/.*[?%;.,"\'].*$/', $tab_new_values['short_libelle'])) ) {
+        if ((preg_match('/.*[?%;.,"\'].*$/', $tab_new_values['libelle'])) || (preg_match('/.*[?%;.,"\'].*$/', $tab_new_values['short_libelle']))) {
             $return .= '<br>' . _('config_abs_saisie_not_ok') . ' : ' . _('config_abs_bad_caracteres') . ' " \' , . ; % ? <br>';
-            $erreur=TRUE;
+            $erreur = true;
         }
         // verif si les champs sont vides
-        if( (strlen($tab_new_values['libelle'])==0) || (strlen($tab_new_values['short_libelle'])==0) || (strlen($tab_new_values['type'])==0) ) {
+        if ((strlen($tab_new_values['libelle']) == 0) || (strlen($tab_new_values['short_libelle']) == 0) || (strlen($tab_new_values['type']) == 0)) {
             $return .= '<br>' . _('config_abs_saisie_not_ok') . ' : ' . _('config_abs_champs_vides') . '<br>';
-            $erreur=TRUE;
+            $erreur = true;
         }
 
-
-        if($erreur) {
+        if ($erreur) {
             $return .= '<br>';
             $return .= '<form action="' . $URL . '" method="POST">';
             $return .= '<input type="hidden" name="id_to_update" value="' . $id_to_update . '">';
-            $return .= '<input type="hidden" name="tab_new_values[libelle]" value="' . $tab_new_values['libelle']. '">';
+            $return .= '<input type="hidden" name="tab_new_values[libelle]" value="' . $tab_new_values['libelle'] . '">';
             $return .= '<input type="hidden" name="tab_new_values[short_libelle]" value="' . $tab_new_values['short_libelle'] . '">';
             $return .= '<input type="hidden" name="tab_new_values[type]" value="' . $tab_new_values['type'] . '">';
             $return .= '<input type="submit" value="' . _('form_redo') . '" >';
@@ -414,25 +409,25 @@ class Fonctions
             $return .= '<br><br>';
         } else {
             // ajout dans la table conges_type_absence
-            $req_insert1="INSERT INTO conges_type_absence (ta_libelle, ta_short_libelle, ta_type) " .
-                "VALUES ('".$tab_new_values['libelle']."', '".$tab_new_values['short_libelle']."', '".$tab_new_values['type']."') ";
+            $req_insert1 = "INSERT INTO conges_type_absence (ta_libelle, ta_short_libelle, ta_type) " .
+                "VALUES ('" . $tab_new_values['libelle'] . "', '" . $tab_new_values['short_libelle'] . "', '" . $tab_new_values['type'] . "') ";
             $result1 = \includes\SQL::query($req_insert1);
 
             // on recup l'id de l'absence qu'on vient de créer
             $new_abs_id = \config\Fonctions::get_last_absence_id();
 
-            if($new_abs_id!=0) {
+            if ($new_abs_id != 0) {
                 // ajout dans la table conges_solde_user (pour chaque user !!)(si c'est un conges, pas si c'est une absence)
-                if( ($tab_new_values['type']=="conges") || ($tab_new_values['type']=="conges_exceptionnels") ) {
+                if (($tab_new_values['type'] == "conges") || ($tab_new_values['type'] == "conges_exceptionnels")) {
                     // recup de users :
-                    $sql_users="SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' " ;
+                    $sql_users = "SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ";
 
                     $ReqLog_users = \includes\SQL::query($sql_users);
 
                     while ($resultat1 = $ReqLog_users->fetch_array()) {
-                        $current_login=$resultat1["u_login"];
+                        $current_login = $resultat1["u_login"];
 
-                        $req_insert2="INSERT INTO conges_solde_user (su_login, su_abs_id, su_nb_an, su_solde, su_reliquat) " .
+                        $req_insert2 = "INSERT INTO conges_solde_user (su_login, su_abs_id, su_nb_an, su_solde, su_reliquat) " .
                             "VALUES ('$current_login', $new_abs_id, 0, 0, 0) ";
                         $result2 = \includes\SQL::query($req_insert2);
                     }
@@ -440,7 +435,7 @@ class Fonctions
                 $return .= '<span class="messages">' . _('form_modif_ok') . '</span><br>';
             }
 
-            $comment_log = "config : ajout_type_absence : ".$tab_new_values['libelle']."  (".$tab_new_values['short_libelle'].") (type : ".$tab_new_values['type'].") ";
+            $comment_log = "config : ajout_type_absence : " . $tab_new_values['libelle'] . "  (" . $tab_new_values['short_libelle'] . ") (type : " . $tab_new_values['type'] . ") ";
             log_action(0, "", "", $comment_log);
             $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $URL . '">';
         }
@@ -450,21 +445,21 @@ class Fonctions
     public static function commit_suppr($session, $id_to_update)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
-        if($session=="") {
+        if ($session == "") {
             $URL = "$PHP_SELF?onglet=type_absence";
         } else {
             $URL = "$PHP_SELF?session=$session&onglet=type_absence";
         }
 
         // delete dans la table conges_type_absence
-        $req_delete1='DELETE FROM conges_type_absence WHERE ta_id='. \includes\SQL::quote($id_to_update);
-        $result1 = \includes\SQL::query($req_delete1);
+        $req_delete1 = 'DELETE FROM conges_type_absence WHERE ta_id=' . \includes\SQL::quote($id_to_update);
+        $result1     = \includes\SQL::query($req_delete1);
 
         // delete dans la table conges_solde_user
-        $req_delete2='DELETE FROM conges_solde_user WHERE su_abs_id='.\includes\SQL::quote($id_to_update);
-        $result2 = \includes\SQL::query($req_delete2);
+        $req_delete2 = 'DELETE FROM conges_solde_user WHERE su_abs_id=' . \includes\SQL::quote($id_to_update);
+        $result2     = \includes\SQL::query($req_delete2);
 
         $return .= '<span class="messages">' . _('form_modif_ok') . '</span><br>';
 
@@ -478,23 +473,22 @@ class Fonctions
     public static function supprimer($session, $id_to_update)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
-        if($session=="") {
+        if ($session == "") {
             $URL = "$PHP_SELF?onglet=type_absence";
         } else {
             $URL = "$PHP_SELF?session=$session&onglet=type_absence";
         }
 
-
         // verif si pas de periode de ce type de conges !!!
         //requête qui récupère les informations de la table conges_periode
-        $sql1 = 'SELECT p_num FROM conges_periode WHERE p_type="'. \includes\SQL::quote($id_to_update).'"';
+        $sql1    = 'SELECT p_num FROM conges_periode WHERE p_type="' . \includes\SQL::quote($id_to_update) . '"';
         $ReqLog1 = \includes\SQL::query($sql1);
 
-        $count= ($ReqLog1->num_rows) ;
+        $count = ($ReqLog1->num_rows);
 
-        if( $count!=0 ) {
+        if ($count != 0) {
             $return .= '<center>';
             $return .= '<br>' . _('config_abs_suppr_impossible') . '<br>' . _('config_abs_already_used') . '<br>';
 
@@ -531,37 +525,36 @@ class Fonctions
     public static function commit_modif_absence(&$tab_new_values, $session, $id_to_update)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
-        if($session=="") {
+        if ($session == "") {
             $URL = "$PHP_SELF";
         } else {
             $URL = "$PHP_SELF?session=$session";
         }
 
-
         // verif de la saisie
-        $erreur=FALSE ;
+        $erreur = false;
         // verif si pas de " ' , . ; % ?
-        if( (preg_match('/.*[?%;.,"\'].*$/', $tab_new_values['libelle'])) || (preg_match('/.*[?%;.,"\'].*$/', $tab_new_values['short_libelle'])) ) {
+        if ((preg_match('/.*[?%;.,"\'].*$/', $tab_new_values['libelle'])) || (preg_match('/.*[?%;.,"\'].*$/', $tab_new_values['short_libelle']))) {
             $return .= '<br>' . _('config_abs_saisie_not_ok') . ' : ' . _('config_abs_bad_caracteres') . ' " \' , . ; % ? <br>';
-            $erreur=TRUE;
+            $erreur = true;
         }
         // verif si les champs sont vides
-        if( (strlen($tab_new_values['libelle'])==0) || (strlen($tab_new_values['short_libelle'])==0) ) {
+        if ((strlen($tab_new_values['libelle']) == 0) || (strlen($tab_new_values['short_libelle']) == 0)) {
             $return .= '<br>' . _('config_abs_saisie_not_ok') . ' : ' . _('config_abs_champs_vides') . '<br>';
-            $erreur=TRUE;
+            $erreur = true;
         }
 
-        if($erreur) {
+        if ($erreur) {
             $return .= '<br>';
-            if($session=="") {
+            if ($session == "") {
                 $return .= '<form action="' . $PHP_SELF . '?onglet=type_absence" method="POST">';
             } else {
                 $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=type_absence" method="POST">';
             }
             $return .= '<input type="hidden" name="action" value="modif">';
-            $return .= '<input type="hidden" name="id_to_update" value="' . $id_to_update .'">';
+            $return .= '<input type="hidden" name="id_to_update" value="' . $id_to_update . '">';
             $return .= '<input type="hidden" name="tab_new_values[libelle]" value="' . $tab_new_values['libelle'] . '">';
             $return .= '<input type="hidden" name="tab_new_values[short_libelle]" value="' . $tab_new_values['short_libelle'] . '">';
             $return .= '<input type="submit" value="' . _('form_redo') . '" >';
@@ -569,12 +562,12 @@ class Fonctions
             $return .= '<br><br>';
         } else {
             // update de la table
-            $req_update='UPDATE conges_type_absence SET ta_libelle=\''.$tab_new_values['libelle'].'\', ta_short_libelle=\''.$tab_new_values['short_libelle'].'\' WHERE ta_id="'. \includes\SQL::quote($id_to_update).'" ';
-            $result1 = \includes\SQL::query($req_update);
+            $req_update = 'UPDATE conges_type_absence SET ta_libelle=\'' . $tab_new_values['libelle'] . '\', ta_short_libelle=\'' . $tab_new_values['short_libelle'] . '\' WHERE ta_id="' . \includes\SQL::quote($id_to_update) . '" ';
+            $result1    = \includes\SQL::query($req_update);
 
             $return .= '<span class="messages">' . _('form_modif_ok') . '</span><br>';
 
-            $comment_log = "config : modif_type_absence ($id_to_update): ".$tab_new_values['libelle']."  (".$tab_new_values['short_libelle'].") ";
+            $comment_log = "config : modif_type_absence ($id_to_update): " . $tab_new_values['libelle'] . "  (" . $tab_new_values['short_libelle'] . ") ";
             log_action(0, "", "", $comment_log);
             $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $URL . '">';
         }
@@ -584,9 +577,9 @@ class Fonctions
     public static function modifier(&$tab_new_values, $session, $id_to_update)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
-        if($session=="") {
+        if ($session == "") {
             $URL = "$PHP_SELF?onglet=type_absence";
         } else {
             $URL = "$PHP_SELF?session=$session&onglet=type_absence";
@@ -598,21 +591,21 @@ class Fonctions
         $return .= '<br>';
 
         // recup des infos du type de conges / absences
-        $sql_cong='SELECT ta_type, ta_libelle, ta_short_libelle FROM conges_type_absence WHERE ta_id = '. \includes\SQL::quote($id_to_update);
+        $sql_cong = 'SELECT ta_type, ta_libelle, ta_short_libelle FROM conges_type_absence WHERE ta_id = ' . \includes\SQL::quote($id_to_update);
 
         $ReqLog_cong = \includes\SQL::query($sql_cong);
 
-        if($resultat_cong = $ReqLog_cong->fetch_array()) {
-            $sql_type=$resultat_cong['ta_type'];
-            $sql_libelle= $resultat_cong['ta_libelle'];
-            $sql_short_libelle= $resultat_cong['ta_short_libelle'];
+        if ($resultat_cong = $ReqLog_cong->fetch_array()) {
+            $sql_type          = $resultat_cong['ta_type'];
+            $sql_libelle       = $resultat_cong['ta_libelle'];
+            $sql_short_libelle = $resultat_cong['ta_short_libelle'];
         }
 
         // mise en place du formulaire
         $return .= '<form action="' . $URL . '" method="POST">';
 
-        $text_libelle ="<input class=\"form-control\" type=\"text\" name=\"tab_new_values[libelle]\" size=\"20\" maxlength=\"20\" value=\"$sql_libelle\" >";
-        $text_short_libelle ="<input class=\"form-control\" type=\"text\" name=\"tab_new_values[short_libelle]\" size=\"3\" maxlength=\"3\" value=\"$sql_short_libelle\" >";
+        $text_libelle       = "<input class=\"form-control\" type=\"text\" name=\"tab_new_values[libelle]\" size=\"20\" maxlength=\"20\" value=\"$sql_libelle\" >";
+        $text_short_libelle = "<input class=\"form-control\" type=\"text\" name=\"tab_new_values[short_libelle]\" size=\"3\" maxlength=\"3\" value=\"$sql_short_libelle\" >";
 
         // affichage
         $table = new \App\Libraries\Structure\Table();
@@ -644,12 +637,12 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage_absence($tab_new_values,$session)
+    public static function affichage_absence($tab_new_values, $session)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
-        if($session=="") {
+        if ($session == "") {
             $URL = "$PHP_SELF?onglet=type_absence";
         } else {
             $URL = "$PHP_SELF?session=$session&onglet=type_absence";
@@ -662,35 +655,34 @@ class Fonctions
 
         // affiche_bouton_retour($session);
 
-
         // affichage de la liste des type d'absence existants
 
         $tab_enum = \config\Fonctions::get_tab_from_mysql_enum_field("conges_type_absence", "ta_type");
 
-        foreach($tab_enum as $ta_type) {
-            if( ($ta_type=="conges_exceptionnels") &&  ($_SESSION['config']['gestion_conges_exceptionnels']==FALSE)) {
+        foreach ($tab_enum as $ta_type) {
+            if (($ta_type == "conges_exceptionnels") && ($_SESSION['config']['gestion_conges_exceptionnels'] == false)) {
             } else {
-                $divers_maj_1 = 'divers_' . $ta_type . '_maj_1';
+                $divers_maj_1       = 'divers_' . $ta_type . '_maj_1';
                 $config_abs_comment = 'config_abs_comment_' . $ta_type;
 
-                $legend= _($divers_maj_1)  ;
-                $comment= _($config_abs_comment)  ;
+                $legend  = _($divers_maj_1);
+                $comment = _($config_abs_comment);
 
                 $return .= '<h2>' . $legend . '</h2>';
                 $return .= '<p>' . $comment . '</p>';
 
                 //requête qui récupère les informations de la table conges_type_absence
-                $sql1 = 'SELECT * FROM conges_type_absence WHERE ta_type = "'. \includes\SQL::quote($ta_type).'"';
+                $sql1    = 'SELECT * FROM conges_type_absence WHERE ta_type = "' . \includes\SQL::quote($ta_type) . '"';
                 $ReqLog1 = \includes\SQL::query($sql1);
 
-                if($ReqLog1->num_rows !=0) {
+                if ($ReqLog1->num_rows != 0) {
                     $table = new \App\Libraries\Structure\Table();
                     $table->addClasses([
                         'table',
                         'table-hover',
                         'table-responsive',
                         'table-condensed',
-                        'table-striped'
+                        'table-striped',
                     ]);
                     $childTable = '<tr>';
                     $childTable .= '<th>' . _('config_abs_libelle') . '</th>';
@@ -699,16 +691,16 @@ class Fonctions
                     $childTable .= '</tr>';
 
                     while ($data = $ReqLog1->fetch_array()) {
-                        $ta_id = $data['ta_id'];
-                        $ta_libelle = $data['ta_libelle'];
+                        $ta_id            = $data['ta_id'];
+                        $ta_libelle       = $data['ta_libelle'];
                         $ta_short_libelle = $data['ta_short_libelle'];
 
-                        if($session=="") {
-                            $text_modif="<a href=\"$PHP_SELF?action=modif&id_to_update=$ta_id&onglet=type_absence\" title=\"". _('form_modif') ."\"><i class=\"fa fa-pencil\"></i></a>";
-                            $text_suppr="<a href=\"$PHP_SELF?action=suppr&id_to_update=$ta_id&onglet=type_absence\" title=\"". _('form_supprim') ."\"><i class=\"fa fa-times-circle\"></i></a>";
+                        if ($session == "") {
+                            $text_modif = "<a href=\"$PHP_SELF?action=modif&id_to_update=$ta_id&onglet=type_absence\" title=\"" . _('form_modif') . "\"><i class=\"fa fa-pencil\"></i></a>";
+                            $text_suppr = "<a href=\"$PHP_SELF?action=suppr&id_to_update=$ta_id&onglet=type_absence\" title=\"" . _('form_supprim') . "\"><i class=\"fa fa-times-circle\"></i></a>";
                         } else {
-                            $text_modif="<a href=\"$PHP_SELF?session=$session&action=modif&id_to_update=$ta_id&onglet=type_absence\" title=\"". _('form_modif') ."\"><i class=\"fa fa-pencil\"></i></a>";
-                            $text_suppr="<a href=\"$PHP_SELF?session=$session&action=suppr&id_to_update=$ta_id&onglet=type_absence\" title=\"". _('form_supprim') ."\"><i class=\"fa fa-times-circle\"></i></a>";
+                            $text_modif = "<a href=\"$PHP_SELF?session=$session&action=modif&id_to_update=$ta_id&onglet=type_absence\" title=\"" . _('form_modif') . "\"><i class=\"fa fa-pencil\"></i></a>";
+                            $text_suppr = "<a href=\"$PHP_SELF?session=$session&action=suppr&id_to_update=$ta_id&onglet=type_absence\" title=\"" . _('form_supprim') . "\"><i class=\"fa fa-times-circle\"></i></a>";
                         }
 
                         $childTable .= '<tr><td><strong>' . $ta_libelle . '</strong></td><td>' . $ta_short_libelle . '</td><td class="action">' . $text_modif . '&nbsp;' . $text_suppr . '</td></tr>';
@@ -733,7 +725,7 @@ class Fonctions
             'table-hover',
             'table-responsive',
             'table-condensed',
-            'table-striped'
+            'table-striped',
         ]);
 
         $childTableAjout = '<tr>';
@@ -742,19 +734,19 @@ class Fonctions
         $childTableAjout .= '<th>' . _('divers_type') . '</th>';
         $childTableAjout .= '</tr>';
         $childTableAjout .= '<tr>';
-        $new_libelle = ( isset($tab_new_values['libelle']) ? $tab_new_values['libelle'] : "" );
-        $new_short_libelle = ( isset($tab_new_values['short_libelle']) ? $tab_new_values['short_libelle'] : "" ) ;
-        $new_type = ( isset($tab_new_values['type']) ? $tab_new_values['type'] : "" ) ;
+        $new_libelle       = (isset($tab_new_values['libelle']) ? $tab_new_values['libelle'] : "");
+        $new_short_libelle = (isset($tab_new_values['short_libelle']) ? $tab_new_values['short_libelle'] : "");
+        $new_type          = (isset($tab_new_values['type']) ? $tab_new_values['type'] : "");
         $childTableAjout .= '<td><input class="form-control" type="text" name="tab_new_values[libelle]" size="20" maxlength="20" value="' . $new_libelle . '"></td>';
         $childTableAjout .= '<td><input class="form-control" type="text" name="tab_new_values[short_libelle]" size="3" maxlength="3" value="' . $new_short_libelle . '" ></td>';
         $childTableAjout .= '<td>';
 
         $childTableAjout .= '<select class="form-control" name=tab_new_values[type]>';
 
-        foreach($tab_enum as $option) {
-            if( ($option=="conges_exceptionnels") &&  ($_SESSION['config']['gestion_conges_exceptionnels']==FALSE)) {
+        foreach ($tab_enum as $option) {
+            if (($option == "conges_exceptionnels") && ($_SESSION['config']['gestion_conges_exceptionnels'] == false)) {
             } else {
-                if($option==$new_type) {
+                if ($option == $new_type) {
                     $childTableAjout .= '<option selected>' . $option . '</option>';
                 } else {
                     $childTableAjout .= '<option>' . $option . '</option>';
@@ -785,24 +777,22 @@ class Fonctions
      */
     public static function typeAbsenceModule()
     {
-        $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : "") ) ;
-        $return = '';
+        $session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : ""));
+        $return  = '';
 
-        if (file_exists(CONFIG_PATH .'config_ldap.php')) {
-            include_once CONFIG_PATH .'config_ldap.php';
+        if (file_exists(CONFIG_PATH . 'config_ldap.php')) {
+            include_once CONFIG_PATH . 'config_ldap.php';
         }
 
         // include_once ROOT_PATH .'fonctions_conges.php' ;
         // include_once INCLUDE_PATH .'fonction.php';
-        if(!isset($_SESSION['config'])) {
-            $_SESSION['config']=init_config_tab();      // on initialise le tableau des variables de config
+        if (!isset($_SESSION['config'])) {
+            $_SESSION['config'] = init_config_tab(); // on initialise le tableau des variables de config
         }
-        include_once INCLUDE_PATH .'session.php';
+        include_once INCLUDE_PATH . 'session.php';
 
         // verif des droits du user à afficher la page
         verif_droits_user($session, "is_admin");
-
-
 
         /*** initialisation des variables ***/
         /*************************************/
@@ -810,21 +800,21 @@ class Fonctions
         // SERVER
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
-        $action         = getpost_variable('action') ;
+        $action         = getpost_variable('action');
         $tab_new_values = getpost_variable('tab_new_values');
         $id_to_update   = htmlentities(getpost_variable('id_to_update'), ENT_QUOTES | ENT_HTML401);
 
         /*********************************/
 
-        if($action=="new") {
-            $return .= \config\Fonctions::commit_ajout($tab_new_values,$session);
-        } elseif($action=="modif") {
+        if ($action == "new") {
+            $return .= \config\Fonctions::commit_ajout($tab_new_values, $session);
+        } elseif ($action == "modif") {
             $return .= \config\Fonctions::modifier($tab_new_values, $session, $id_to_update);
-        } elseif($action=="commit_modif") {
+        } elseif ($action == "commit_modif") {
             $return .= \config\Fonctions::commit_modif_absence($tab_new_values, $session, $id_to_update);
-        } elseif($action=="suppr") {
+        } elseif ($action == "suppr") {
             $return .= \config\Fonctions::supprimer($session, $id_to_update);
-        } elseif($action=="commit_suppr") {
+        } elseif ($action == "commit_suppr") {
             $return .= \config\Fonctions::commit_suppr($session, $id_to_update);
         } else {
             $return .= \config\Fonctions::affichage_absence($tab_new_values, $session);
@@ -836,70 +826,70 @@ class Fonctions
     public static function commit_saisie(&$tab_new_values, $session)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
-        if($session=="") {
+        if ($session == "") {
             $URL = "$PHP_SELF";
         } else {
             $URL = "$PHP_SELF?session=$session";
         }
 
-        $timeout=2 ;  // temps d'attente pour rafraichir l'écran après l'update !
+        $timeout = 2; // temps d'attente pour rafraichir l'écran après l'update !
 
-        foreach($tab_new_values as $key => $value ) {
+        foreach ($tab_new_values as $key => $value) {
             $value = htmlentities($value, ENT_QUOTES | ENT_HTML401);
             // CONTROLE gestion_conges_exceptionnels
             // si désactivation les conges exceptionnels, on verif s'il y a des conges exceptionnels enregistres ! si oui : changement impossible !
-            if(($key=="gestion_conges_exceptionnels") && ($value=="FALSE") ) {
-                $sql_abs="SELECT ta_id, ta_libelle FROM conges_type_absence WHERE ta_type='conges_exceptionnels' ";
+            if (($key == "gestion_conges_exceptionnels") && ($value == "FALSE")) {
+                $sql_abs    = "SELECT ta_id, ta_libelle FROM conges_type_absence WHERE ta_type='conges_exceptionnels' ";
                 $ReqLog_abs = \includes\SQL::query($sql_abs);
 
-                if($ReqLog_abs->num_rows !=0) {
+                if ($ReqLog_abs->num_rows != 0) {
                     $return .= '<b>' . _('config_abs_desactive_cong_excep_impossible') . '</b><br>';
-                    $value = "TRUE" ;
-                    $timeout=5 ;
+                    $value   = "TRUE";
+                    $timeout = 5;
                 }
             }
 
             // CONTROLE jour_mois_limite_reliquats
             // si modif de jour_mois_limite_reliquats, on verifie le format ( 0 ou jj-mm) , sinon : changement impossible !
-            if( ($key=="jour_mois_limite_reliquats") && ($value!= "0") ) {
-                $t=explode("-", $value);
-                if(checkdate($t[1], $t[0], date("Y"))==FALSE) {
+            if (($key == "jour_mois_limite_reliquats") && ($value != "0")) {
+                $t = explode("-", $value);
+                if (checkdate($t[1], $t[0], date("Y")) == false) {
                     $return .= '<b>' . _('config_jour_mois_limite_reliquats_modif_impossible') . '</b><br>';
-                    $sql_date="SELECT conf_valeur FROM conges_config WHERE conf_nom='jour_mois_limite_reliquats' ";
+                    $sql_date    = "SELECT conf_valeur FROM conges_config WHERE conf_nom='jour_mois_limite_reliquats' ";
                     $ReqLog_date = \includes\SQL::query($sql_date);
-                    $data = $ReqLog_date->fetch_row();
-                    $value = $data[0] ;
-                    $timeout=5 ;
+                    $data        = $ReqLog_date->fetch_row();
+                    $value       = $data[0];
+                    $timeout     = 5;
                 }
             }
 
-            if(preg_match("/_installed$/",$key) && ($value=="1")) {
-                $plugin = explode("_",$key);
+            if (preg_match("/_installed$/", $key) && ($value == "1")) {
+                $plugin = explode("_", $key);
                 $plugin = $plugin[0];
                 install_plugin($plugin);
-            } elseif(preg_match("/_installed$/",$key) && ($value=="0")) {
-                $plugin = explode("_",$key);
+            } elseif (preg_match("/_installed$/", $key) && ($value == "0")) {
+                $plugin = explode("_", $key);
                 $plugin = $plugin[0];
                 uninstall_plugin($plugin);
             }
-            if(preg_match("/_activated$/",$key) && ($value=="1")) {
-                $plugin = explode("_",$key);
+            if (preg_match("/_activated$/", $key) && ($value == "1")) {
+                $plugin = explode("_", $key);
                 $plugin = $plugin[0];
                 activate_plugin($plugin);
-            } elseif(preg_match("/_activated$/",$key) && ($value=="0")) {
-                $plugin = explode("_",$key);
+            } elseif (preg_match("/_activated$/", $key) && ($value == "0")) {
+                $plugin = explode("_", $key);
                 $plugin = $plugin[0];
                 disable_plugin($plugin);
             }
 
             // Mise à jour
-            $sql2 = 'UPDATE conges_config SET conf_valeur = \''.addslashes($value).'\' WHERE conf_nom ="'. \includes\SQL::quote($key).'" ';
+            $sql2    = 'UPDATE conges_config SET conf_valeur = \'' . addslashes($value) . '\' WHERE conf_nom ="' . \includes\SQL::quote($key) . '" ';
             $ReqLog2 = \includes\SQL::query($sql2);
         }
 
-        $_SESSION['config']=init_config_tab();      // on re-initialise le tableau des variables de config
+        $_SESSION['config'] = init_config_tab(); // on re-initialise le tableau des variables de config
 
         // enregistrement dans les logs
         $comment_log = "nouvelle configuration de php_conges ";
@@ -914,14 +904,13 @@ class Fonctions
     public static function affichage_configuration($session)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $return = '';
+        $return   = '';
 
         // affiche_bouton_retour($session);
 
-
         // affichage de la liste des variables
 
-        if($session=="") {
+        if ($session == "") {
             $return .= '<form action="' . $PHP_SELF . '" method="POST">';
         } else {
             $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
@@ -929,11 +918,11 @@ class Fonctions
         $return .= '<input type="hidden" name="action" value="commit">';
 
         //requête qui récupère les informations de config
-        $sql1 = "SELECT * FROM conges_config ORDER BY conf_groupe ASC";
+        $sql1    = "SELECT * FROM conges_config ORDER BY conf_groupe ASC";
         $ReqLog1 = \includes\SQL::query($sql1);
 
-        $old_groupe="";
-        $config = [];
+        $old_groupe = "";
+        $config     = [];
         while ($data = $ReqLog1->fetch_array()) {
             $config[$data['conf_groupe']][] = $data;
         }
@@ -943,18 +932,18 @@ class Fonctions
             $table = new \App\Libraries\Structure\Table();
             $table->addAttribute('width', '100%');
             $childTable = '<tr><td>';
-            $childTable .= '<fieldset class="cal_saisie '. $groupName . '">';
+            $childTable .= '<fieldset class="cal_saisie ' . $groupName . '">';
             $childTable .= '<legend class="boxlogin">' . _($groupName) . '</legend>';
 
             foreach ($group as $data) {
-                $conf_nom = $data['conf_nom'];
-                $conf_valeur = $data['conf_valeur'];
-                $conf_groupe = $data['conf_groupe'];
-                $conf_type = strtolower($data['conf_type']);
+                $conf_nom         = $data['conf_nom'];
+                $conf_valeur      = $data['conf_valeur'];
+                $conf_groupe      = $data['conf_groupe'];
+                $conf_type        = strtolower($data['conf_type']);
                 $conf_commentaire = strtolower($data['conf_commentaire']);
 
-                if($conf_nom=="lang") {
-                    $childTable .= _('choisir_langue').'<br>';
+                if ($conf_nom == "lang") {
+                    $childTable .= _('choisir_langue') . '<br>';
                     // affichage de la liste des langues supportées ...
                     // on lit le contenu du répertoire lang et on parse les nom de ficher (ex lang_fr_francais.php)
                     //affiche_select_from_lang_directory("tab_new_values[$conf_nom]");
@@ -964,29 +953,29 @@ class Fonctions
                     $childTable .= '<br><i>' . _($conf_commentaire) . '</i><br>';
 
                     // affichage saisie variable
-                    if($conf_nom=="installed_version") {
+                    if ($conf_nom == "installed_version") {
                         $childTable .= '<b>' . $conf_nom . '&nbsp;&nbsp;=&nbsp;&nbsp;' . $conf_valeur . '</b><br>';
-                    } elseif( ($conf_type=="texte") || ($conf_type=="path") ) {
+                    } elseif (($conf_type == "texte") || ($conf_type == "path")) {
                         $childTable .= '<b>' . $conf_nom . '</b>&nbsp;=&nbsp;<input type="text" class="form-control" size="50" maxlength="200" name="tab_new_values[' . $conf_nom . ']" value="' . $conf_valeur . '"><br>';
-                    } elseif($conf_type=="boolean") {
+                    } elseif ($conf_type == "boolean") {
                         $childTable .= '<b>' . $conf_nom . '</b>&nbsp;=&nbsp;<select class="form-control" name="tab_new_values[' . $conf_nom . ']">';
                         $childTable .= '<option value="TRUE"';
-                        if($conf_valeur=="TRUE") {
+                        if ($conf_valeur == "TRUE") {
                             $childTable .= ' selected';
                         }
                         $childTable .= '>TRUE</option>';
                         $childTable .= '<option value="FALSE"';
-                        if($conf_valeur=="FALSE") {
+                        if ($conf_valeur == "FALSE") {
                             $childTable .= ' selected';
                         }
                         $childTable .= '>FALSE</option>';
                         $childTable .= '</select><br>';
-                    } elseif(substr($conf_type,0,4)=="enum") {
+                    } elseif (substr($conf_type, 0, 4) == "enum") {
                         $childTable .= '<b>' . $conf_nom . '</b>&nbsp;=&nbsp;<select class="form-control" name="tab_new_values[' . $conf_nom . ']">';
-                        $options=explode("/", substr(strstr($conf_type, '='),1));
-                        for($i=0; $i<count($options); $i++) {
+                        $options = explode("/", substr(strstr($conf_type, '='), 1));
+                        for ($i = 0; $i < count($options); $i++) {
                             $childTable .= '<option value="' . $options[$i] . '"';
-                            if($conf_valeur==$options[$i]) {
+                            if ($conf_valeur == $options[$i]) {
                                 $childTable .= ' selected';
                             }
                             $childTable .= '>' . $options[$i] . '</option>';
@@ -1006,7 +995,6 @@ class Fonctions
             $table->render();
             $return .= ob_get_clean();
         }
-
 
         /******************* GESTION DES PLUGINS V1.7 *************************/
 
@@ -1032,16 +1020,16 @@ class Fonctions
         $childTableAddon = '<tr><td>';
         $childTableAddon .= '<fieldset class="cal_saisie plugins">';
         $childTableAddon .= '<legend class="boxlogin">Plugins</legend>';
-        foreach($my_plugins as $my_plugin) {
-            if(is_dir(PLUGINS_DIR."/$my_plugin") && !preg_match("/^\./",$my_plugin)) {
-                $childTableAddon .= _('plugin_detect').'<br>';
-                $childTableAddon .= '<b>' . $my_plugin . ' : </b>'._('plugin_install').'
+        foreach ($my_plugins as $my_plugin) {
+            if (is_dir(PLUGINS_DIR . "/$my_plugin") && !preg_match("/^\./", $my_plugin)) {
+                $childTableAddon .= _('plugin_detect') . '<br>';
+                $childTableAddon .= '<b>' . $my_plugin . ' : </b>' . _('plugin_install') . '
                     <select class="form-control" name=tab_new_values[' . $my_plugin . '_installed]>';
 
-                $sql_plug="SELECT p_is_active, p_is_install FROM conges_plugins WHERE p_name = '".$my_plugin."';";
+                $sql_plug    = "SELECT p_is_active, p_is_install FROM conges_plugins WHERE p_name = '" . $my_plugin . "';";
                 $ReqLog_plug = \includes\SQL::query($sql_plug);
-                if($ReqLog_plug->num_rows !=0) {
-                    while($plug = $ReqLog_plug->fetch_array()){
+                if ($ReqLog_plug->num_rows != 0) {
+                    while ($plug = $ReqLog_plug->fetch_array()) {
                         $p_install = $plug["p_is_install"];
                         if ($p_install == '1') {
                             $childTableAddon .= '<option selected="selected" value="1">Y</option><option value="0">N</option>';
@@ -1049,7 +1037,7 @@ class Fonctions
                             $childTableAddon .= '<option value="1">Y</option><option selected="selected" value="0">N</option>';
                         }
                         $childTableAddon .= '</select>';
-                        $childTableAddon .= _('plugin_active').' <select class="form-control" name=tab_new_values[' . $my_plugin . '_activated]>';
+                        $childTableAddon .= _('plugin_active') . ' <select class="form-control" name=tab_new_values[' . $my_plugin . '_activated]>';
                         $p_active = $plug["p_is_active"];
                         if ($p_active == '1') {
                             $childTableAddon .= '<option selected="selected" value="1">Y</option><option value="0">N</option>';
@@ -1060,7 +1048,7 @@ class Fonctions
                 } else {
                     $childTableAddon .= '<option value="1">Y</option><option selected="selected" value="0">N</option>';
                     $childTableAddon .= '</select>';
-                    $childTableAddon .= _('plugin_active').' <select class="form-control" name=tab_new_values[' . $my_plugin . '_activated]>';
+                    $childTableAddon .= _('plugin_active') . ' <select class="form-control" name=tab_new_values[' . $my_plugin . '_activated]>';
                     $childTableAddon .= '<option value="1">Y</option><option selected="selected" value="0">N</option>';
                 }
                 $childTableAddon .= '</select>';
@@ -1068,7 +1056,7 @@ class Fonctions
                 $plug_count++;
             }
         }
-        if($plug_count == 0){
+        if ($plug_count == 0) {
             $childTableAddon .= _('no_plugin');
         }
         $childTableAddon .= '</td></tr>';
@@ -1101,8 +1089,8 @@ class Fonctions
         $return = '';
 
         /*** initialisation des variables ***/
-        $action="";
-        $tab_new_values=array();
+        $action         = "";
+        $tab_new_values = array();
         /************************************/
 
         /*************************************/
@@ -1110,12 +1098,12 @@ class Fonctions
         // SERVER
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
-        $action         = getpost_variable('action') ;
+        $action         = getpost_variable('action');
         $tab_new_values = getpost_variable('tab_new_values');
 
         /*************************************/
 
-        if($action=="commit") {
+        if ($action == "commit") {
             $return .= \config\Fonctions::commit_saisie($tab_new_values, $session);
         } else {
             $return .= '<div class="wrapper configure">';

--- a/config/config_logs.php
+++ b/config/config_logs.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \config\Fonctions::logModule($session);

--- a/config/config_type_absence.php
+++ b/config/config_type_absence.php
@@ -1,7 +1,7 @@
 <?php
 
 include_once ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
 echo \config\Fonctions::typeAbsenceModule();
 bottom();

--- a/config/index.php
+++ b/config/index.php
@@ -4,89 +4,89 @@ define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 include_once INCLUDE_PATH . 'fonction.php';
 
-$session =(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
 if (empty($session)) {
-	redirect(ROOT_PATH . 'index.php?return_url=config/index.php');
+    redirect(ROOT_PATH . 'index.php?return_url=config/index.php');
 }
 
+include_once ROOT_PATH . 'fonctions_conges.php';
 
-include_once ROOT_PATH .'fonctions_conges.php' ;
-
-$_SESSION['config']=init_config_tab();      // on initialise le tableau des variables de config
-include_once INCLUDE_PATH .'session.php';
+$_SESSION['config'] = init_config_tab(); // on initialise le tableau des variables de config
+include_once INCLUDE_PATH . 'session.php';
 
 $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
-$session=session_id();
+$session = session_id();
 
 // verif des droits du user à afficher la page
 verif_droits_user($session, "is_admin");
 
-$_SESSION['from_config']=TRUE;  // initialise ce flag pour changer le bouton de retour des popup
+$_SESSION['from_config'] = true; // initialise ce flag pour changer le bouton de retour des popup
 
-	$onglet = htmlentities(getpost_variable('onglet'), ENT_QUOTES | ENT_HTML401);
+$onglet = htmlentities(getpost_variable('onglet'), ENT_QUOTES | ENT_HTML401);
 
-	if(!$onglet && $_SESSION['userlogin']=="admin")
-	{
-		$onglet = 'general';
-	} elseif (!$onglet && $_SESSION['userlogin']!="admin") {
+if (!$onglet && $_SESSION['userlogin'] == "admin") {
+    $onglet = 'general';
+} elseif (!$onglet && $_SESSION['userlogin'] != "admin") {
 
-		if($_SESSION['config']['affiche_bouton_config_pour_admin'])
-			$onglet = 'general';
-		elseif($_SESSION['config']['affiche_bouton_config_absence_pour_admin'])
-			$onglet = 'type_absence';
-		elseif($_SESSION['config']['affiche_bouton_config_mail_pour_admin'])
-			$onglet = 'config_mail';
+    if ($_SESSION['config']['affiche_bouton_config_pour_admin']) {
+        $onglet = 'general';
+    } elseif ($_SESSION['config']['affiche_bouton_config_absence_pour_admin']) {
+        $onglet = 'type_absence';
+    } elseif ($_SESSION['config']['affiche_bouton_config_mail_pour_admin']) {
+        $onglet = 'config_mail';
+    }
 
-	}
+}
 
-	/*********************************/
-	/*   COMPOSITION DES ONGLETS...  */
-	/*********************************/
+/*********************************/
+/*   COMPOSITION DES ONGLETS...  */
+/*********************************/
 
-	$onglets = array();
+$onglets = array();
 
-	if($_SESSION['config']['affiche_bouton_config_pour_admin'] || $_SESSION['userlogin']=="admin")
-		$onglets['general'] = _('install_config_appli');
+if ($_SESSION['config']['affiche_bouton_config_pour_admin'] || $_SESSION['userlogin'] == "admin") {
+    $onglets['general'] = _('install_config_appli');
+}
 
-	if($_SESSION['config']['affiche_bouton_config_absence_pour_admin'] || $_SESSION['userlogin']=="admin")
-		$onglets['type_absence'] = _('install_config_types_abs');
+if ($_SESSION['config']['affiche_bouton_config_absence_pour_admin'] || $_SESSION['userlogin'] == "admin") {
+    $onglets['type_absence'] = _('install_config_types_abs');
+}
 
-	if($_SESSION['config']['affiche_bouton_config_mail_pour_admin'] || $_SESSION['userlogin']=="admin")
-		$onglets['mail'] = _('install_config_mail');
+if ($_SESSION['config']['affiche_bouton_config_mail_pour_admin'] || $_SESSION['userlogin'] == "admin") {
+    $onglets['mail'] = _('install_config_mail');
+}
 
-	$onglets['logs'] = _('config_logs');
+$onglets['logs'] = _('config_logs');
 
-	/*********************************/
-	/*   COMPOSITION DU HEADER...    */
-	/*********************************/
+/*********************************/
+/*   COMPOSITION DU HEADER...    */
+/*********************************/
 
-	$add_css = '<style>#onglet_menu .onglet{ width: '. (str_replace(',', '.', 100 / count($onglets) )).'% ;}</style>';
-	header_menu('', 'Libertempo : '._('admin_button_config_1'),$add_css);
+$add_css = '<style>#onglet_menu .onglet{ width: ' . (str_replace(',', '.', 100 / count($onglets))) . '% ;}</style>';
+header_menu('', 'Libertempo : ' . _('admin_button_config_1'), $add_css);
 
+/*********************************/
+/*   AFFICHAGE DES ONGLETS...  */
+/*********************************/
 
-	/*********************************/
-	/*   AFFICHAGE DES ONGLETS...  */
-	/*********************************/
-
-	echo '<div id="onglet_menu">';
-	foreach($onglets as $key => $title) {
-		echo '<div class="onglet '.($onglet == $key ? ' active': '').'" >
-			<a href="'.$PHP_SELF.'?session='.$session.'&onglet='.$key.'">'. $title .'</a>
+echo '<div id="onglet_menu">';
+foreach ($onglets as $key => $title) {
+    echo '<div class="onglet ' . ($onglet == $key ? ' active' : '') . '" >
+			<a href="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $key . '">' . $title . '</a>
 		</div>';
-	}
-	echo '</div>';
+}
+echo '</div>';
 
-	echo '<div class="'.$onglet.' wrapper">';
+echo '<div class="' . $onglet . ' wrapper">';
 
-		echo '<a href="' . ROOT_PATH . "admin/admin_index.php?session=$session\" class=\"admin-back\"><i class=\"fa fa-arrow-circle-o-left\"></i>". _('form_retour')."</a>\n";
+echo '<a href="' . ROOT_PATH . "admin/admin_index.php?session=$session\" class=\"admin-back\"><i class=\"fa fa-arrow-circle-o-left\"></i>" . _('form_retour') . "</a>\n";
 
-		if($onglet == 'general') {
-			include_once ROOT_PATH . 'config/configure.php';
-		}
-		else {
-			include_once ROOT_PATH . 'config/config_'.$onglet.'.php';
-		}
+if ($onglet == 'general') {
+    include_once ROOT_PATH . 'config/configure.php';
+} else {
+    include_once ROOT_PATH . 'config/config_' . $onglet . '.php';
+}
 
-	echo '</div>';
+echo '</div>';

--- a/deconnexion.php
+++ b/deconnexion.php
@@ -3,30 +3,29 @@
 define('ROOT_PATH', '');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-include_once ROOT_PATH .'fonctions_conges.php';
-include_once INCLUDE_PATH .'fonction.php';
-include_once INCLUDE_PATH .'session.php';
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+include_once INCLUDE_PATH . 'session.php';
 
-$how_to_connect_user=$_SESSION['config']['how_to_connect_user'];
-$URL_ACCUEIL_CONGES=$_SESSION['config']['URL_ACCUEIL_CONGES'];
+$how_to_connect_user = $_SESSION['config']['how_to_connect_user'];
+$URL_ACCUEIL_CONGES  = $_SESSION['config']['URL_ACCUEIL_CONGES'];
 
-$comment_log = "Deconnexion de ".$_SESSION['userlogin'];
+$comment_log = "Deconnexion de " . $_SESSION['userlogin'];
 log_action(0, "", $_SESSION['userlogin'], $comment_log);
 
 //Dans le cas ou le système d'authentification CAS est utilisé, lorsque l'utilisateur se deconnecte,
 // on détruit le ticket qui a permis d'authentifier l'utilisateur.
-if($how_to_connect_user=="cas")
-{
-    $logoutCas=1;
+if ($how_to_connect_user == "cas") {
+    $logoutCas = 1;
     deconnexion_CAS($URL_ACCUEIL_CONGES);
 }
 
 session_delete($session);
 
-$session="";
-$session_username="";
-$session_password="";
+$session          = "";
+$session_username = "";
+$session_password = "";
 
-redirect( $URL_ACCUEIL_CONGES );
+redirect($URL_ACCUEIL_CONGES);

--- a/define.php
+++ b/define.php
@@ -1,32 +1,32 @@
 <?php
 define('_PHP_CONGES', 1);
-defined( 'ROOT_PATH' ) or die( 'ROOT_PATH not defined !' );
+defined('ROOT_PATH') or die('ROOT_PATH not defined !');
 
-if (!defined( 'DEFINE_INCLUDE' )) {
+if (!defined('DEFINE_INCLUDE')) {
     define('ENV_DEV', 1);
     define('ENV_TEST', 2);
     define('ENV_PROD', 3);
-    define('DEFINE_INCLUDE',   true);
-    define('SHOW_SQL',         false);
+    define('DEFINE_INCLUDE', true);
+    define('SHOW_SQL', false);
     define('ABSOLUTE_SYSPATH', dirname(__FILE__) . '/');
-    define('DEBUG_SYSPATH',    ABSOLUTE_SYSPATH . 'debug/');
-    define('PUBLIC_PATH',      ROOT_PATH . 'Public/');
-    define('ASSETS_PATH',      PUBLIC_PATH . 'Assets/');
-    define('JS_PATH',          ASSETS_PATH . 'Js/');
-    define('IMG_PATH',         ASSETS_PATH . 'Img/');
-    define('FONT_PATH',        ASSETS_PATH . 'Font/');
-    define('CSS_PATH',         ASSETS_PATH . 'Css/');
-    define('LIBRARY_PATH',     ROOT_PATH . 'library/');
-    define('INCLUDE_PATH',     ROOT_PATH . 'includes/');
-    define('CONFIG_PATH',      ROOT_PATH . 'cfg/');
-    define('INSTALL_PATH',     ROOT_PATH . 'install/');
-    define('LOCALE_PATH',      ROOT_PATH . 'locale/');
-    define('DUMP_PATH',        ROOT_PATH . 'dump/');
-    define('TEMPLATE_PATH',    ROOT_PATH . 'template/reboot/');
-    define('PLUGINS_DIR',      INCLUDE_PATH . 'plugins/');
-    define('NIL_INT',          -1);
-    define('STATUS_ACTIVE',    1);
-    define('STATUS_DELETED',   2);
+    define('DEBUG_SYSPATH', ABSOLUTE_SYSPATH . 'debug/');
+    define('PUBLIC_PATH', ROOT_PATH . 'Public/');
+    define('ASSETS_PATH', PUBLIC_PATH . 'Assets/');
+    define('JS_PATH', ASSETS_PATH . 'Js/');
+    define('IMG_PATH', ASSETS_PATH . 'Img/');
+    define('FONT_PATH', ASSETS_PATH . 'Font/');
+    define('CSS_PATH', ASSETS_PATH . 'Css/');
+    define('LIBRARY_PATH', ROOT_PATH . 'library/');
+    define('INCLUDE_PATH', ROOT_PATH . 'includes/');
+    define('CONFIG_PATH', ROOT_PATH . 'cfg/');
+    define('INSTALL_PATH', ROOT_PATH . 'install/');
+    define('LOCALE_PATH', ROOT_PATH . 'locale/');
+    define('DUMP_PATH', ROOT_PATH . 'dump/');
+    define('TEMPLATE_PATH', ROOT_PATH . 'template/reboot/');
+    define('PLUGINS_DIR', INCLUDE_PATH . 'plugins/');
+    define('NIL_INT', -1);
+    define('STATUS_ACTIVE', 1);
+    define('STATUS_DELETED', 2);
 
     require_once ROOT_PATH . 'vendor/autoload.php';
     require_once ROOT_PATH . 'vendor/raveren/kint/Kint.class.php';
@@ -37,7 +37,7 @@ if (!defined( 'DEFINE_INCLUDE' )) {
         case ENV_DEV:
             error_reporting(-1);
             \Kint::enabled(true);
-            // no break;
+        // no break;
         case ENV_TEST:
             \Kint::enabled(true);
             if (ENV === ENV_TEST) {
@@ -49,12 +49,12 @@ if (!defined( 'DEFINE_INCLUDE' )) {
              * Logue les variables à déboguer
              */
             function debug()
-            {
+        {
                 global $debug;
                 $debug[] = [
-                    'Kint' => @d(func_get_args()),
+                    'Kint'      => @d(func_get_args()),
                     'Backtrace' => '<pre>' . print_r(debug_backtrace(), true) . '</pre>',
-                    'LastError' => '<pre>' . print_r(error_get_last(), true)  .'</pre>',
+                    'LastError' => '<pre>' . print_r(error_get_last(), true) . '</pre>',
                 ];
             }
             register_shutdown_function(function () {
@@ -71,7 +71,7 @@ if (!defined( 'DEFINE_INCLUDE' )) {
                 }
                 foreach ($debug as $v) {
                     foreach ($v as $title => $data) {
-                        fwrite($file, '####################<br># ' . $title. '<br>####################<br>');
+                        fwrite($file, '####################<br># ' . $title . '<br>####################<br>');
                         fwrite($file, $data . '<br><br>');
                     }
                 }

--- a/edition/Fonctions.php
+++ b/edition/Fonctions.php
@@ -3,19 +3,19 @@
 namespace edition;
 
 /**
-* Regroupement des fonctions liées à l'édition
-*/
+ * Regroupement des fonctions liées à l'édition
+ */
 class Fonctions
 {
     public static function affiche_anciennes_editions($login)
     {
-        $session=session_id();
-        $return = '';
+        $session = session_id();
+        $return  = '';
 
         $return .= '<CENTER>';
 
         // recup du tableau des types de conges (seulement les conges)
-        $tab_type_cong=recup_tableau_types_conges();
+        $tab_type_cong = recup_tableau_types_conges();
 
         /*************************************/
         /* Historique des éditions           */
@@ -25,7 +25,7 @@ class Fonctions
 
         $return .= '<h3>' . _('editions_hitorique_edit') . ' :</h3>';
 
-        if(count($tab_editions_user)==0) {
+        if (count($tab_editions_user) == 0) {
             $return .= '<b>' . _('editions_aucun_hitorique') . '</b><br>';
         } else {
             // AFFICHAGE TABLEAU
@@ -33,7 +33,7 @@ class Fonctions
             $return .= '<thead><tr align="center">';
             $return .= '<th>' . _('editions_numero') . '</th>';
             $return .= '<th>' . _('editions_date') . '</th>';
-            foreach($tab_type_cong as $id_abs => $libelle) {
+            foreach ($tab_type_cong as $id_abs => $libelle) {
                 $return .= '<th>' . _('divers_solde_maj_1') . ' ' . $libelle . '</th>';
             }
 
@@ -41,21 +41,21 @@ class Fonctions
             $return .= '<th></th>';
             $return .= '</tr></thead><tbody>';
 
-            foreach($tab_editions_user as $id_edition => $tab_ed) {
+            foreach ($tab_editions_user as $id_edition => $tab_ed) {
                 //$text_edit_a_nouveau="<a href=\"edition_papier.php?session=$session&user_login=$login&edit_id=$sql_id\">Editer à nouveau</a>" ;
-                $text_edit_a_nouveau="<a href=\"edition_papier.php?session=$session&user_login=$login&edit_id=$id_edition\">" .
-                        "<img src=\"". IMG_PATH . "fileprint_16x16_2.png\" width=\"16\" height=\"16\" border=\"0\" title=\"". _('editions_edit_again') ."\" alt=\"". _('editions_edit_again') ."\">" .
-                        " ". _('editions_edit_again')  .
-                        "</a>\n";
-                $text_edit_pdf_a_nouveau="<a href=\"edition_pdf.php?session=$session&user_login=$login&edit_id=$id_edition\">" .
-                        "<img src=\"". IMG_PATH . "pdf_16x16_2.png\" width=\"16\" height=\"16\" border=\"0\" title=\"". _('editions_edit_again_pdf') ."\" alt=\"". _('editions_edit_again_pdf') ."\">" .
-                        " ". _('editions_edit_again_pdf')  .
-                        "</a>\n";
+                $text_edit_a_nouveau = "<a href=\"edition_papier.php?session=$session&user_login=$login&edit_id=$id_edition\">" .
+                "<img src=\"" . IMG_PATH . "fileprint_16x16_2.png\" width=\"16\" height=\"16\" border=\"0\" title=\"" . _('editions_edit_again') . "\" alt=\"" . _('editions_edit_again') . "\">" .
+                " " . _('editions_edit_again') .
+                    "</a>\n";
+                $text_edit_pdf_a_nouveau = "<a href=\"edition_pdf.php?session=$session&user_login=$login&edit_id=$id_edition\">" .
+                "<img src=\"" . IMG_PATH . "pdf_16x16_2.png\" width=\"16\" height=\"16\" border=\"0\" title=\"" . _('editions_edit_again_pdf') . "\" alt=\"" . _('editions_edit_again_pdf') . "\">" .
+                " " . _('editions_edit_again_pdf') .
+                    "</a>\n";
 
                 $return .= '<tr align="center">';
                 $return .= '<td>' . $tab_ed['num_for_user'] . '</td>';
                 $return .= '<td class="histo-big">' . $tab_ed['date'] . '</td>';
-                foreach($tab_type_cong as $id_abs => $libelle) {
+                foreach ($tab_type_cong as $id_abs => $libelle) {
                     $return .= '<td>' . $tab_ed['conges'][$id_abs] . '</td>';
                 }
 
@@ -74,8 +74,8 @@ class Fonctions
 
     public static function affiche_nouvelle_edition($login)
     {
-        $session=session_id();
-        $return = '';
+        $session = session_id();
+        $return  = '';
         $return .= '<CENTER>';
 
         /*************************************/
@@ -83,23 +83,23 @@ class Fonctions
         /*************************************/
         // Récupération des informations
         // recup de ttes les periodes de type conges du user, sauf les demandes, qui ne sont pas dejà sur une édition papier
-        $sql2 = "SELECT p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_etat, p_date_demande, p_date_traitement, ta_libelle ";
-        $sql2=$sql2."FROM conges_periode as a, conges_type_absence as b ";
-        $sql2=$sql2."WHERE (p_etat!='demande' AND p_etat!='valid') ";
-        $sql2=$sql2."AND p_edition_id IS NULL ";
-        $sql2=$sql2."AND (p_login = '$login') ";
-        $sql2=$sql2."AND (a.p_type=b.ta_id AND  ( (b.ta_type='conges') OR (b.ta_type='conges_exceptionnels') ) )";
-        $sql2=$sql2."ORDER BY p_date_deb ASC ";
+        $sql2    = "SELECT p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_etat, p_date_demande, p_date_traitement, ta_libelle ";
+        $sql2    = $sql2 . "FROM conges_periode as a, conges_type_absence as b ";
+        $sql2    = $sql2 . "WHERE (p_etat!='demande' AND p_etat!='valid') ";
+        $sql2    = $sql2 . "AND p_edition_id IS NULL ";
+        $sql2    = $sql2 . "AND (p_login = '$login') ";
+        $sql2    = $sql2 . "AND (a.p_type=b.ta_id AND  ( (b.ta_type='conges') OR (b.ta_type='conges_exceptionnels') ) )";
+        $sql2    = $sql2 . "ORDER BY p_date_deb ASC ";
         $ReqLog2 = \includes\SQL::query($sql2);
 
         $return .= '<h3>' . _('editions_last_edition') . ' :</h3>';
 
-        $count2=$ReqLog2->num_rows;
-        if($count2==0) {
+        $count2 = $ReqLog2->num_rows;
+        if ($count2 == 0) {
             $return .= '<b>' . _('editions_aucun_conges') . '</b><br>';
         } else {
             // AFFICHAGE TABLEAU
-            if($_SESSION['config']['affiche_date_traitement']) {
+            if ($_SESSION['config']['affiche_date_traitement']) {
                 $return .= '<table cellpadding="2" class="tablo" width="850">';
             } else {
                 $return .= '<table cellpadding="2" class="tablo" width="750">';
@@ -111,39 +111,49 @@ class Fonctions
             $return .= '<th>' . _('divers_debut_maj_1') . '</th>';
             $return .= '<th>' . _('divers_fin_maj_1') . '</th>';
             $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
-            if($_SESSION['config']['affiche_date_traitement']) {
+            if ($_SESSION['config']['affiche_date_traitement']) {
                 $return .= '<th>' . _('divers_date_traitement') . '</td>';
             }
             $return .= '</tr></thead></tbody>';
 
             while ($resultat2 = $ReqLog2->fetch_array()) {
-                $sql_p_date_deb = eng_date_to_fr($resultat2["p_date_deb"]);
+                $sql_p_date_deb      = eng_date_to_fr($resultat2["p_date_deb"]);
                 $sql_p_demi_jour_deb = $resultat2["p_demi_jour_deb"];
-                if($sql_p_demi_jour_deb=="am") $demi_j_deb="mat";  else $demi_j_deb="aprm";
-                $sql_p_date_fin = eng_date_to_fr($resultat2["p_date_fin"]);
+                if ($sql_p_demi_jour_deb == "am") {
+                    $demi_j_deb = "mat";
+                } else {
+                    $demi_j_deb = "aprm";
+                }
+
+                $sql_p_date_fin      = eng_date_to_fr($resultat2["p_date_fin"]);
                 $sql_p_demi_jour_fin = $resultat2["p_demi_jour_fin"];
-                if($sql_p_demi_jour_fin=="am") $demi_j_fin="mat";  else $demi_j_fin="aprm";
-                $sql_p_nb_jours = $resultat2["p_nb_jours"];
-                $sql_p_commentaire = $resultat2["p_commentaire"];
-                $sql_p_type = $resultat2["ta_libelle"];
-                $sql_p_etat = $resultat2["p_etat"];
-                $sql_p_date_demande = $resultat2["p_date_demande"];
+                if ($sql_p_demi_jour_fin == "am") {
+                    $demi_j_fin = "mat";
+                } else {
+                    $demi_j_fin = "aprm";
+                }
+
+                $sql_p_nb_jours        = $resultat2["p_nb_jours"];
+                $sql_p_commentaire     = $resultat2["p_commentaire"];
+                $sql_p_type            = $resultat2["ta_libelle"];
+                $sql_p_etat            = $resultat2["p_etat"];
+                $sql_p_date_demande    = $resultat2["p_date_demande"];
                 $sql_p_date_traitement = $resultat2["p_date_traitement"];
 
                 $return .= '<tr align="center">';
                 $return .= '<td>' . $sql_p_type . '</td>';
                 $return .= '<td>';
-                if($sql_p_etat=="refus") {
+                if ($sql_p_etat == "refus") {
                     $return .= _('divers_refuse');
-                } elseif($sql_p_etat=="annul") {
+                } elseif ($sql_p_etat == "annul") {
                     $return .= _('divers_annule');
                 } else {
                     $return .= $sql_p_etat;
                 }
                 $return .= '</td>';
-                if($sql_p_etat=="ok") {
+                if ($sql_p_etat == "ok") {
                     $return .= '<td class="histo-big"> -' . $sql_p_nb_jours . '</td>';
-                } elseif($sql_p_etat=="ajout") {
+                } elseif ($sql_p_etat == "ajout") {
                     $return .= '<td class="histo-big"> +' . $sql_p_nb_jours . '</td>';
                 } else {
                     $return .= '<td>' . $sql_p_nb_jours . '</td>';
@@ -151,11 +161,10 @@ class Fonctions
                 $return .= '<td>' . $sql_p_date_deb . '_' . $demi_j_deb . '</td>';
                 $return .= '<td>' . $sql_p_date_fin . '_' . $demi_j_fin . '</td>';
                 $return .= '<td>' . $sql_p_commentaire . '</td>';
-                if($_SESSION['config']['affiche_date_traitement']) {
-                    if($sql_p_date_demande == NULL) {
+                if ($_SESSION['config']['affiche_date_traitement']) {
+                    if ($sql_p_date_demande == null) {
                         $return .= '<td class="histo-left">' . _('divers_traitement') . ' : ' . $sql_p_date_traitement . '</td>';
-                    }
-                    else {
+                    } else {
                         $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_p_date_traitement . '</td>';
                     }
                 }
@@ -194,16 +203,16 @@ class Fonctions
     public static function affichage($login)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
-        $sql1 = 'SELECT u_nom, u_prenom, u_quotite FROM conges_users where u_login = "'. \includes\SQL::quote($login).'"';
+        $sql1    = 'SELECT u_nom, u_prenom, u_quotite FROM conges_users where u_login = "' . \includes\SQL::quote($login) . '"';
         $ReqLog1 = \includes\SQL::query($sql1);
 
         while ($resultat1 = $ReqLog1->fetch_array()) {
-            $sql_nom=$resultat1["u_nom"];
-            $sql_prenom=$resultat1["u_prenom"];
-            $sql_quotite=$resultat1["u_quotite"];
+            $sql_nom     = $resultat1["u_nom"];
+            $sql_prenom  = $resultat1["u_prenom"];
+            $sql_quotite = $resultat1["u_quotite"];
         }
 
         // TITRE
@@ -239,13 +248,12 @@ class Fonctions
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
         $user_login = htmlentities(getpost_variable('user_login', $_SESSION['userlogin']), ENT_QUOTES | ENT_HTML401);
-        $return = '';
-        header_popup( _('editions_titre') .' : '.$user_login);
-
+        $return     = '';
+        header_popup(_('editions_titre') . ' : ' . $user_login);
 
         /*************************************/
 
-        if ($user_login != $_SESSION['userlogin'] && !is_hr($_SESSION['userlogin']) && !is_resp_of_user($_SESSION['userlogin'] , $user_login)) {
+        if ($user_login != $_SESSION['userlogin'] && !is_hr($_SESSION['userlogin']) && !is_resp_of_user($_SESSION['userlogin'], $user_login)) {
             redirect(ROOT_PATH . 'deconnexion.php');
             exit;
         }
@@ -268,11 +276,11 @@ class Fonctions
         $return .= '<th>' . _('divers_solde_maj') . '</th>';
         $return .= '</tr></thead><tbody>';
 
-        foreach($tab_type_cong as $id_abs => $libelle) {
-            $return .= '<tr><td>' . $libelle . '</td><td>' . $tab_info_user['conges'][$libelle]['nb_an']. '</td><td align="center" bgcolor="#FF9191"><b>' . $tab_info_edition['conges'][$id_abs] . '</b></td>';
+        foreach ($tab_type_cong as $id_abs => $libelle) {
+            $return .= '<tr><td>' . $libelle . '</td><td>' . $tab_info_user['conges'][$libelle]['nb_an'] . '</td><td align="center" bgcolor="#FF9191"><b>' . $tab_info_edition['conges'][$id_abs] . '</b></td>';
         }
-        foreach($tab_type_conges_exceptionnels as $id_abs => $libelle) {
-            $return .= '<tr><td>' . $libelle . '</td><td>' . $tab_info_user['conges'][$libelle]['nb_an'] . '</td><td align="center" bgcolor="#FF9191"><b>'. $tab_info_edition['conges'][$id_abs] . '</b></td>';
+        foreach ($tab_type_conges_exceptionnels as $id_abs => $libelle) {
+            $return .= '<tr><td>' . $libelle . '</td><td>' . $tab_info_user['conges'][$libelle]['nb_an'] . '</td><td align="center" bgcolor="#FF9191"><b>' . $tab_info_edition['conges'][$id_abs] . '</b></td>';
         }
         $return .= '</tr>';
         $return .= '</tbody></table>';
@@ -282,8 +290,8 @@ class Fonctions
 
     public static function edition_papier($login, $edit_id)
     {
-        $session=session_id();
-        $return = '';
+        $session = session_id();
+        $return  = '';
 
         // recup infos du user
         $tab_info_user = \edition\Fonctions::recup_info_user_pour_edition($login);
@@ -292,15 +300,15 @@ class Fonctions
         $tab_info_edition = \edition\Fonctions::recup_info_edition($edit_id);
 
         // recup du tableau des types de conges exceptionnels (seulement les conge sexceptionnels )
-        $tab_type_cong=recup_tableau_types_conges();
+        $tab_type_cong = recup_tableau_types_conges();
         // recup du tableau des types de conges (seulement les conges)
         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-            $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
+            $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
         } else {
-            $tab_type_conges_exceptionnels=array();
+            $tab_type_conges_exceptionnels = array();
         }
         // recup du tableau de tous les types de conges
-        $tab_type_all_cong=recup_tableau_tout_types_abs();
+        $tab_type_all_cong = recup_tableau_tout_types_abs();
 
         /**************************************/
         /* affichage du texte en haut de page */
@@ -315,9 +323,8 @@ class Fonctions
         /* affichage du TITRE                 */
         /**************************************/
         $return .= '<H1>' . $tab_info_user['nom'] . ' ' . $tab_info_user['prenom'] . '</H1>';
-        $tab_date=explode("-", $tab_info_edition['date']);
+        $tab_date = explode("-", $tab_info_edition['date']);
         $return .= '<H2>' . _('editions_bilan_au') . ' ' . $tab_date[2] . '/' . $tab_date[1] . '/' . $tab_date[0] . '</H2>';
-
 
         /****************************/
         /* tableau Bilan des Conges */
@@ -325,12 +332,11 @@ class Fonctions
         // affichage du tableau récapitulatif des solde de congés d'un user DE cette edition !
         $return .= \edition\Fonctions::affiche_tableau_bilan_conges_user_edition($tab_info_user, $tab_info_edition, $tab_type_cong, $tab_type_conges_exceptionnels);
 
-        $quotite=$tab_info_user['quotite'];
+        $quotite = $tab_info_user['quotite'];
         $return .= '<h3>' . _('divers_quotite') . '&nbsp; : &nbsp;' . $quotite . ' %</h3>';
         $return .= '<br><br><br>';
 
-
-        if($_SESSION['config']['affiche_date_traitement']) {
+        if ($_SESSION['config']['affiche_date_traitement']) {
             $return .= '<table cellpadding="0" cellspacing="0" border="1" width="870">';
         } else {
             $return .= '<table cellpadding="0" cellspacing="0" border="1" width="770">';
@@ -348,18 +354,18 @@ class Fonctions
 
         // Récupération des informations
         // on ne recup QUE les periodes de l'edition choisie
-        $sql2 = "SELECT p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_etat, p_date_demande, p_date_traitement ";
-        $sql2=$sql2."FROM conges_periode ";
-        $sql2=$sql2."WHERE p_edition_id = $edit_id ";
-        $sql2=$sql2."ORDER BY p_date_deb ASC ";
+        $sql2    = "SELECT p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_etat, p_date_demande, p_date_traitement ";
+        $sql2    = $sql2 . "FROM conges_periode ";
+        $sql2    = $sql2 . "WHERE p_edition_id = $edit_id ";
+        $sql2    = $sql2 . "ORDER BY p_date_deb ASC ";
         $ReqLog2 = \includes\SQL::query($sql2);
 
-        $count2=$ReqLog2->num_rows;
-        if($count2==0) {
+        $count2 = $ReqLog2->num_rows;
+        if ($count2 == 0) {
             $return .= '<b>' . _('editions_aucun_conges') . '</b><br>';
         } else {
             // AFFICHAGE TABLEAU
-            if($_SESSION['config']['affiche_date_traitement']) {
+            if ($_SESSION['config']['affiche_date_traitement']) {
                 $return .= '<table cellpadding="2" class="tablo-edit" width="850">';
             } else {
                 $return .= '<table cellpadding="2" class="tablo-edit" width="750">';
@@ -372,21 +378,20 @@ class Fonctions
             $return .= '<tr>';
             $return .= '<td colspan="5">';
             $edition_precedente_id = \edition\Fonctions::get_id_edition_precedente_user($login, $edit_id);
-            if($edition_precedente_id==0) {
+            if ($edition_precedente_id == 0) {
                 $return .= '<b>' . _('editions_soldes_precedents_inconnus') . '!... ';
             } else {
                 $tab_edition_precedente = \edition\Fonctions::recup_info_edition($edition_precedente_id);
-                foreach($tab_type_cong as $id_abs => $libelle) {
+                foreach ($tab_type_cong as $id_abs => $libelle) {
                     $return .= _('editions_solde_precedent') . ' <b>' . $libelle . ' : ' . $tab_edition_precedente['conges'][$id_abs] . '</b><br>';
                 }
-                foreach($tab_type_conges_exceptionnels as $id_abs => $libelle) {
+                foreach ($tab_type_conges_exceptionnels as $id_abs => $libelle) {
                     $return .= _('editions_solde_precedent') . ' <b>' . $libelle . ' : ' . $tab_edition_precedente['conges'][$id_abs] . '</b><br>';
                 }
             }
 
             $return .= '<td>';
             $return .= '</tr>';
-
 
             /*************************************/
             /* affichage lignes de l'edition     */
@@ -399,57 +404,57 @@ class Fonctions
             $return .= '<td class="titre-edit">' . _('divers_debut_maj_1') . '</td>';
             $return .= '<td class="titre-edit">' . _('divers_fin_maj_1') . '</td>';
             $return .= '<td class="titre-edit">' . _('divers_comment_maj_1') . '</td>';
-            if($_SESSION['config']['affiche_date_traitement']) {
+            if ($_SESSION['config']['affiche_date_traitement']) {
                 $return .= '<td class="titre-edit">' . _('divers_date_traitement') . '</td>';
             }
             $return .= '</tr>';
 
             while ($resultat2 = $ReqLog2->fetch_array()) {
-                $sql_p_date_deb = eng_date_to_fr($resultat2["p_date_deb"]);
+                $sql_p_date_deb      = eng_date_to_fr($resultat2["p_date_deb"]);
                 $sql_p_demi_jour_deb = $resultat2["p_demi_jour_deb"];
-                if($sql_p_demi_jour_deb=="am") {
-                    $demi_j_deb =  _('divers_am_short') ;
+                if ($sql_p_demi_jour_deb == "am") {
+                    $demi_j_deb = _('divers_am_short');
                 } else {
-                    $demi_j_deb =  _('divers_pm_short') ;
+                    $demi_j_deb = _('divers_pm_short');
                 }
-                $sql_p_date_fin = eng_date_to_fr($resultat2["p_date_fin"]);
+                $sql_p_date_fin      = eng_date_to_fr($resultat2["p_date_fin"]);
                 $sql_p_demi_jour_fin = $resultat2["p_demi_jour_fin"];
-                if($sql_p_demi_jour_fin=="am") {
-                    $demi_j_fin =  _('divers_am_short') ;
+                if ($sql_p_demi_jour_fin == "am") {
+                    $demi_j_fin = _('divers_am_short');
                 } else {
-                    $demi_j_fin =  _('divers_pm_short') ;
+                    $demi_j_fin = _('divers_pm_short');
                 }
-                $sql_p_nb_jours = $resultat2["p_nb_jours"];
-                $sql_p_commentaire = $resultat2["p_commentaire"];
-                $sql_p_type = $resultat2["p_type"];
-                $sql_p_etat = $resultat2["p_etat"];
-                $sql_p_date_demande = $resultat2["p_date_demande"];
+                $sql_p_nb_jours        = $resultat2["p_nb_jours"];
+                $sql_p_commentaire     = $resultat2["p_commentaire"];
+                $sql_p_type            = $resultat2["p_type"];
+                $sql_p_etat            = $resultat2["p_etat"];
+                $sql_p_date_demande    = $resultat2["p_date_demande"];
                 $sql_p_date_traitement = $resultat2["p_date_traitement"];
 
                 $return .= '<tr>';
                 $return .= '<td class="histo-edit">' . $tab_type_all_cong[$sql_p_type]['libelle'] . '</td>';
                 $return .= '<td class="histo-edit">';
-                if($sql_p_etat=="refus") {
-                    $return .= _('divers_refuse') ;
-                } elseif($sql_p_etat=="annul") {
-                    $return .= _('divers_annule') ;
+                if ($sql_p_etat == "refus") {
+                    $return .= _('divers_refuse');
+                } elseif ($sql_p_etat == "annul") {
+                    $return .= _('divers_annule');
                 } else {
                     $return .= '"' . $sql_p_etat . '"';
                 }
                 $return .= '</td>';
-                if($sql_p_etat=="ok") {
+                if ($sql_p_etat == "ok") {
                     $return .= '<td class="histo-big"> -' . $sql_p_nb_jours . '</td>';
-                } elseif($sql_p_etat=="ajout") {
+                } elseif ($sql_p_etat == "ajout") {
                     $return .= '<td class="histo-big"> +' . $sql_p_nb_jours . '</td>';
                 } else {
                     $return .= '<td> ' . $sql_p_nb_jours . '</td>';
                 }
-                $return .= '<td class="histo-edit">' . $sql_p_date_deb . '_' .  $demi_j_deb . '</td>';
-                $return .= '<td class="histo-edit">' . $sql_p_date_fin . '_' .  $demi_j_fin . '</td>';
+                $return .= '<td class="histo-edit">' . $sql_p_date_deb . '_' . $demi_j_deb . '</td>';
+                $return .= '<td class="histo-edit">' . $sql_p_date_fin . '_' . $demi_j_fin . '</td>';
                 $return .= '<td class="histo-edit">' . $sql_p_commentaire . '</td>';
 
-                if($_SESSION['config']['affiche_date_traitement']) {
-                    if($sql_p_date_demande == NULL) {
+                if ($_SESSION['config']['affiche_date_traitement']) {
+                    if ($sql_p_date_demande == null) {
                         $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_p_date_traitement . '</td>';
                     } else {
                         $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : pas traité</td>';
@@ -464,7 +469,7 @@ class Fonctions
             $return .= '<!-- affichage nouveaux soldes -->';
             $return .= '<tr>';
             $return .= '<td colspan="5">';
-            foreach($tab_type_cong as $id_abs => $libelle) {
+            foreach ($tab_type_cong as $id_abs => $libelle) {
                 $return .= _('editions_nouveau_solde') . ' <b>' . $libelle . ': ' . $tab_info_edition['conges'][$id_abs] . '</b><br>';
             }
             $return .= '<td>';
@@ -495,7 +500,6 @@ class Fonctions
         $return .= '</tr>';
         $return .= '</table>';
 
-
         /*************************************/
         /* affichage du texte en bas de page */
         /*************************************/
@@ -523,23 +527,24 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
         // GET / POST
-        $user_login = getpost_variable('user_login') ;
-        $edit_id = getpost_variable('edit_id', 0) ;
-        $return = '';
+        $user_login = getpost_variable('user_login');
+        $edit_id    = getpost_variable('edit_id', 0);
+        $return     = '';
         /*************************************/
 
-        if ($user_login != $_SESSION['userlogin'] && !is_hr($_SESSION['userlogin']) && !is_resp_of_user($_SESSION['userlogin'] , $user_login)) {
+        if ($user_login != $_SESSION['userlogin'] && !is_hr($_SESSION['userlogin']) && !is_resp_of_user($_SESSION['userlogin'], $user_login)) {
             redirect(ROOT_PATH . 'deconnexion.php');
             exit;
         }
 
         /************************************/
 
-        $css = '<link href="'. CSS_PATH .'style_calendar_edition.css" rel="stylesheet" type="text/css">';
+        $css = '<link href="' . CSS_PATH . 'style_calendar_edition.css" rel="stylesheet" type="text/css">';
 
-        header_popup(_('editions_etat_conges').' : '.$user_login , $css);
+        header_popup(_('editions_etat_conges') . ' : ' . $user_login, $css);
 
-        if($edit_id==0) {  // si c'est une nouvelle édition, on insert dans la base avant d'éditer et on renvoit l'id de l'édition
+        if ($edit_id == 0) {
+            // si c'est une nouvelle édition, on insert dans la base avant d'éditer et on renvoit l'id de l'édition
             $edit_id = \edition\Fonctions::enregistrement_edition($user_login);
         }
 
@@ -561,12 +566,12 @@ class Fonctions
 
         // (largeur totale page = 210 ( - 2x10 de marge))
         // tailles des cellules du tableau
-        $size_cell_type = 30;
-        $size_cell_etat = 15;
-        $size_cell_nb_jours = 20;  //90
-        $size_cell_debut = 30;
-        $size_cell_fin = 30;
-        $size_cell_comment = 60;
+        $size_cell_type     = 30;
+        $size_cell_etat     = 15;
+        $size_cell_nb_jours = 20; //90
+        $size_cell_debut    = 30;
+        $size_cell_fin      = 30;
+        $size_cell_comment  = 60;
         //          total = 190 (185+decalage)
 
         /*************************************/
@@ -577,75 +582,75 @@ class Fonctions
 
         //$pdf->SetFont('Times', 'B', 10);
         $pdf->SetFont('Times', 'B', 10);
-        $pdf->Cell($size_cell_type, 5,  _('divers_type_maj_1') , 1, 0, 'C', 1);
-        $pdf->Cell($size_cell_etat, 5,  _('divers_etat_maj_1') , 1, 0, 'C', 1);
-        $pdf->Cell($size_cell_nb_jours, 5,  _('divers_nb_jours_maj_1') , 1, 0, 'C', 1);
-        $pdf->Cell($size_cell_debut, 5,  _('divers_debut_maj_1') , 1, 0, 'C', 1);
-        $pdf->Cell($size_cell_fin, 5,  _('divers_fin_maj_1') , 1, 0, 'C', 1);
-        $pdf->Cell($size_cell_comment, 5,  _('divers_comment_maj_1') , 1, 1, 'C', 1);
+        $pdf->Cell($size_cell_type, 5, _('divers_type_maj_1'), 1, 0, 'C', 1);
+        $pdf->Cell($size_cell_etat, 5, _('divers_etat_maj_1'), 1, 0, 'C', 1);
+        $pdf->Cell($size_cell_nb_jours, 5, _('divers_nb_jours_maj_1'), 1, 0, 'C', 1);
+        $pdf->Cell($size_cell_debut, 5, _('divers_debut_maj_1'), 1, 0, 'C', 1);
+        $pdf->Cell($size_cell_fin, 5, _('divers_fin_maj_1'), 1, 0, 'C', 1);
+        $pdf->Cell($size_cell_comment, 5, _('divers_comment_maj_1'), 1, 1, 'C', 1);
 
         while ($resultat2 = $ReqLog2->fetch_array()) {
-            $sql_p_date_deb = eng_date_to_fr($resultat2["p_date_deb"]);
+            $sql_p_date_deb      = eng_date_to_fr($resultat2["p_date_deb"]);
             $sql_p_demi_jour_deb = $resultat2["p_demi_jour_deb"];
-            if($sql_p_demi_jour_deb=="am") {
-                $demi_j_deb =  _('divers_am_short') ;
+            if ($sql_p_demi_jour_deb == "am") {
+                $demi_j_deb = _('divers_am_short');
             } else {
-                $demi_j_deb =  _('divers_pm_short') ;
+                $demi_j_deb = _('divers_pm_short');
             }
-            $sql_p_date_fin = eng_date_to_fr($resultat2["p_date_fin"]);
+            $sql_p_date_fin      = eng_date_to_fr($resultat2["p_date_fin"]);
             $sql_p_demi_jour_fin = $resultat2["p_demi_jour_fin"];
-            if($sql_p_demi_jour_fin=="am") {
-                $demi_j_fin =  _('divers_am_short') ;
+            if ($sql_p_demi_jour_fin == "am") {
+                $demi_j_fin = _('divers_am_short');
             } else {
-                $demi_j_fin =  _('divers_pm_short') ;
+                $demi_j_fin = _('divers_pm_short');
             }
-            $sql_p_nb_jours = $resultat2["p_nb_jours"];
-            $sql_p_commentaire = $resultat2["p_commentaire"];
-            $sql_p_type = $resultat2["p_type"];
-            $sql_p_etat = $resultat2["p_etat"];
-            $sql_p_date_demande = $resultat2["p_date_demande"];
+            $sql_p_nb_jours        = $resultat2["p_nb_jours"];
+            $sql_p_commentaire     = $resultat2["p_commentaire"];
+            $sql_p_type            = $resultat2["p_type"];
+            $sql_p_etat            = $resultat2["p_etat"];
+            $sql_p_date_demande    = $resultat2["p_date_demande"];
             $sql_p_date_traitement = $resultat2["p_date_traitement"];
 
             // decalage pour centrer
             $pdf->Cell($decalage);
-            $hauteur_cellule=5;
+            $hauteur_cellule = 5;
 
-            $taille_font=10;
+            $taille_font = 10;
 
             $pdf->SetFont('Times', '', $taille_font);
 
             $pdf->Cell($size_cell_type, $hauteur_cellule, $tab_type_all_cong[$sql_p_type]['libelle'], 1, 0, 'C');
 
-            if($sql_p_etat=="refus") {
-                $text_etat =  _('divers_refuse') ;
-            } elseif($sql_p_etat=="annul") {
-                $text_etat =  _('divers_annule') ;
+            if ($sql_p_etat == "refus") {
+                $text_etat = _('divers_refuse');
+            } elseif ($sql_p_etat == "annul") {
+                $text_etat = _('divers_annule');
             } else {
-                $text_etat=$sql_p_etat;
+                $text_etat = $sql_p_etat;
             }
             $pdf->Cell($size_cell_etat, $hauteur_cellule, $text_etat, 1, 0, 'C');
 
-            if( ($sql_p_etat=="refus") || ($sql_p_etat=="annul") ) {
+            if (($sql_p_etat == "refus") || ($sql_p_etat == "annul")) {
                 $pdf->SetFont('Times', '', $taille_font);
             } else {
                 $pdf->SetFont('Times', 'B', $taille_font);
             }
 
-            if($sql_p_etat=="ok") {
-                $text_nb_jours="-".$sql_p_nb_jours;
-            } elseif($sql_p_etat=="ajout") {
-                $text_nb_jours="+".$sql_p_nb_jours;
+            if ($sql_p_etat == "ok") {
+                $text_nb_jours = "-" . $sql_p_nb_jours;
+            } elseif ($sql_p_etat == "ajout") {
+                $text_nb_jours = "+" . $sql_p_nb_jours;
             } else {
-                $text_nb_jours=$sql_p_nb_jours;
+                $text_nb_jours = $sql_p_nb_jours;
             }
             $pdf->Cell($size_cell_nb_jours, $hauteur_cellule, $text_nb_jours, 1, 0, 'C');
 
             $pdf->SetFont('Times', '', $taille_font);
-            $pdf->Cell($size_cell_debut, $hauteur_cellule, $sql_p_date_deb." _ ".$demi_j_deb, 1, 0, 'C');
-            $pdf->Cell($size_cell_fin, $hauteur_cellule, $sql_p_date_fin." _ ".$demi_j_fin, 1, 0, 'C');
+            $pdf->Cell($size_cell_debut, $hauteur_cellule, $sql_p_date_deb . " _ " . $demi_j_deb, 1, 0, 'C');
+            $pdf->Cell($size_cell_fin, $hauteur_cellule, $sql_p_date_fin . " _ " . $demi_j_fin, 1, 0, 'C');
             // reduction de la taille du commentaire pour rentrer dans la cellule
-            if(strlen($sql_p_commentaire)>39) {
-                $sql_p_commentaire = substr($sql_p_commentaire, 0, 35)." ..." ;
+            if (strlen($sql_p_commentaire) > 39) {
+                $sql_p_commentaire = substr($sql_p_commentaire, 0, 35) . " ...";
             }
             $pdf->Cell($size_cell_comment, $hauteur_cellule, $sql_p_commentaire, 1, 1, 'C');
         }
@@ -655,12 +660,12 @@ class Fonctions
     {
         // (largeur totale page = 210 ( - 2x10 de marge))
         // tailles des cellules du tableau
-        $size_cell_type = 25;
-        $size_cell_etat = 15;
-        $size_cell_nb_jours = 15;  //90
-        $size_cell_debut = 25;
-        $size_cell_fin = 25;
-        $size_cell_comment = 40;
+        $size_cell_type            = 25;
+        $size_cell_etat            = 15;
+        $size_cell_nb_jours        = 15; //90
+        $size_cell_debut           = 25;
+        $size_cell_fin             = 25;
+        $size_cell_comment         = 40;
         $size_cell_date_traitement = 40;
         //          total = 190 (185+decalage)
 
@@ -671,75 +676,81 @@ class Fonctions
         $pdf->Cell($decalage);
 
         $pdf->SetFont('Times', 'B', 9);
-        $pdf->Cell($size_cell_type, 5,  _('divers_type_maj_1') , 1, 0, 'C', 1);
-        $pdf->Cell($size_cell_etat, 5,  _('divers_etat_maj_1') , 1, 0, 'C', 1);
-        $pdf->Cell($size_cell_nb_jours, 5,  _('divers_nb_jours_maj_1') , 1, 0, 'C', 1);
-        $pdf->Cell($size_cell_debut, 5,  _('divers_debut_maj_1') , 1, 0, 'C', 1);
-        $pdf->Cell($size_cell_fin, 5,  _('divers_fin_maj_1') , 1, 0, 'C', 1);
-        $pdf->Cell($size_cell_comment, 5,  _('divers_comment_maj_1') , 1, 1, 'C', 1);
+        $pdf->Cell($size_cell_type, 5, _('divers_type_maj_1'), 1, 0, 'C', 1);
+        $pdf->Cell($size_cell_etat, 5, _('divers_etat_maj_1'), 1, 0, 'C', 1);
+        $pdf->Cell($size_cell_nb_jours, 5, _('divers_nb_jours_maj_1'), 1, 0, 'C', 1);
+        $pdf->Cell($size_cell_debut, 5, _('divers_debut_maj_1'), 1, 0, 'C', 1);
+        $pdf->Cell($size_cell_fin, 5, _('divers_fin_maj_1'), 1, 0, 'C', 1);
+        $pdf->Cell($size_cell_comment, 5, _('divers_comment_maj_1'), 1, 1, 'C', 1);
 
         while ($resultat2 = $ReqLog2->fetch_array()) {
-            $sql_p_date_deb = eng_date_to_fr($resultat2["p_date_deb"]);
+            $sql_p_date_deb      = eng_date_to_fr($resultat2["p_date_deb"]);
             $sql_p_demi_jour_deb = $resultat2["p_demi_jour_deb"];
-            if($sql_p_demi_jour_deb=="am") {
-                $demi_j_deb =  _('divers_am_short') ;
+            if ($sql_p_demi_jour_deb == "am") {
+                $demi_j_deb = _('divers_am_short');
             } else {
-                $demi_j_deb =  _('divers_pm_short') ;
+                $demi_j_deb = _('divers_pm_short');
             }
-            $sql_p_date_fin = eng_date_to_fr($resultat2["p_date_fin"]);
+            $sql_p_date_fin      = eng_date_to_fr($resultat2["p_date_fin"]);
             $sql_p_demi_jour_fin = $resultat2["p_demi_jour_fin"];
-            if($sql_p_demi_jour_fin=="am") {
-                $demi_j_fin =  _('divers_am_short') ;
+            if ($sql_p_demi_jour_fin == "am") {
+                $demi_j_fin = _('divers_am_short');
             } else {
-                $demi_j_fin =  _('divers_pm_short') ;
+                $demi_j_fin = _('divers_pm_short');
             }
-            $sql_p_nb_jours = $resultat2["p_nb_jours"];
-            $sql_p_commentaire = $resultat2["p_commentaire"];
-            $sql_p_type = $resultat2["p_type"];
-            $sql_p_etat = $resultat2["p_etat"];
-            $sql_p_date_demande = $resultat2["p_date_demande"];
+            $sql_p_nb_jours        = $resultat2["p_nb_jours"];
+            $sql_p_commentaire     = $resultat2["p_commentaire"];
+            $sql_p_type            = $resultat2["p_type"];
+            $sql_p_etat            = $resultat2["p_etat"];
+            $sql_p_date_demande    = $resultat2["p_date_demande"];
             $sql_p_date_traitement = $resultat2["p_date_traitement"];
 
             // decalage pour centrer
             $pdf->Cell($decalage);
-            $hauteur_cellule=5;
+            $hauteur_cellule = 5;
 
-            $taille_font=8;
+            $taille_font = 8;
 
             $pdf->SetFont('Times', '', $taille_font);
 
-            $pdf->Cell($size_cell_type, $hauteur_cellule*2, $tab_type_all_cong[$sql_p_type]['libelle'], 1, 0, 'C');
+            $pdf->Cell($size_cell_type, $hauteur_cellule * 2, $tab_type_all_cong[$sql_p_type]['libelle'], 1, 0, 'C');
 
-            if($sql_p_etat=="refus")
-                $text_etat =  _('divers_refuse') ;
-            elseif($sql_p_etat=="annul")
-                $text_etat =  _('divers_annule') ;
-            else
-                $text_etat=$sql_p_etat;
-            $pdf->Cell($size_cell_etat, $hauteur_cellule*2, $text_etat, 1, 0, 'C');
+            if ($sql_p_etat == "refus") {
+                $text_etat = _('divers_refuse');
+            } elseif ($sql_p_etat == "annul") {
+                $text_etat = _('divers_annule');
+            } else {
+                $text_etat = $sql_p_etat;
+            }
 
-            if( ($sql_p_etat=="refus") || ($sql_p_etat=="annul") )
+            $pdf->Cell($size_cell_etat, $hauteur_cellule * 2, $text_etat, 1, 0, 'C');
+
+            if (($sql_p_etat == "refus") || ($sql_p_etat == "annul")) {
                 $pdf->SetFont('Times', '', $taille_font);
-            else
+            } else {
                 $pdf->SetFont('Times', 'B', $taille_font);
+            }
 
-            if($sql_p_etat=="ok")
-                $text_nb_jours="-".$sql_p_nb_jours;
-            elseif($sql_p_etat=="ajout")
-                $text_nb_jours="+".$sql_p_nb_jours;
-            else
-                $text_nb_jours=$sql_p_nb_jours;
-            $pdf->Cell($size_cell_nb_jours, $hauteur_cellule*2, $text_nb_jours, 1, 0, 'C');
+            if ($sql_p_etat == "ok") {
+                $text_nb_jours = "-" . $sql_p_nb_jours;
+            } elseif ($sql_p_etat == "ajout") {
+                $text_nb_jours = "+" . $sql_p_nb_jours;
+            } else {
+                $text_nb_jours = $sql_p_nb_jours;
+            }
+
+            $pdf->Cell($size_cell_nb_jours, $hauteur_cellule * 2, $text_nb_jours, 1, 0, 'C');
 
             $pdf->SetFont('Times', '', $taille_font);
-            $pdf->Cell($size_cell_debut, $hauteur_cellule*2, $sql_p_date_deb." _ ".$demi_j_deb, 1, 0, 'C');
-            $pdf->Cell($size_cell_fin, $hauteur_cellule*2, $sql_p_date_fin." _ ".$demi_j_fin, 1, 0, 'C');
+            $pdf->Cell($size_cell_debut, $hauteur_cellule * 2, $sql_p_date_deb . " _ " . $demi_j_deb, 1, 0, 'C');
+            $pdf->Cell($size_cell_fin, $hauteur_cellule * 2, $sql_p_date_fin . " _ " . $demi_j_fin, 1, 0, 'C');
             // reduction de la taille du commentaire pour rentrer dans la cellule
-            if(strlen($sql_p_commentaire)>39)
-                $sql_p_commentaire = substr($sql_p_commentaire, 0, 35)." ..." ;
+            if (strlen($sql_p_commentaire) > 39) {
+                $sql_p_commentaire = substr($sql_p_commentaire, 0, 35) . " ...";
+            }
 
-            $pdf->Cell($size_cell_comment, $hauteur_cellule*2, $sql_p_commentaire."\n ", 1, 'L');
-            $pdf->MultiCell($size_cell_date_traitement, $hauteur_cellule, "demande : ".$sql_p_date_demande."\ntraitement : ".$sql_p_date_traitement , 1, 'L' );
+            $pdf->Cell($size_cell_comment, $hauteur_cellule * 2, $sql_p_commentaire . "\n ", 1, 'L');
+            $pdf->MultiCell($size_cell_date_traitement, $hauteur_cellule, "demande : " . $sql_p_date_demande . "\ntraitement : " . $sql_p_date_traitement, 1, 'L');
         }
     }
 
@@ -747,21 +758,19 @@ class Fonctions
     public static function affiche_pdf_nouveau_solde(&$pdf, $login, $tab_info_edition, $tab_type_cong, $tab_type_conges_exceptionnels, $decalage)
     {
 
-        foreach($tab_type_cong as $id_abs => $libelle)
-        {
+        foreach ($tab_type_cong as $id_abs => $libelle) {
             $pdf->Cell($decalage);
             $pdf->SetFont('Times', '', 10);
-            $pdf->Cell(24, 5,  _('editions_nouveau_solde') ." ",0,0);
+            $pdf->Cell(24, 5, _('editions_nouveau_solde') . " ", 0, 0);
             $pdf->SetFont('Times', 'B', 10);
-            $pdf->Cell(40, 5, $libelle." : ".$tab_info_edition['conges'][$id_abs], 0, 1);
+            $pdf->Cell(40, 5, $libelle . " : " . $tab_info_edition['conges'][$id_abs], 0, 1);
         }
-        foreach($tab_type_conges_exceptionnels as $id_abs => $libelle)
-        {
+        foreach ($tab_type_conges_exceptionnels as $id_abs => $libelle) {
             $pdf->Cell($decalage);
             $pdf->SetFont('Times', '', 10);
-            $pdf->Cell(24, 5,  _('editions_nouveau_solde') ." ",0,0);
+            $pdf->Cell(24, 5, _('editions_nouveau_solde') . " ", 0, 0);
             $pdf->SetFont('Times', 'B', 10);
-            $pdf->Cell(40, 5, $libelle." : ".$tab_info_edition['conges'][$id_abs], 0, 1);
+            $pdf->Cell(40, 5, $libelle . " : " . $tab_info_edition['conges'][$id_abs], 0, 1);
         }
     }
 
@@ -771,31 +780,26 @@ class Fonctions
         //    $pdf->SetFont('Times', 'B', 10);
 
         $edition_precedente_id = \edition\Fonctions::get_id_edition_precedente_user($login, $edit_id);
-        if($edition_precedente_id==0)
-        {
+        if ($edition_precedente_id == 0) {
             $pdf->Cell($decalage);
             $pdf->SetFont('Times', '', 10);
-            $pdf->Cell(50, 5,  _('editions_soldes_precedents_inconnus') ." !...",0,1);
-        }
-        else
-        {
+            $pdf->Cell(50, 5, _('editions_soldes_precedents_inconnus') . " !...", 0, 1);
+        } else {
             $tab_edition_precedente = \edition\Fonctions::recup_info_edition($edition_precedente_id);
 
-            foreach($tab_type_cong as $id_abs => $libelle)
-            {
+            foreach ($tab_type_cong as $id_abs => $libelle) {
                 $pdf->Cell($decalage);
                 $pdf->SetFont('Times', '', 10);
-                $pdf->Cell(26, 5,  _('editions_solde_precedent') ." ",0,0);
+                $pdf->Cell(26, 5, _('editions_solde_precedent') . " ", 0, 0);
                 $pdf->SetFont('Times', 'B', 10);
-                $pdf->Cell(10, 5, $libelle." : ".$tab_edition_precedente['conges'][$id_abs], 0, 1);
+                $pdf->Cell(10, 5, $libelle . " : " . $tab_edition_precedente['conges'][$id_abs], 0, 1);
             }
-            foreach($tab_type_conges_exceptionnels as $id_abs => $libelle)
-            {
+            foreach ($tab_type_conges_exceptionnels as $id_abs => $libelle) {
                 $pdf->Cell($decalage);
                 $pdf->SetFont('Times', '', 10);
-                $pdf->Cell(26, 5,  _('editions_solde_precedent') ." ",0,0);
+                $pdf->Cell(26, 5, _('editions_solde_precedent') . " ", 0, 0);
                 $pdf->SetFont('Times', 'B', 10);
-                $pdf->Cell(10, 5, $libelle." : ".$tab_edition_precedente['conges'][$id_abs], 0, 1);
+                $pdf->Cell(10, 5, $libelle . " : " . $tab_edition_precedente['conges'][$id_abs], 0, 1);
             }
         }
     }
@@ -804,23 +808,23 @@ class Fonctions
     public static function affiche_pdf_tableau_bilan_conges_user_edtion(&$pdf, $tab_info_user, $tab_info_edition, $tab_type_cong, $tab_type_conges_exceptionnels)
     {
         // calcul du décalage pour centrer ( = (21cm - (marges x 2) - (sommes des cell définies en dessous) )/2  ) (marges=10mm)
-        $decalage = 55 ;
+        $decalage = 55;
 
         // affichage :
         $pdf->SetFont('Times', 'B', 11);
 
         $pdf->Cell($decalage);
         $pdf->Cell(40, 5, " ", 1, 0, 'C');
-        $pdf->Cell(20, 5, " ". _('editions_jours_an') , 1, 0, 'C');
-        $pdf->Cell(20, 5,  _('divers_solde_maj_1') ." ", 1, 1, 'C');
+        $pdf->Cell(20, 5, " " . _('editions_jours_an'), 1, 0, 'C');
+        $pdf->Cell(20, 5, _('divers_solde_maj_1') . " ", 1, 1, 'C');
 
-        foreach($tab_type_cong as $id_abs => $libelle) {
+        foreach ($tab_type_cong as $id_abs => $libelle) {
             $pdf->Cell($decalage);
             $pdf->Cell(40, 5, " $libelle ", 1, 0, 'C');
             $pdf->Cell(20, 5, $tab_info_user['conges'][$libelle]['nb_an'], 1, 0, 'C');
             $pdf->Cell(20, 5, $tab_info_edition['conges'][$id_abs], 1, 1, 'C', 1);
         }
-        foreach($tab_type_conges_exceptionnels as $id_abs => $libelle) {
+        foreach ($tab_type_conges_exceptionnels as $id_abs => $libelle) {
             $pdf->Cell($decalage);
             $pdf->Cell(40, 5, " $libelle ", 1, 0, 'C');
             $pdf->Cell(20, 5, $tab_info_user['conges'][$libelle]['nb_an'], 1, 0, 'C');
@@ -834,15 +838,15 @@ class Fonctions
     public static function edition_pdf($login, $edit_id)
     {
         // recup du tableau des types de conges (seulement les conges)
-        $tab_type_cong=recup_tableau_types_conges();
+        $tab_type_cong = recup_tableau_types_conges();
         // recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-            $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
+            $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
         } else {
-            $tab_type_conges_exceptionnels=array();
+            $tab_type_conges_exceptionnels = array();
         }
         // recup du tableau de tous les types de conges
-        $tab_type_all_cong=recup_tableau_tout_types_abs();
+        $tab_type_all_cong = recup_tableau_tout_types_abs();
 
         // recup infos du user
         $tab_info_user = \edition\Fonctions::recup_info_user_pour_edition($login);
@@ -850,14 +854,13 @@ class Fonctions
         // recup infos de l'édition
         $tab_info_edition = \edition\Fonctions::recup_info_edition($edit_id);
 
-
         /**************************************/
         /* on commence l'affichage ...        */
         /**************************************/
         header('content-type: application/pdf');
         //header('content-Disposition: attachement; filename="downloaded.pdf"');    // pour IE
 
-        $pdf=new \edition\PDF( 'P', 'mm', 'A4', true, "UTF-8");
+        $pdf = new \edition\PDF('P', 'mm', 'A4', true, "UTF-8");
         $pdf->AddPage();
         $pdf->SetFillColor(200);
 
@@ -870,29 +873,28 @@ class Fonctions
         /* affichage du TITRE                 */
         /**************************************/
         $pdf->SetFont('Times', 'B', 18);
-        $pdf->Cell(0, 5, $tab_info_user['nom']." ".  $tab_info_user['prenom'],0,1,'C');
+        $pdf->Cell(0, 5, $tab_info_user['nom'] . " " . $tab_info_user['prenom'], 0, 1, 'C');
         $pdf->Ln(5);
         $pdf->SetFont('Times', 'B', 13);
-        $tab_date=explode("-", $tab_info_edition['date']);
-        $pdf->Cell(0, 5,  _('editions_bilan_au') ." ".$tab_date[2]." / ".$tab_date[1]." / ".$tab_date[0],0,1,'C');
+        $tab_date = explode("-", $tab_info_edition['date']);
+        $pdf->Cell(0, 5, _('editions_bilan_au') . " " . $tab_date[2] . " / " . $tab_date[1] . " / " . $tab_date[0], 0, 1, 'C');
         $pdf->Ln(4);
 
         /****************************/
         /* tableau Bilan des Conges */
         /****************************/
         // affichage en pdf du tableau récapitulatif des solde de congés d'un user
-        \edition\Fonctions::affiche_pdf_tableau_bilan_conges_user_edtion($pdf, $tab_info_user, $tab_info_edition, $tab_type_cong, $tab_type_conges_exceptionnels) ;
+        \edition\Fonctions::affiche_pdf_tableau_bilan_conges_user_edtion($pdf, $tab_info_user, $tab_info_edition, $tab_type_cong, $tab_type_conges_exceptionnels);
 
         // affichage de la quotité
         $pdf->SetFont('Times', 'B', 13);
-        $quotite=$tab_info_user['quotite'];
-        $pdf->Cell(0, 5,  _('divers_quotite') ."  :  $quotite % ",0,1,'C');
+        $quotite = $tab_info_user['quotite'];
+        $pdf->Cell(0, 5, _('divers_quotite') . "  :  $quotite % ", 0, 1, 'C');
         $pdf->Ln(4);
         $pdf->Ln(8);
 
-
         $pdf->SetFont('Times', 'BU', 11);
-        $pdf->Cell(0, 5,  _('editions_historique') ." :",0,1,'C');
+        $pdf->Cell(0, 5, _('editions_historique') . " :", 0, 1, 'C');
         $pdf->Ln(5);
         /*********************************************/
         /* Tableau Historique des Conges et demandes */
@@ -905,15 +907,15 @@ class Fonctions
 
         // Récupération des informations
         // on ne recup QUE les periodes de l'edition choisie
-        $sql2 = "SELECT p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_etat, p_date_demande, p_date_traitement ";
-        $sql2=$sql2."FROM conges_periode ";
-        $sql2=$sql2."WHERE p_edition_id = $edit_id ";
-        $sql2=$sql2."ORDER BY p_date_deb ASC ";
-        $ReqLog2 = \includes\SQL::query($sql2) ;
+        $sql2    = "SELECT p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_etat, p_date_demande, p_date_traitement ";
+        $sql2    = $sql2 . "FROM conges_periode ";
+        $sql2    = $sql2 . "WHERE p_edition_id = $edit_id ";
+        $sql2    = $sql2 . "ORDER BY p_date_deb ASC ";
+        $ReqLog2 = \includes\SQL::query($sql2);
 
-        $count2=$ReqLog2->num_rows;
-        if($count2==0) {
-            $pdf->Cell(0, 5,  _('editions_aucun_conges') ." ...",0,1,'C');
+        $count2 = $ReqLog2->num_rows;
+        if ($count2 == 0) {
+            $pdf->Cell(0, 5, _('editions_aucun_conges') . " ...", 0, 1, 'C');
             $pdf->Ln(5);
         } else {
             // AFFICHAGE TABLEAU
@@ -924,13 +926,13 @@ class Fonctions
             /* affichage anciens soldes          */
             /*************************************/
             // affichage en pdf des anciens soldes de congés d'un user
-            \edition\Fonctions::affiche_pdf_ancien_solde($pdf, $login, $edit_id, $tab_type_cong, $tab_type_conges_exceptionnels, $decalage) ;
+            \edition\Fonctions::affiche_pdf_ancien_solde($pdf, $login, $edit_id, $tab_type_cong, $tab_type_conges_exceptionnels, $decalage);
 
             $pdf->Ln(2);
 
             // (largeur totale page = 210 ( - 2x10 de marge))
             // tailles des cellules du tableau
-            if($_SESSION['config']['affiche_date_traitement']) {
+            if ($_SESSION['config']['affiche_date_traitement']) {
                 \edition\Fonctions::affiche_tableau_conges_avec_date_traitement($pdf, $ReqLog2, $decalage, $tab_type_all_cong);
             } else {
                 \edition\Fonctions::affiche_tableau_conges_normal($pdf, $ReqLog2, $decalage, $tab_type_all_cong);
@@ -942,7 +944,7 @@ class Fonctions
             /* affichage nouveaux soldes         */
             /*************************************/
             // affichage en pdf des nouveaux soldes de congés d'un user
-            \edition\Fonctions::affiche_pdf_nouveau_solde($pdf, $login, $tab_info_edition, $tab_type_cong, $tab_type_conges_exceptionnels, $decalage) ;
+            \edition\Fonctions::affiche_pdf_nouveau_solde($pdf, $login, $tab_info_edition, $tab_type_cong, $tab_type_conges_exceptionnels, $decalage);
         }
 
         $pdf->Ln(8);
@@ -953,18 +955,18 @@ class Fonctions
         $pdf->SetFont('Times', 'B', 10);
         // decalage pour centrer
         $pdf->Cell(20);
-        $pdf->Cell(70, 5,  _('editions_date') ." :",0,0);
-        $pdf->Cell(70, 5,  _('editions_date') ." :",0,1);
+        $pdf->Cell(70, 5, _('editions_date') . " :", 0, 0);
+        $pdf->Cell(70, 5, _('editions_date') . " :", 0, 1);
         // decalage pour centrer
         $pdf->Cell(20);
-        $pdf->Cell(70, 5,  _('editions_signature_1') ." :",0,0);
-        $pdf->Cell(70, 5,  _('editions_signature_2') ." :",0,1);
+        $pdf->Cell(70, 5, _('editions_signature_1') . " :", 0, 0);
+        $pdf->Cell(70, 5, _('editions_signature_2') . " :", 0, 1);
 
         $pdf->SetFont('Times', 'I', 10);
         // decalage pour centrer
         $pdf->Cell(20);
-        $pdf->Cell(70, 5, "",0,0);
-        $pdf->Cell(70, 5, "(". _('editions_cachet_etab') .")",0,1);
+        $pdf->Cell(70, 5, "", 0, 0);
+        $pdf->Cell(70, 5, "(" . _('editions_cachet_etab') . ")", 0, 1);
 
         $pdf->Ln(30);
 
@@ -990,17 +992,18 @@ class Fonctions
         /*************************************/
         // recup des parametres reçus :
         // GET / POST
-        $user_login = getpost_variable('user_login') ;
-        $edit_id = getpost_variable('edit_id', 0) ;
+        $user_login = getpost_variable('user_login');
+        $edit_id    = getpost_variable('edit_id', 0);
         /*************************************/
 
-        if ($user_login != $_SESSION['userlogin'] && !is_hr($_SESSION['userlogin']) && !is_resp_of_user($_SESSION['userlogin'] , $user_login)) {
+        if ($user_login != $_SESSION['userlogin'] && !is_hr($_SESSION['userlogin']) && !is_resp_of_user($_SESSION['userlogin'], $user_login)) {
             redirect(ROOT_PATH . 'deconnexion.php');
             exit;
         }
 
         /************************************/
-        if($edit_id==0) {  // si c'est une nouvelle édition, on insert dans la base avant d'éditer et on renvoit l'id de l'édition
+        if ($edit_id == 0) {
+            // si c'est une nouvelle édition, on insert dans la base avant d'éditer et on renvoit l'id de l'édition
             $edit_id = \edition\Fonctions::enregistrement_edition($user_login);
         }
 
@@ -1014,28 +1017,26 @@ class Fonctions
     // renvoit un tableau vide si pas de'edition pour le user
     public static function recup_editions_user($login)
     {
-        $tab_ed=array();
+        $tab_ed = array();
 
-        $sql2 = "SELECT ep_id, ep_date, ep_num_for_user ";
-        $sql2=$sql2."FROM conges_edition_papier WHERE ep_login = '$login' ";
-        $sql2=$sql2."ORDER BY ep_num_for_user DESC ";
+        $sql2    = "SELECT ep_id, ep_date, ep_num_for_user ";
+        $sql2    = $sql2 . "FROM conges_edition_papier WHERE ep_login = '$login' ";
+        $sql2    = $sql2 . "ORDER BY ep_num_for_user DESC ";
         $ReqLog2 = \includes\SQL::query($sql2);
 
-        if($ReqLog2->num_rows != 0)
-        {
-            while ($resultat2 = $ReqLog2->fetch_array())
-            {
-                $tab=array();
-                $sql_id = $resultat2["ep_id"];
-                $tab['date'] = eng_date_to_fr($resultat2["ep_date"]);
+        if ($ReqLog2->num_rows != 0) {
+            while ($resultat2 = $ReqLog2->fetch_array()) {
+                $tab                 = array();
+                $sql_id              = $resultat2["ep_id"];
+                $tab['date']         = eng_date_to_fr($resultat2["ep_date"]);
                 $tab['num_for_user'] = $resultat2["ep_num_for_user"];
                 // recup du tab des soldes des conges pour cette edition
                 $tab['conges'] = \edition\Fonctions::recup_solde_conges_of_edition($sql_id);
 
-                $tab_ed[$sql_id]=$tab;
+                $tab_ed[$sql_id] = $tab;
             }
         }
-        return $tab_ed ;
+        return $tab_ed;
     }
 
     // recup infos de l'édition
@@ -1043,36 +1044,35 @@ class Fonctions
     public static function recup_info_edition($edit_id)
     {
 
-        $tab=array();
+        $tab = array();
 
-        $sql_edition= 'SELECT ep_date, ep_num_for_user FROM conges_edition_papier where ep_id = '.\includes\SQL::quote($edit_id);
+        $sql_edition    = 'SELECT ep_date, ep_num_for_user FROM conges_edition_papier where ep_id = ' . \includes\SQL::quote($edit_id);
         $ReqLog_edition = \includes\SQL::query($sql_edition);
 
-        if($resultat_edition = $ReqLog_edition->fetch_array())
-        {
-            $tab['date']=$resultat_edition["ep_date"];
+        if ($resultat_edition = $ReqLog_edition->fetch_array()) {
+            $tab['date']         = $resultat_edition["ep_date"];
             $tab['num_for_user'] = $resultat_edition["ep_num_for_user"];
             // recup du tab des soldes des conges pour cette edition
             $tab['conges'] = \edition\Fonctions::recup_solde_conges_of_edition($edit_id);
         }
-        return $tab ;
+        return $tab;
     }
 
     // recup infos du user
     public static function recup_info_user_pour_edition($login)
     {
-        $tab=array();
-        $sql_user = 'SELECT u_nom, u_prenom, u_quotite FROM conges_users where u_login = "'. \includes\SQL::quote($login).'"';
+        $tab         = array();
+        $sql_user    = 'SELECT u_nom, u_prenom, u_quotite FROM conges_users where u_login = "' . \includes\SQL::quote($login) . '"';
         $ReqLog_user = \includes\SQL::query($sql_user);
 
         while ($resultat_user = $ReqLog_user->fetch_array()) {
-            $tab['nom']=$resultat_user["u_nom"];
-            $tab['prenom']=$resultat_user["u_prenom"];
-            $tab['quotite']=$sql_quotite=$resultat_user["u_quotite"];
+            $tab['nom']     = $resultat_user["u_nom"];
+            $tab['prenom']  = $resultat_user["u_prenom"];
+            $tab['quotite'] = $sql_quotite = $resultat_user["u_quotite"];
         }
 
         // recup dans un tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-        $tab['conges']=recup_tableau_conges_for_user($login, false) ;
+        $tab['conges'] = recup_tableau_conges_for_user($login, false);
 
         return $tab;
     }
@@ -1081,15 +1081,14 @@ class Fonctions
     public static function recup_solde_conges_of_edition($edition_id)
     {
 
-        $tab=array();
-        $sql_ed = 'SELECT se_id_absence, se_solde FROM conges_solde_edition where se_id_edition = '.\includes\SQL::quote($edition_id);
+        $tab       = array();
+        $sql_ed    = 'SELECT se_id_absence, se_solde FROM conges_solde_edition where se_id_edition = ' . \includes\SQL::quote($edition_id);
         $ReqLog_ed = \includes\SQL::query($sql_ed);
 
-        $tab=array();
-        while ($resultat_ed = $ReqLog_ed->fetch_array())
-        {
-            $id_absence=$resultat_ed["se_id_absence"];
-            $tab[$id_absence]=$resultat_ed["se_solde"];
+        $tab = array();
+        while ($resultat_ed = $ReqLog_ed->fetch_array()) {
+            $id_absence       = $resultat_ed["se_id_absence"];
+            $tab[$id_absence] = $resultat_ed["se_solde"];
         }
         return $tab;
     }
@@ -1099,17 +1098,17 @@ class Fonctions
     {
 
         // verif si le user n'a pas une seule edition
-        $sql1 = 'SELECT * FROM conges_edition_papier WHERE ep_login="'.\includes\SQL::quote($login).'"';
+        $sql1    = 'SELECT * FROM conges_edition_papier WHERE ep_login="' . \includes\SQL::quote($login) . '"';
         $ReqLog1 = \includes\SQL::query($sql1);
 
-        $resultat1 = $ReqLog1->num_rows ;
-        if($resultat1<=1)    // une seule edition pour ce user
-            return 0;
-        else
+        $resultat1 = $ReqLog1->num_rows;
+        if ($resultat1 <= 1) // une seule edition pour ce user
         {
-            $sql2 = 'SELECT MAX(ep_id) FROM conges_edition_papier WHERE ep_login="'. \includes\SQL::quote($login).'" AND ep_id<'.\includes\SQL::quote($edition_id);
+            return 0;
+        } else {
+            $sql2    = 'SELECT MAX(ep_id) FROM conges_edition_papier WHERE ep_login="' . \includes\SQL::quote($login) . '" AND ep_id<' . \includes\SQL::quote($edition_id);
             $ReqLog2 = \includes\SQL::query($sql2);
-            $tmp = $ReqLog2->fetch_row();
+            $tmp     = $ReqLog2->fetch_row();
             return $tmp[0];
         }
     }
@@ -1119,16 +1118,17 @@ class Fonctions
     {
 
         // verif si le user a une edition
-        $sql1 = 'SELECT ep_num_for_user FROM conges_edition_papier WHERE ep_login="'. \includes\SQL::quote($login).'"';
+        $sql1    = 'SELECT ep_num_for_user FROM conges_edition_papier WHERE ep_login="' . \includes\SQL::quote($login) . '"';
         $ReqLog1 = \includes\SQL::query($sql1);
 
-        if($ReqLog1->num_rows==0)
-            return 0;    // c'est qu'il n'y a pas encore d'edition pour ce user
-        else
-        {
-            $sql2 = 'SELECT MAX(ep_num_for_user) FROM conges_edition_papier WHERE ep_login="'. \includes\SQL::quote($login).'"';
+        if ($ReqLog1->num_rows == 0) {
+            return 0;
+        }
+        // c'est qu'il n'y a pas encore d'edition pour ce user
+        else {
+            $sql2    = 'SELECT MAX(ep_num_for_user) FROM conges_edition_papier WHERE ep_login="' . \includes\SQL::quote($login) . '"';
             $ReqLog2 = \includes\SQL::query($sql2);
-            $tmp = $ReqLog2->fetch_row();
+            $tmp     = $ReqLog2->fetch_row();
             return $tmp[0];
         }
     }
@@ -1137,16 +1137,17 @@ class Fonctions
     public static function get_last_edition_id()
     {
         // verif si table edition pas vide
-        $sql1 = "SELECT ep_id FROM conges_edition_papier ";
+        $sql1    = "SELECT ep_id FROM conges_edition_papier ";
         $ReqLog1 = \includes\SQL::query($sql1);
 
-        if($ReqLog1->num_rows==0)
-            return 0;    // c'est qu'il n'y a pas encore d'edition
-        else
-        {
-            $sql2 = 'SELECT MAX(ep_id) FROM conges_edition_papier ';
+        if ($ReqLog1->num_rows == 0) {
+            return 0;
+        }
+        // c'est qu'il n'y a pas encore d'edition
+        else {
+            $sql2    = 'SELECT MAX(ep_id) FROM conges_edition_papier ';
             $ReqLog2 = \includes\SQL::query($sql2);
-            $tmp = $ReqLog2->fetch_row();
+            $tmp     = $ReqLog2->fetch_row();
             return $tmp[0];
         }
     }
@@ -1156,18 +1157,17 @@ class Fonctions
 
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
-        $tab_solde_user=array();
-        $sql1 = 'SELECT su_abs_id, su_solde FROM conges_solde_user where su_login = "'. \includes\SQL::quote($login).'"';
-        $ReqLog1 = \includes\SQL::query($sql1);
+        $tab_solde_user = array();
+        $sql1           = 'SELECT su_abs_id, su_solde FROM conges_solde_user where su_login = "' . \includes\SQL::quote($login) . '"';
+        $ReqLog1        = \includes\SQL::query($sql1);
 
-        while ($resultat1 = $ReqLog1->fetch_array())
-        {
-            $sql_id=$resultat1["su_abs_id"];
-            $tab_solde_user[$sql_id]=$resultat1["su_solde"];
+        while ($resultat1 = $ReqLog1->fetch_array()) {
+            $sql_id                  = $resultat1["su_abs_id"];
+            $tab_solde_user[$sql_id] = $resultat1["su_solde"];
         }
-        $new_edition_id = \edition\Fonctions::get_last_edition_id()+1;
-        $aujourdhui = date("Y-m-d");
-        $num_for_user = \edition\Fonctions::get_num_last_edition_user($login)+1;
+        $new_edition_id = \edition\Fonctions::get_last_edition_id() + 1;
+        $aujourdhui     = date("Y-m-d");
+        $num_for_user   = \edition\Fonctions::get_num_last_edition_user($login) + 1;
 
         /*************************************************/
         /* Insertion dans le table conges_edition_papier */
@@ -1176,24 +1176,20 @@ class Fonctions
                 SET ep_id=$new_edition_id, ep_login='$login', ep_date='$aujourdhui', ep_num_for_user=$num_for_user ";
         $result_insert = \includes\SQL::query($sql_insert);
 
-
         /*************************************************/
         /* Insertion dans le table conges_solde_edition  */
         /*************************************************/
         // recup du tableau des types de conges (seulement les conges)
-        $tab_type_cong=recup_tableau_types_conges();
-        foreach($tab_type_cong as $id_abs => $libelle)
-        {
+        $tab_type_cong = recup_tableau_types_conges();
+        foreach ($tab_type_cong as $id_abs => $libelle) {
             $sql_insert_2 = "INSERT INTO conges_solde_edition
                     SET se_id_edition=$new_edition_id, se_id_absence=$id_abs, se_solde=$tab_solde_user[$id_abs] ";
             $result_insert_2 = \includes\SQL::query($sql_insert_2);
         }
-        if ($_SESSION['config']['gestion_conges_exceptionnels'])
-        {
-            $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
-            foreach($tab_type_conges_exceptionnels as $id_abs => $libelle)
-            {
-                $sql_insert_3 = "INSERT INTO conges_solde_edition SET se_id_edition=$new_edition_id, se_id_absence=$id_abs, se_solde=$tab_solde_user[$id_abs] ";
+        if ($_SESSION['config']['gestion_conges_exceptionnels']) {
+            $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
+            foreach ($tab_type_conges_exceptionnels as $id_abs => $libelle) {
+                $sql_insert_3    = "INSERT INTO conges_solde_edition SET se_id_edition=$new_edition_id, se_id_absence=$id_abs, se_solde=$tab_solde_user[$id_abs] ";
                 $result_insert_3 = \includes\SQL::query($sql_insert_3);
             }
         }
@@ -1202,22 +1198,23 @@ class Fonctions
         /* Update du num edition dans la table periode pour les Conges et demandes de cette edition */
         /********************************************************************************************/
         // recup de la liste des id des absence de type conges !
-        $sql_list="SELECT ta_id FROM conges_type_absence WHERE ta_type='conges' OR ta_type='conges_exceptionnels'";
+        $sql_list    = "SELECT ta_id FROM conges_type_absence WHERE ta_type='conges' OR ta_type='conges_exceptionnels'";
         $ReqLog_list = \includes\SQL::query($sql_list);
 
-        $list_abs_id="";
-        while($resultat_list = $ReqLog_list->fetch_array())
-        {
-            if($list_abs_id=="")
-                $list_abs_id=$resultat_list['ta_id'] ;
-            else
-                $list_abs_id=$list_abs_id.", ".$resultat_list['ta_id'] ;
+        $list_abs_id = "";
+        while ($resultat_list = $ReqLog_list->fetch_array()) {
+            if ($list_abs_id == "") {
+                $list_abs_id = $resultat_list['ta_id'];
+            } else {
+                $list_abs_id = $list_abs_id . ", " . $resultat_list['ta_id'];
+            }
+
         }
 
-        $sql_update = 'UPDATE conges_periode SET p_edition_id=\''.$new_edition_id.'\'
-                WHERE p_login = \''.$login.'\'
+        $sql_update = 'UPDATE conges_periode SET p_edition_id=\'' . $new_edition_id . '\'
+                WHERE p_login = \'' . $login . '\'
                 AND p_edition_id IS NULL
-                AND (p_type IN ('.$list_abs_id.') )
+                AND (p_type IN (' . $list_abs_id . ') )
                 AND (p_etat!=\'demande\') ';
         $ReqLog_update = \includes\SQL::query($sql_update);
 

--- a/edition/PDF.php
+++ b/edition/PDF.php
@@ -4,24 +4,24 @@ namespace edition;
 
 class PDF extends \TCPDF
 {
-    function Header()
+    public function Header()
     {
         /**************************************/
         /* affichage du texte en haut de page */
         /**************************************/
-        $this->SetFont('Times','',10);
-        $this->Cell(0,3, $_SESSION['config']['texte_haut_edition_papier'],0,1,'C');
+        $this->SetFont('Times', '', 10);
+        $this->Cell(0, 3, $_SESSION['config']['texte_haut_edition_papier'], 0, 1, 'C');
         $this->Ln(10);
     }
 
-    function Footer()
+    public function Footer()
     {
         /**************************************/
         /* affichage du texte de bas de page */
         /**************************************/
-        $this->SetFont('Times','',10);
+        $this->SetFont('Times', '', 10);
         //$pdf->Cell(0,6, 'texte_haut_edition_papier',0,1,'C');
-        $this->Cell(0,3, $_SESSION['config']['texte_bas_edition_papier'],0,1,'C');
+        $this->Cell(0, 3, $_SESSION['config']['texte_bas_edition_papier'], 0, 1, 'C');
         $this->Ln(10);
     }
 }

--- a/edition/edit_user.php
+++ b/edition/edit_user.php
@@ -3,11 +3,11 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-include_once ROOT_PATH .'fonctions_conges.php' ;
-include_once INCLUDE_PATH .'fonction.php';
-include_once INCLUDE_PATH .'session.php';
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+include_once INCLUDE_PATH . 'session.php';
 
 echo \edition\Fonctions::editUserModule($session);
 bottom();

--- a/edition/edition_papier.php
+++ b/edition/edition_papier.php
@@ -3,11 +3,11 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-include_once ROOT_PATH .'fonctions_conges.php' ;
-include_once INCLUDE_PATH .'fonction.php';
-include_once INCLUDE_PATH .'session.php';
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+include_once INCLUDE_PATH . 'session.php';
 
 echo \edition\Fonctions::editPapierModule($session);
 bottom();

--- a/edition/edition_pdf.php
+++ b/edition/edition_pdf.php
@@ -3,10 +3,10 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-include_once ROOT_PATH .'fonctions_conges.php' ;
-include_once INCLUDE_PATH .'fonction.php';
-include_once INCLUDE_PATH .'session.php';
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+include_once INCLUDE_PATH . 'session.php';
 
 \edition\Fonctions::editPDFModule($session);

--- a/export/Fonctions.php
+++ b/export/Fonctions.php
@@ -3,33 +3,35 @@
 namespace export;
 
 /**
-* Regroupement des fonctions liées à l'export
-*/
+ * Regroupement des fonctions liées à l'export
+ */
 class Fonctions
 {
     public static function form_saisie($user, $date_debut, $date_fin)
     {
-    	$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-    	$session=session_id();
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session  = session_id();
 
-    	$date_today=date("d-m-Y");
-    	if($date_debut=="")
-    		$date_debut=$date_today;
-    	if($date_fin=="")
-    		$date_fin=$date_today;
+        $date_today = date("d-m-Y");
+        if ($date_debut == "") {
+            $date_debut = $date_today;
+        }
 
-    	$huser = hash_user($user);
+        if ($date_fin == "") {
+            $date_fin = $date_today;
+        }
 
-    	header_popup();
+        $huser = hash_user($user);
 
+        header_popup();
 
-    	echo "<center>\n";
-    	echo "<h1>". _('export_cal_titre') ."</h1>\n";
+        echo "<center>\n";
+        echo "<h1>" . _('export_cal_titre') . "</h1>\n";
 
-    	echo _('button_export_2')."<br>";
-    	echo " <a href='".ROOT_PATH."export/ics_export.php?usr=".$huser."'>".$_SESSION['config']['URL_ACCUEIL_CONGES']."/export/ics_export.php?usr=".$huser."<a>";
+        echo _('button_export_2') . "<br>";
+        echo " <a href='" . ROOT_PATH . "export/ics_export.php?usr=" . $huser . "'>" . $_SESSION['config']['URL_ACCUEIL_CONGES'] . "/export/ics_export.php?usr=" . $huser . "<a>";
 
-    	bottom();
+        bottom();
     }
 
     /**
@@ -43,129 +45,135 @@ class Fonctions
      */
     public static function exportVCalendarModule($session)
     {
-    	/*** initialisation des variables ***/
-    	$session=session_id();
-    	/************************************/
+        /*** initialisation des variables ***/
+        $session = session_id();
+        /************************************/
 
-    	/*************************************/
-    	// recup des parametres reçus :
-    	// SERVER
-    	$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-    	// GET	/ POST
-    	$action     = getpost_variable('action') ;
-    	$user_login = getpost_variable('user_login') ;
-    	$date_debut = getpost_variable('date_debut') ;
-    	$date_fin   = getpost_variable('date_fin') ;
-    	$choix_format  = getpost_variable('choix_format') ;
-    	/*************************************/
+        /*************************************/
+        // recup des parametres reçus :
+        // SERVER
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        // GET    / POST
+        $action       = getpost_variable('action');
+        $user_login   = getpost_variable('user_login');
+        $date_debut   = getpost_variable('date_debut');
+        $date_fin     = getpost_variable('date_fin');
+        $choix_format = getpost_variable('choix_format');
+        /*************************************/
 
-
-    	\export\Fonctions::form_saisie($user_login, $date_debut, $date_fin);
+        \export\Fonctions::form_saisie($user_login, $date_debut, $date_fin);
     }
 
     public static function remplace_accents($str)
     {
-    	$accent        = array("à", "â", "ä", "é", "è", "ê", "ë", "î", "ï", "ô", "ö", "ù", "û", "ü", "ç");
-    	$sans_accent   = array("a", "a", "a", "e", "e", "e", "e", "i", "i", "o", "o", "u", "u", "u", "c");
-    	return str_replace($accent, $sans_accent, $str) ;
+        $accent      = array("à", "â", "ä", "é", "è", "ê", "ë", "î", "ï", "ô", "ö", "ù", "û", "ü", "ç");
+        $sans_accent = array("a", "a", "a", "e", "e", "e", "e", "i", "i", "o", "o", "u", "u", "u", "c");
+        return str_replace($accent, $sans_accent, $str);
     }
 
     // export des périodes des conges et d'absences comprise entre les 2 dates , dans un fichier texte au format ICAL
     public static function export_ical($user_login)
     {
-    	$good_date_debut = date("Y-m-d", strtotime("-1 year"));
-    	$good_date_fin = date("Y-m-d", strtotime('+1 year'));
-    		/********************************/
-    		// initialisation de variables communes a ttes les periodes
+        $good_date_debut = date("Y-m-d", strtotime("-1 year"));
+        $good_date_fin   = date("Y-m-d", strtotime('+1 year'));
+        /********************************/
+        // initialisation de variables communes a ttes les periodes
 
-    		// recup des infos du user
-    		$tab_infos_user=recup_infos_du_user($user_login, "");
+        // recup des infos du user
+        $tab_infos_user = recup_infos_du_user($user_login, "");
 
-    		$tab_types_abs=recup_tableau_tout_types_abs() ;
+        $tab_types_abs = recup_tableau_tout_types_abs();
 
-    		/********************************/
-    		// affichage dans un fichier non html !
+        /********************************/
+        // affichage dans un fichier non html !
 
-    		header("content-type: application/ics");
-    		header("Content-disposition: filename=libertempo.ics");
+        header("content-type: application/ics");
+        header("Content-disposition: filename=libertempo.ics");
 
+        echo "BEGIN:VCALENDAR\r\n" .
+            "PRODID:-//Libertempo \r\n" .
+            "VERSION:2.0\r\n\r\n";
 
-    		echo "BEGIN:VCALENDAR\r\n" .
-    				"PRODID:-//Libertempo \r\n" .
-    				"VERSION:2.0\r\n\r\n";
+        // SELECT des periodes à exporter .....
+        // on prend toutes les periodes de conges qui chevauchent la periode donnée par les dates demandées
+        $sql_periodes = "SELECT p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_commentaire, p_type, p_etat, p_date_demande  " .
+        'FROM conges_periode WHERE p_login=\'' . \includes\SQL::quote($user_login) . '\' AND ((p_date_deb>=\'' . \includes\SQL::quote($good_date_debut) . '\' AND  p_date_deb<=\'' . \includes\SQL::quote($good_date_fin) . '\') OR (p_date_fin>=\'' . \includes\SQL::quote($good_date_debut) . '\' AND p_date_fin<=\'' . \includes\SQL::quote($good_date_fin) . '\'))';
+        $res_periodes = \includes\SQL::query($sql_periodes);
 
-    		// SELECT des periodes à exporter .....
-    		// on prend toutes les periodes de conges qui chevauchent la periode donnée par les dates demandées
-    		$sql_periodes="SELECT p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_commentaire, p_type, p_etat, p_date_demande  " .
-    				'FROM conges_periode WHERE p_login=\''. \includes\SQL::quote($user_login).'\' AND ((p_date_deb>=\''. \includes\SQL::quote($good_date_debut).'\' AND  p_date_deb<=\''.\includes\SQL::quote($good_date_fin).'\') OR (p_date_fin>=\''. \includes\SQL::quote($good_date_debut).'\' AND p_date_fin<=\''. \includes\SQL::quote($good_date_fin).'\'))';
-    		$res_periodes = \includes\SQL::query($sql_periodes);
+        if ($num_periodes = $res_periodes->num_rows != 0) {
+            while ($result_periodes = $res_periodes->fetch_array()) {
+                $sql_date_debut    = $result_periodes['p_date_deb'];
+                $sql_demi_jour_deb = $result_periodes['p_demi_jour_deb'];
+                $sql_date_fin      = $result_periodes['p_date_fin'];
+                $sql_demi_jour_fin = $result_periodes['p_demi_jour_fin'];
+                $sql_type          = $result_periodes['p_type'];
+                $sql_etat          = $result_periodes['p_etat'];
+                $sql_dateh_demande = $result_periodes['p_date_demande'];
 
-    		if($num_periodes=$res_periodes->num_rows!=0)
-    		{
-    			while ($result_periodes = $res_periodes->fetch_array())
-    			{
-    				$sql_date_debut=$result_periodes['p_date_deb'];
-    				$sql_demi_jour_deb=$result_periodes['p_demi_jour_deb'];
-    				$sql_date_fin=$result_periodes['p_date_fin'];
-    				$sql_demi_jour_fin=$result_periodes['p_demi_jour_fin'];
-    				$sql_type=$result_periodes['p_type'];
-    				$sql_etat=$result_periodes['p_etat'];
-    				$sql_dateh_demande=$result_periodes['p_date_demande'];
+                // PB : les fichiers ical et vcal doivent être encodés en UTF-8, or php ne gère pas l'utf-8
+                // on remplace donc les caractères spéciaux de la chaine de caractères
+                $sql_comment = \export\Fonctions::remplace_accents($result_periodes['p_commentaire']);
 
-    				// PB : les fichiers ical et vcal doivent être encodés en UTF-8, or php ne gère pas l'utf-8
-    				// on remplace donc les caractères spéciaux de la chaine de caractères
-    				$sql_comment=\export\Fonctions::remplace_accents($result_periodes['p_commentaire']);
+                // même problème
+                $type_abs = \export\Fonctions::remplace_accents($tab_types_abs[$sql_type]['libelle']);
 
-    				// même problème
-    				$type_abs=\export\Fonctions::remplace_accents($tab_types_abs[$sql_type]['libelle']) ;
+                //conversion format date
+                $replaceThis  = array('-' => '', ':' => '', ' ' => 'T');
+                $sql_date_dem = str_replace(array_keys($replaceThis), $replaceThis, $sql_dateh_demande);
+                $DTSTAMP      = $sql_date_dem . "Z";
+                $tab_date_deb = explode("-", $sql_date_debut);
+                $tab_date_fin = explode("-", $sql_date_fin);
 
-    				//conversion format date
-    				$replaceThis = Array('-' => '',':' => '',' ' => 'T',);
-    				$sql_date_dem=str_replace(array_keys($replaceThis), $replaceThis, $sql_dateh_demande);
-    				$DTSTAMP=$sql_date_dem."Z";
-    				$tab_date_deb=explode("-", $sql_date_debut);
-    				$tab_date_fin=explode("-", $sql_date_fin);
+                //conversion etat demande en status
+                switch ($sql_etat) {
+                    case "ok":
+                        $status = "CONFIRMED";
+                        break;
+                    case "refus":
+                        $status = "CANCELLED";
+                        break;
+                    default:
+                        $status = "TENTATIVE";
+                }
+                if ($sql_demi_jour_deb == "am") {
+                    $DTSTART = $tab_date_deb[0] . $tab_date_deb[1] . $tab_date_deb[2] . "T070000Z";
+                }
+                // .....
+                else {
+                    $DTSTART = $tab_date_deb[0] . $tab_date_deb[1] . $tab_date_deb[2] . "T120000Z";
+                }
+                // .....
 
-    				//conversion etat demande en status
-    				switch ($sql_etat) {
-    					case "ok":
-    						$status="CONFIRMED";
-    						break;
-    					case "refus":
-    						$status="CANCELLED";
-    						break;
-    					default:
-    						$status="TENTATIVE";
-    					}
-    				if($sql_demi_jour_deb=="am")
-    					$DTSTART=$tab_date_deb[0].$tab_date_deb[1].$tab_date_deb[2]."T070000Z";   // .....
-    				else
-    					$DTSTART=$tab_date_deb[0].$tab_date_deb[1].$tab_date_deb[2]."T120000Z";   // .....
+                if ($sql_demi_jour_fin == "am") {
+                    $DTEND = $tab_date_fin[0] . $tab_date_fin[1] . $tab_date_fin[2] . "T120000Z";
+                }
+                // .....
+                else {
+                    $DTEND = $tab_date_fin[0] . $tab_date_fin[1] . $tab_date_fin[2] . "T210000Z";
+                }
+                // .....
 
-    				if($sql_demi_jour_fin=="am")
-    					$DTEND=$tab_date_fin[0].$tab_date_fin[1].$tab_date_fin[2]."T120000Z";   // .....
-    				else
-    					$DTEND=$tab_date_fin[0].$tab_date_fin[1].$tab_date_fin[2]."T210000Z";   // .....
+                echo "BEGIN:VEVENT\r\n" .
+                    "DTSTAMP:$DTSTAMP\r\n" .
+                    "ORGANIZER:MAILTO:" . $tab_infos_user['email'] . "\r\n" .
+                    "CREATED:$DTSTART\r\n" .
+                    "STATUS:$status\r\n" .
+                    "UID:$user_login@Libertempo-$sql_date_dem\r\n";
+                if ($sql_comment != "") {
+                    echo "DESCRIPTION:$sql_comment\r\n";
+                }
 
-    					echo "BEGIN:VEVENT\r\n" .
-    						"DTSTAMP:$DTSTAMP\r\n" .
-    						"ORGANIZER:MAILTO:".$tab_infos_user['email']."\r\n" .
-    						"CREATED:$DTSTART\r\n" .
-    						"STATUS:$status\r\n" .
-    						"UID:$user_login@Libertempo-$sql_date_dem\r\n";
-    				if($sql_comment!="")
-    					echo "DESCRIPTION:$sql_comment\r\n";
-    				echo "SUMMARY:$type_abs\r\n" .
-    						"CLASS:PUBLIC\r\n" .
-    						"PRIORITY:1\r\n" .
-    						"DTSTART:$DTSTART\r\n" .
-    						"DTEND:$DTEND\r\n" .
-    						"TRANSP:OPAQUE\r\n" .
-    						"END:VEVENT\r\n\r\n" ;
-    			}
-    		}
+                echo "SUMMARY:$type_abs\r\n" .
+                    "CLASS:PUBLIC\r\n" .
+                    "PRIORITY:1\r\n" .
+                    "DTSTART:$DTSTART\r\n" .
+                    "DTEND:$DTEND\r\n" .
+                    "TRANSP:OPAQUE\r\n" .
+                    "END:VEVENT\r\n\r\n";
+            }
+        }
 
-    		echo "END:VCALENDAR\r\n";
+        echo "END:VCALENDAR\r\n";
     }
 
     /**
@@ -177,10 +185,10 @@ class Fonctions
      */
     public static function exportICSModule()
     {
-        $_SESSION['config']=init_config_tab();      // on initialise le tableau des variables de config
-        if($_SESSION['config']['export_ical']==FALSE) {
+        $_SESSION['config'] = init_config_tab(); // on initialise le tableau des variables de config
+        if ($_SESSION['config']['export_ical'] == false) {
             header('HTTP/1.0 403 Forbidden');
-        	exit('403 Forbidden');
+            exit('403 Forbidden');
         }
 
         //on récupère le hash du user
@@ -189,7 +197,9 @@ class Fonctions
         //on récupère le nom associé au hash
         $session_username = unhash_user($usrh);
 
-        if ($session_username != "")
-        	\export\Fonctions::export_ical($session_username);
+        if ($session_username != "") {
+            \export\Fonctions::export_ical($session_username);
+        }
+
     }
 }

--- a/export/export_vcalendar.php
+++ b/export/export_vcalendar.php
@@ -3,10 +3,10 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-include_once ROOT_PATH .'fonctions_conges.php';
-include_once INCLUDE_PATH .'fonction.php';
-include_once INCLUDE_PATH .'session.php';
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+include_once INCLUDE_PATH . 'session.php';
 
 \export\Fonctions::exportVCalendarModule($session);

--- a/export/ics_export.php
+++ b/export/ics_export.php
@@ -2,8 +2,8 @@
 
 define('ROOT_PATH', '../');
 include ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
-include INCLUDE_PATH .'fonction.php';
-include ROOT_PATH .'fonctions_conges.php'; // for init_config_tab()
+include INCLUDE_PATH . 'fonction.php';
+include ROOT_PATH . 'fonctions_conges.php'; // for init_config_tab()
 \export\Fonctions::exportICSModule();

--- a/fonctions_calcul.php
+++ b/fonctions_calcul.php
@@ -1,13 +1,13 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
 // calcule le nb de jours de conges à prendre pour un user entre 2 dates
 // retourne le nb de jours  (opt_debut et opt_fin ont les valeurs "am" ou "pm"
-function compter($user, $num_current_periode, $date_debut, $date_fin, $opt_debut, $opt_fin, &$comment,  $num_update = null)
+function compter($user, $num_current_periode, $date_debut, $date_fin, $opt_debut, $opt_fin, &$comment, $num_update = null)
 {
-	$date_debut = convert_date($date_debut);
-	$date_fin = convert_date($date_fin);
+    $date_debut = convert_date($date_debut);
+    $date_fin   = convert_date($date_fin);
 
     $planningUser = \utilisateur\Fonctions::getUserPlanning($user);
     if (is_null($planningUser)) {
@@ -15,349 +15,342 @@ function compter($user, $num_current_periode, $date_debut, $date_fin, $opt_debut
         return 0;
     }
 
-	// verif si date_debut est bien anterieure à date_fin
-	// ou si meme jour mais debut l'apres midi et fin le matin
-	if( (strtotime($date_debut) > strtotime($date_fin)) || ( ($date_debut==$date_fin) && ($opt_debut=="pm") && ($opt_fin=="am") ) )
-	{
-		$comment =  _('calcul_nb_jours_commentaire_bad_date') ;
-		return 0 ;
-	}
+    // verif si date_debut est bien anterieure à date_fin
+    // ou si meme jour mais debut l'apres midi et fin le matin
+    if ((strtotime($date_debut) > strtotime($date_fin)) || (($date_debut == $date_fin) && ($opt_debut == "pm") && ($opt_fin == "am"))) {
+        $comment = _('calcul_nb_jours_commentaire_bad_date');
+        return 0;
+    }
 
-
-	if( ($date_debut!=0) && ($date_fin!=0) )
-	{
-		// On ne peut pas calculer si, pour l'année considérée, les jours feries ont ete saisis
-		if( (verif_jours_feries_saisis($date_debut, $num_update)==FALSE) || (verif_jours_feries_saisis($date_fin, $num_update)==FALSE) )
-		{
-			$comment =  _('calcul_impossible') ."<br>\n". _('jours_feries_non_saisis') ."<br>\n". _('contacter_rh') ."<br>\n" ;
-			return 0 ;
-		}
-
-
-		/************************************************************/
-		// 1 : on fabrique un tableau de jours (divisé chacun en 2 demi-jour) de la date_debut à la date_fin
-		// 2 : on verifie que le conges demandé ne chevauche pas une periode deja posée
-		// 3 : on affecte à 0 ou 1 chaque demi jour, en fonction de s'il est travaillé ou pas
-		// 4 : à la fin , on parcours le tableau en comptant le nb de demi-jour à 1, on multiplie ce total par 0.5, ça donne le nb de jours du conges !
-
-		$nb_jours=0;
-
-		/************************************************************/
-		// 1 : fabrication et initialisation du tableau des demi-jours de la date_debut à la date_fin
-		$tab_periode_calcul = make_tab_demi_jours_periode($date_debut, $date_fin, $opt_debut, $opt_fin);
-
-
-		/************************************************************/
-		// 2 : on verifie que le conges demandé ne chevauche pas une periode deja posée
-		if(verif_periode_chevauche_periode_user($date_debut, $date_fin, $user, $num_current_periode, $tab_periode_calcul, $comment, $num_update)) {
-			return 0;
+    if (($date_debut != 0) && ($date_fin != 0)) {
+        // On ne peut pas calculer si, pour l'année considérée, les jours feries ont ete saisis
+        if ((verif_jours_feries_saisis($date_debut, $num_update) == false) || (verif_jours_feries_saisis($date_fin, $num_update) == false)) {
+            $comment = _('calcul_impossible') . "<br>\n" . _('jours_feries_non_saisis') . "<br>\n" . _('contacter_rh') . "<br>\n";
+            return 0;
         }
 
+        /************************************************************/
+        // 1 : on fabrique un tableau de jours (divisé chacun en 2 demi-jour) de la date_debut à la date_fin
+        // 2 : on verifie que le conges demandé ne chevauche pas une periode deja posée
+        // 3 : on affecte à 0 ou 1 chaque demi jour, en fonction de s'il est travaillé ou pas
+        // 4 : à la fin , on parcours le tableau en comptant le nb de demi-jour à 1, on multiplie ce total par 0.5, ça donne le nb de jours du conges !
 
-		/************************************************************/
-		// 3 : on affecte à 0 ou 1 chaque demi jour, en fonction de s'il est travaillé ou pas
+        $nb_jours = 0;
 
-		// on initialise le tableau global des jours fériés s'il ne l'est pas déjà :
-		if(!isset($_SESSION["tab_j_feries"]))
-		{
-			init_tab_jours_feries();
-		}
-		// on initialise le tableau global des jours fermés s'il ne l'est pas déjà :
-		if(!isset($_SESSION["tab_j_fermeture"]))
-		{
-			init_tab_jours_fermeture($user);
-		}
+        /************************************************************/
+        // 1 : fabrication et initialisation du tableau des demi-jours de la date_debut à la date_fin
+        $tab_periode_calcul = make_tab_demi_jours_periode($date_debut, $date_fin, $opt_debut, $opt_fin);
 
-		$current_day=$date_debut;
-		$date_limite=jour_suivant($date_fin);
+        /************************************************************/
+        // 2 : on verifie que le conges demandé ne chevauche pas une periode deja posée
+        if (verif_periode_chevauche_periode_user($date_debut, $date_fin, $user, $num_current_periode, $tab_periode_calcul, $comment, $num_update)) {
+            return 0;
+        }
 
-		// on va avancer jour par jour jusqu'à la date limite et voir si chaque jour est travaillé, férié, rtt, etc ...
-		while($current_day!=$date_limite)
-		{
-			// calcul du timestamp du jour courant
-			if(substr_count($current_day,'/')){
-				$pieces = explode("/", $current_day);  // date de la forme jj/mm/yyyy
-				$y=$pieces[2];
-				$m=$pieces[1];
-				$j=$pieces[0];
-			}else{
-				$pieces = explode("-", $current_day);  // date de la forme yyyy-mm-dd
-				$y=$pieces[0];
-				$m=$pieces[1];
-				$j=$pieces[2];
-			}
-			$timestamp_du_jour=mktime (0,0,0,$m,$j,$y);
+        /************************************************************/
+        // 3 : on affecte à 0 ou 1 chaque demi jour, en fonction de s'il est travaillé ou pas
 
-			// on regarde si le jour est travaillé ou pas dans la config de l'appli
-			$j_name=date("D", $timestamp_du_jour);
-			if( (($j_name=="Sat")&&($_SESSION['config']['samedi_travail']==FALSE)) || (($j_name=="Sun")&&($_SESSION['config']['dimanche_travail']==FALSE)))
-			{
-				// on ne compte ce jour à 0
-				$tab_periode_calcul[$current_day]['am']=0;
-				$tab_periode_calcul[$current_day]['pm']=0;
-			}
-			elseif(est_chome($timestamp_du_jour)) // verif si jour férié
-			{
-				// on ne compte ce jour à 0
-				$tab_periode_calcul[$current_day]['am']=0;
-				$tab_periode_calcul[$current_day]['pm']=0;
-			}
-			else
-			{
-				/***************/
-				// verif des rtt ou temp partiel (dans la table rtt)
-				$val_matin="N";
-				$val_aprem="N";
-				recup_infos_artt_du_jour($user, $timestamp_du_jour, $val_matin, $val_aprem, $planningUser);
+        // on initialise le tableau global des jours fériés s'il ne l'est pas déjà :
+        if (!isset($_SESSION["tab_j_feries"])) {
+            init_tab_jours_feries();
+        }
+        // on initialise le tableau global des jours fermés s'il ne l'est pas déjà :
+        if (!isset($_SESSION["tab_j_fermeture"])) {
+            init_tab_jours_fermeture($user);
+        }
 
-				if($val_matin=="Y")  // rtt le matin
-					$tab_periode_calcul[$current_day]['am']=0;
+        $current_day = $date_debut;
+        $date_limite = jour_suivant($date_fin);
 
-				if($val_aprem=="Y") // rtt l'après midi
-					$tab_periode_calcul[$current_day]['pm']=0;
-			}
+        // on va avancer jour par jour jusqu'à la date limite et voir si chaque jour est travaillé, férié, rtt, etc ...
+        while ($current_day != $date_limite) {
+            // calcul du timestamp du jour courant
+            if (substr_count($current_day, '/')) {
+                $pieces = explode("/", $current_day); // date de la forme jj/mm/yyyy
+                $y      = $pieces[2];
+                $m      = $pieces[1];
+                $j      = $pieces[0];
+            } else {
+                $pieces = explode("-", $current_day); // date de la forme yyyy-mm-dd
+                $y      = $pieces[0];
+                $m      = $pieces[1];
+                $j      = $pieces[2];
+            }
+            $timestamp_du_jour = mktime(0, 0, 0, $m, $j, $y);
+
+            // on regarde si le jour est travaillé ou pas dans la config de l'appli
+            $j_name = date("D", $timestamp_du_jour);
+            if ((($j_name == "Sat") && ($_SESSION['config']['samedi_travail'] == false)) || (($j_name == "Sun") && ($_SESSION['config']['dimanche_travail'] == false))) {
+                // on ne compte ce jour à 0
+                $tab_periode_calcul[$current_day]['am'] = 0;
+                $tab_periode_calcul[$current_day]['pm'] = 0;
+            } elseif (est_chome($timestamp_du_jour)) // verif si jour férié
+            {
+                // on ne compte ce jour à 0
+                $tab_periode_calcul[$current_day]['am'] = 0;
+                $tab_periode_calcul[$current_day]['pm'] = 0;
+            } else {
+                /***************/
+                // verif des rtt ou temp partiel (dans la table rtt)
+                $val_matin = "N";
+                $val_aprem = "N";
+                recup_infos_artt_du_jour($user, $timestamp_du_jour, $val_matin, $val_aprem, $planningUser);
+
+                if ($val_matin == "Y") // rtt le matin
+                {
+                    $tab_periode_calcul[$current_day]['am'] = 0;
+                }
+
+                if ($val_aprem == "Y") // rtt l'après midi
+                {
+                    $tab_periode_calcul[$current_day]['pm'] = 0;
+                }
+
+            }
 
             $nb_jours = $nb_jours + $tab_periode_calcul[$current_day]['am'] + $tab_periode_calcul[$current_day]['pm'];
 
-			$current_day=jour_suivant($current_day);
-		}
-		$nb_jours = $nb_jours * 0.5;
-		$VerifDec = verif_saisie_decimal($nb_jours);
-		return $nb_jours;
-	}
-	else
-		return 0;
+            $current_day = jour_suivant($current_day);
+        }
+        $nb_jours = $nb_jours * 0.5;
+        $VerifDec = verif_saisie_decimal($nb_jours);
+        return $nb_jours;
+    } else {
+        return 0;
+    }
+
 }
 
 // renvoit le jour suivant de la date passée en paramètre sous la forme jj/mm/yyyy
 function jour_suivant($date)
 {
-	if(substr_count($date,'/')){
-		$pieces = explode("/", $date);  // date de la forme jj/mm/yyyy
-		$y=$pieces[2];
-		$m=$pieces[1];
-		$j=$pieces[0];
-		$lendemain = date("d/m/Y", mktime(0, 0, 0, $m , $j+1, $y) );
-	}else{
-		$pieces = explode("-", $date);  // date de la forme yyyy-mm-dd
-		$y=$pieces[0];
-		$m=$pieces[1];
-		$j=$pieces[2];
-		$lendemain = date("Y-m-d", mktime(0, 0, 0, $m , $j+1, $y) );
-	}
+    if (substr_count($date, '/')) {
+        $pieces    = explode("/", $date); // date de la forme jj/mm/yyyy
+        $y         = $pieces[2];
+        $m         = $pieces[1];
+        $j         = $pieces[0];
+        $lendemain = date("d/m/Y", mktime(0, 0, 0, $m, $j + 1, $y));
+    } else {
+        $pieces    = explode("-", $date); // date de la forme yyyy-mm-dd
+        $y         = $pieces[0];
+        $m         = $pieces[1];
+        $j         = $pieces[2];
+        $lendemain = date("Y-m-d", mktime(0, 0, 0, $m, $j + 1, $y));
+    }
 
-	return $lendemain;
+    return $lendemain;
 }
 
 // verifie si les jours fériés de l'annee de la date donnée sont enregistrés
 // retourne TRUE ou FALSE
 function verif_jours_feries_saisis($date)
 {
-	// on calcule le premier de l'an et le dernier de l'an de l'année de la date passee en parametre
-	if(substr_count($date,'/'))
-	{
-		$tab_date=explode("/", $date); // date est de la forme dd/mm/YYYY
-		$an=$tab_date[2];
-	}
-	if(substr_count($date,'-'))
-	{
-		$tab_date=explode("-", $date); // date est de la forme yyyy-mm-dd
-		$an=$tab_date[0];
-	}
-	$premier_an="$an-01-01";
-	$dernier_an="$an-12-31";
+    // on calcule le premier de l'an et le dernier de l'an de l'année de la date passee en parametre
+    if (substr_count($date, '/')) {
+        $tab_date = explode("/", $date); // date est de la forme dd/mm/YYYY
+        $an       = $tab_date[2];
+    }
+    if (substr_count($date, '-')) {
+        $tab_date = explode("-", $date); // date est de la forme yyyy-mm-dd
+        $an       = $tab_date[0];
+    }
+    $premier_an = "$an-01-01";
+    $dernier_an = "$an-12-31";
 
-	$sql_select='SELECT jf_date FROM conges_jours_feries WHERE jf_date >= "'.\includes\SQL::quote($premier_an).'" AND jf_date <= "'. \includes\SQL::quote($dernier_an).'" ';
-	$res_select = \includes\SQL::query($sql_select);
+    $sql_select = 'SELECT jf_date FROM conges_jours_feries WHERE jf_date >= "' . \includes\SQL::quote($premier_an) . '" AND jf_date <= "' . \includes\SQL::quote($dernier_an) . '" ';
+    $res_select = \includes\SQL::query($sql_select);
 
-	return ($res_select->num_rows != 0);
+    return ($res_select->num_rows != 0);
 }
 
 // fabrication et initialisation du tableau des demi-jours de la date_debut à la date_fin d'une periode
 function make_tab_demi_jours_periode($date_debut, $date_fin, $opt_debut, $opt_fin)
 {
-	$tab_periode_calcul=array();
-	$nb_jours_entre_date = (((strtotime(str_replace('/','-',$date_fin)) - strtotime(str_replace('/','-',$date_debut)))/3600)/24)+1 ;
+    $tab_periode_calcul  = array();
+    $nb_jours_entre_date = (((strtotime(str_replace('/', '-', $date_fin)) - strtotime(str_replace('/', '-', $date_debut))) / 3600) / 24) + 1;
 
-	// on va avancer jour par jour jusqu'à la date limite
-	$current_day=$date_debut;
-	$date_limite=jour_suivant($date_fin);
-	while($current_day!=$date_limite)
-	{
-		$jour['am']=1;
-		$jour['pm']=1;
-		$tab_periode_calcul[$current_day]=$jour;
-		$current_day=jour_suivant($current_day);
-	}
-	// attention au premier et dernier jour :
-	if($opt_debut=="pm")
-		$tab_periode_calcul[$date_debut]['am']=0;
-	if($opt_fin=="am")
-		$tab_periode_calcul[$date_fin]['pm']=0;
-	return $tab_periode_calcul;
+    // on va avancer jour par jour jusqu'à la date limite
+    $current_day = $date_debut;
+    $date_limite = jour_suivant($date_fin);
+    while ($current_day != $date_limite) {
+        $jour['am']                       = 1;
+        $jour['pm']                       = 1;
+        $tab_periode_calcul[$current_day] = $jour;
+        $current_day                      = jour_suivant($current_day);
+    }
+    // attention au premier et dernier jour :
+    if ($opt_debut == "pm") {
+        $tab_periode_calcul[$date_debut]['am'] = 0;
+    }
+
+    if ($opt_fin == "am") {
+        $tab_periode_calcul[$date_fin]['pm'] = 0;
+    }
+
+    return $tab_periode_calcul;
 }
 
 // verifie si la periode donnee chevauche une periode de conges d'un user donné
 // attention à ne pas verifer le chevauchement avec la periode qu on est en train de traiter (si celle ci a déjà un num_periode)
 // retourne TRUE si chevauchement et FALSE sinon !
-function verif_periode_chevauche_periode_user($date_debut, $date_fin, $user, $num_current_periode='', $tab_periode_calcul, &$comment, $num_update = null)
+function verif_periode_chevauche_periode_user($date_debut, $date_fin, $user, $num_current_periode = '', $tab_periode_calcul, &$comment, $num_update = null)
 {
 
-	/************************************************************/
-	// 2 : on verifie que le conges demandé ne chevauche pas une periode deja posée
-	// -> on recupere les periodes par rapport aux dates, on en fait une tableau de 1/2 journees, et on compare par 1/2 journee
-	$tab_periode_deja_prise=array();
-	$current_day=$date_debut;
-	$date_limite=jour_suivant($date_fin);
+    /************************************************************/
+    // 2 : on verifie que le conges demandé ne chevauche pas une periode deja posée
+    // -> on recupere les periodes par rapport aux dates, on en fait une tableau de 1/2 journees, et on compare par 1/2 journee
+    $tab_periode_deja_prise = array();
+    $current_day            = $date_debut;
+    $date_limite            = jour_suivant($date_fin);
 
-	// on va avancer jour par jour jusqu'à la date limite et recupere les periodes qui contiennent ce jour...
-	// on construit un tableau par date et 1/2 jour avec l'état de la periode
-	while($current_day!=$date_limite)
-	{
-		$tab_periode_deja_prise[$current_day]['am']="no" ;
-		$tab_periode_deja_prise[$current_day]['pm']="no" ;
+    // on va avancer jour par jour jusqu'à la date limite et recupere les periodes qui contiennent ce jour...
+    // on construit un tableau par date et 1/2 jour avec l'état de la periode
+    while ($current_day != $date_limite) {
+        $tab_periode_deja_prise[$current_day]['am'] = "no";
+        $tab_periode_deja_prise[$current_day]['pm'] = "no";
 
-		if ($num_update === null)
-		{
-			// verif si c'est deja un conges
-			$user_periode_sql = 'SELECT  p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_etat
+        if ($num_update === null) {
+            // verif si c'est deja un conges
+            $user_periode_sql = 'SELECT  p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_etat
 						FROM conges_periode
-						WHERE p_login = "'.\includes\SQL::quote($user).'" AND ( p_etat=\'ok\' OR p_etat=\'valid\' OR p_etat=\'demande\' )
-						'.(!empty($num_current_periode) ? 'AND p_num != '.intval($num_current_periode).' ' : '') .'
-						AND p_date_deb<="'.\includes\SQL::quote($current_day).'" AND p_date_fin>="'.\includes\SQL::quote($current_day).'" ';
-		}
-		else
-		{
-			// verif si c'est deja un conges
-			$user_periode_sql = 'SELECT  p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_etat
+						WHERE p_login = "' . \includes\SQL::quote($user) . '" AND ( p_etat=\'ok\' OR p_etat=\'valid\' OR p_etat=\'demande\' )
+						' . (!empty($num_current_periode) ? 'AND p_num != ' . intval($num_current_periode) . ' ' : '') . '
+						AND p_date_deb<="' . \includes\SQL::quote($current_day) . '" AND p_date_fin>="' . \includes\SQL::quote($current_day) . '" ';
+        } else {
+            // verif si c'est deja un conges
+            $user_periode_sql = 'SELECT  p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_etat
 						FROM conges_periode
-						WHERE p_login = "'.\includes\SQL::quote($user).'" AND ( p_etat=\'ok\' OR p_etat=\'valid\' OR p_etat=\'demande\' )
-						'.(!empty($num_current_periode) ? 'AND p_num != '.intval($num_current_periode).' ' : '') .'
-						AND p_date_deb<="'.\includes\SQL::quote($current_day).'" AND p_date_fin>="'. \includes\SQL::quote($current_day).'"
-						AND p_num != \''.intval($num_update).'\' ';
-		}
+						WHERE p_login = "' . \includes\SQL::quote($user) . '" AND ( p_etat=\'ok\' OR p_etat=\'valid\' OR p_etat=\'demande\' )
+						' . (!empty($num_current_periode) ? 'AND p_num != ' . intval($num_current_periode) . ' ' : '') . '
+						AND p_date_deb<="' . \includes\SQL::quote($current_day) . '" AND p_date_fin>="' . \includes\SQL::quote($current_day) . '"
+						AND p_num != \'' . intval($num_update) . '\' ';
+        }
 
-		$user_periode_request = \includes\SQL::query($user_periode_sql);
+        $user_periode_request = \includes\SQL::query($user_periode_sql);
 
-		if($user_periode_request->num_rows !=0)  // le jour courant est dans une periode de conges du user
-		{
-			while($resultat_periode=$user_periode_request->fetch_array())
-			{
-				$sql_p_date_deb=$resultat_periode["p_date_deb"];
-				$sql_p_date_fin=$resultat_periode["p_date_fin"];
-				$sql_p_demi_jour_deb=$resultat_periode["p_demi_jour_deb"];
-				$sql_p_demi_jour_fin=$resultat_periode["p_demi_jour_fin"];
-				$sql_p_etat=$resultat_periode["p_etat"];
+        if ($user_periode_request->num_rows != 0) // le jour courant est dans une periode de conges du user
+        {
+            while ($resultat_periode = $user_periode_request->fetch_array()) {
+                $sql_p_date_deb      = $resultat_periode["p_date_deb"];
+                $sql_p_date_fin      = $resultat_periode["p_date_fin"];
+                $sql_p_demi_jour_deb = $resultat_periode["p_demi_jour_deb"];
+                $sql_p_demi_jour_fin = $resultat_periode["p_demi_jour_fin"];
+                $sql_p_etat          = $resultat_periode["p_etat"];
 
-				if( ($current_day!=$sql_p_date_deb) && ($current_day!=$sql_p_date_fin) )
-				{
-					// pas la peine d'aller + loin, on chevauche une periode de conges !!!
-					if($sql_p_etat=="demande")
-							$comment =  _('calcul_nb_jours_commentaire_impossible') ;
-						else
-							$comment =  _('calcul_nb_jours_commentaire') ;
+                if (($current_day != $sql_p_date_deb) && ($current_day != $sql_p_date_fin)) {
+                    // pas la peine d'aller + loin, on chevauche une periode de conges !!!
+                    if ($sql_p_etat == "demande") {
+                        $comment = _('calcul_nb_jours_commentaire_impossible');
+                    } else {
+                        $comment = _('calcul_nb_jours_commentaire');
+                    }
 
-					return TRUE ;
-				}
-				elseif( ($current_day==$sql_p_date_deb) && ($current_day==$sql_p_date_fin) ) // periode sur une seule journee
-				{
-					if($sql_p_demi_jour_deb=="am")
-						$tab_periode_deja_prise[$current_day]['am']="$sql_p_etat" ;
-					if($sql_p_demi_jour_fin=="pm")
-						$tab_periode_deja_prise[$current_day]['pm']="$sql_p_etat" ;
-				}
-				elseif($current_day==$sql_p_date_deb)
-				{
-					if($sql_p_demi_jour_deb=="am")
-					{
-						$tab_periode_deja_prise[$current_day]['am']="$sql_p_etat" ;
-						$tab_periode_deja_prise[$current_day]['pm']="$sql_p_etat" ;
-					}
-					else // alors ($sql_p_demi_jour_deb=="pm")
-						$tab_periode_deja_prise[$current_day]['pm']="$sql_p_etat" ;
-				}
-				else // alors ($current_day==$sql_p_date_fin)
-				{
-					if($sql_p_demi_jour_fin=="pm")
-					{
-						$tab_periode_deja_prise[$current_day]['am']="$sql_p_etat" ;
-						$tab_periode_deja_prise[$current_day]['pm']="$sql_p_etat" ;
-					}
-					else // alors ($sql_p_demi_jour_fin=="am")
-						$tab_periode_deja_prise[$current_day]['am']="$sql_p_etat" ;
-				}
-			}
-		}
-		$current_day=jour_suivant($current_day);
-	}// fin du while
-	/**********************************************/
-	// Ensuite verifie en parcourant le tableau qu'on vient de crée (s'il n'est pas vide)
+                    return true;
+                } elseif (($current_day == $sql_p_date_deb) && ($current_day == $sql_p_date_fin)) // periode sur une seule journee
+                {
+                    if ($sql_p_demi_jour_deb == "am") {
+                        $tab_periode_deja_prise[$current_day]['am'] = "$sql_p_etat";
+                    }
+
+                    if ($sql_p_demi_jour_fin == "pm") {
+                        $tab_periode_deja_prise[$current_day]['pm'] = "$sql_p_etat";
+                    }
+
+                } elseif ($current_day == $sql_p_date_deb) {
+                    if ($sql_p_demi_jour_deb == "am") {
+                        $tab_periode_deja_prise[$current_day]['am'] = "$sql_p_etat";
+                        $tab_periode_deja_prise[$current_day]['pm'] = "$sql_p_etat";
+                    } else // alors ($sql_p_demi_jour_deb=="pm")
+                    {
+                        $tab_periode_deja_prise[$current_day]['pm'] = "$sql_p_etat";
+                    }
+
+                } else // alors ($current_day==$sql_p_date_fin)
+                {
+                    if ($sql_p_demi_jour_fin == "pm") {
+                        $tab_periode_deja_prise[$current_day]['am'] = "$sql_p_etat";
+                        $tab_periode_deja_prise[$current_day]['pm'] = "$sql_p_etat";
+                    } else // alors ($sql_p_demi_jour_fin=="am")
+                    {
+                        $tab_periode_deja_prise[$current_day]['am'] = "$sql_p_etat";
+                    }
+
+                }
+            }
+        }
+        $current_day = jour_suivant($current_day);
+    } // fin du while
+    /**********************************************/
+    // Ensuite verifie en parcourant le tableau qu'on vient de crée (s'il n'est pas vide)
     $donneesPeriodeDebut = $tab_periode_calcul[$date_debut];
-    $donneesPeriodeFin = $tab_periode_calcul[$date_fin];
+    $donneesPeriodeFin   = $tab_periode_calcul[$date_fin];
     if (1 == $donneesPeriodeDebut['am']) {
         $periodeDebut = (1 == $donneesPeriodeDebut['pm'])
-            ? \App\Models\Planning\Creneau::TYPE_PERIODE_MATIN_APRES_MIDI
-            : \App\Models\Planning\Creneau::TYPE_PERIODE_MATIN;
+        ? \App\Models\Planning\Creneau::TYPE_PERIODE_MATIN_APRES_MIDI
+        : \App\Models\Planning\Creneau::TYPE_PERIODE_MATIN;
     } elseif (1 == $donneesPeriodeDebut['pm']) {
         $periodeDebut = \App\Models\Planning\Creneau::TYPE_PERIODE_APRES_MIDI;
     }
 
     if (1 == $donneesPeriodeFin['pm']) {
         $periodeFin = (1 == $donneesPeriodeFin['am'])
-            ? \App\Models\Planning\Creneau::TYPE_PERIODE_MATIN_APRES_MIDI
-            : \App\Models\Planning\Creneau::TYPE_PERIODE_APRES_MIDI;
+        ? \App\Models\Planning\Creneau::TYPE_PERIODE_MATIN_APRES_MIDI
+        : \App\Models\Planning\Creneau::TYPE_PERIODE_APRES_MIDI;
     } elseif (1 == $donneesPeriodeFin['am']) {
         $periodeFin = \App\Models\Planning\Creneau::TYPE_PERIODE_MATIN;
     }
 
     $conge = new \App\ProtoControllers\Employe\Conge();
     if ($conge->isChevauchement($user, $date_debut, $periodeDebut, $date_fin, $periodeFin)) {
-        $comment =  _('demande_heure_chevauche_demande');
+        $comment = _('demande_heure_chevauche_demande');
         return true;
     }
 
-	if(count($tab_periode_deja_prise)!=0)
-	{
-		$current_day=$date_debut;
-		$date_limite=jour_suivant($date_fin);
-		// on va avancer jour par jour jusqu'à la date limite et recupere les periodes qui contiennent ce jour...
-		// on construit un tableau par date et 1/2 jour avec l'état de la periode
-		while($current_day!=$date_limite)
-		{
-			if( ($tab_periode_calcul[$current_day]['am']==1) && ($tab_periode_deja_prise[$current_day]['am']!="no") )
-			{
-				// pas la peine d'aller + loin, on chevauche une periode de conges !!!
-				if($tab_periode_deja_prise[$current_day]['am']=="demande")
-					$comment =  _('calcul_nb_jours_commentaire_impossible') ;
-				else
-					$comment =  _('calcul_nb_jours_commentaire') ;
-				return TRUE ;
-			}
-			if( ($tab_periode_calcul[$current_day]['pm']==1) && ($tab_periode_deja_prise[$current_day]['pm']!="no") )
-			{
-				// pas la peine d'aller + loin, on chevauche une periode de conges !!!
-				if($tab_periode_deja_prise[$current_day]['pm']=="demande")
-					$comment =  _('calcul_nb_jours_commentaire_impossible') ;
-				else
-					$comment =  _('calcul_nb_jours_commentaire') ;
+    if (count($tab_periode_deja_prise) != 0) {
+        $current_day = $date_debut;
+        $date_limite = jour_suivant($date_fin);
+        // on va avancer jour par jour jusqu'à la date limite et recupere les periodes qui contiennent ce jour...
+        // on construit un tableau par date et 1/2 jour avec l'état de la periode
+        while ($current_day != $date_limite) {
+            if (($tab_periode_calcul[$current_day]['am'] == 1) && ($tab_periode_deja_prise[$current_day]['am'] != "no")) {
+                // pas la peine d'aller + loin, on chevauche une periode de conges !!!
+                if ($tab_periode_deja_prise[$current_day]['am'] == "demande") {
+                    $comment = _('calcul_nb_jours_commentaire_impossible');
+                } else {
+                    $comment = _('calcul_nb_jours_commentaire');
+                }
 
-				return TRUE ;
-			}
-			$current_day=jour_suivant($current_day);
-		}// fin du while
-	}
+                return true;
+            }
+            if (($tab_periode_calcul[$current_day]['pm'] == 1) && ($tab_periode_deja_prise[$current_day]['pm'] != "no")) {
+                // pas la peine d'aller + loin, on chevauche une periode de conges !!!
+                if ($tab_periode_deja_prise[$current_day]['pm'] == "demande") {
+                    $comment = _('calcul_nb_jours_commentaire_impossible');
+                } else {
+                    $comment = _('calcul_nb_jours_commentaire');
+                }
 
+                return true;
+            }
+            $current_day = jour_suivant($current_day);
+        } // fin du while
+    }
 
-	return FALSE ;
+    return false;
 
-	/************************************************************/
-	// Fin de le verif de chevauchement d'une période déja saisie
+    /************************************************************/
+    // Fin de le verif de chevauchement d'une période déja saisie
 }
 
 //retourne un nombre arrondit à 0.5 près à partir d'un nombre décimal
 function round_to_half($num)
 {
-	if($num >= ($half = ($ceil = ceil($num))- 0.5) + 0.25) return $ceil;
-	else if($num < $half - 0.25) return floor($num);
-	else return $half;
+    if ($num >= ($half = ($ceil = ceil($num)) - 0.5) + 0.25) {
+        return $ceil;
+    } else if ($num < $half - 0.25) {
+        return floor($num);
+    } else {
+        return $half;
+    }
+
 }

--- a/fonctions_conges.php
+++ b/fonctions_conges.php
@@ -1,76 +1,88 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
 // affichage du calendrier avec les case à cocher, du mois du début du congés
-function  affiche_calendrier_saisie_date($user_login, $year, $mois, $type_debut_fin) {
-    $jour_today            = date('j');
-    $jour_today_name        = date('D');
-    $first_jour_mois_timestamp    = mktime(0,0,0,$mois,1,$year);
-    $last_jour_mois_timestamp    = mktime(0,0,0,$mois +1 , 0,$year);
-    $mois_name            = date_fr('F', $first_jour_mois_timestamp);
-    $first_jour_mois_rang        = date('w', $first_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
-    $last_jour_mois_rang        = date('w', $last_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
-    $nb_jours_mois            = ( $last_jour_mois_timestamp - $first_jour_mois_timestamp + 60*60 *12 ) / (24 * 60 * 60); // + 60*60 *12 for fucking DST
+function affiche_calendrier_saisie_date($user_login, $year, $mois, $type_debut_fin)
+{
+    $jour_today                = date('j');
+    $jour_today_name           = date('D');
+    $first_jour_mois_timestamp = mktime(0, 0, 0, $mois, 1, $year);
+    $last_jour_mois_timestamp  = mktime(0, 0, 0, $mois + 1, 0, $year);
+    $mois_name                 = date_fr('F', $first_jour_mois_timestamp);
+    $first_jour_mois_rang      = date('w', $first_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
+    $last_jour_mois_rang       = date('w', $last_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
+    $nb_jours_mois             = ($last_jour_mois_timestamp - $first_jour_mois_timestamp + 60 * 60 * 12) / (24 * 60 * 60); // + 60*60 *12 for fucking DST
 
-    if( $first_jour_mois_rang == 0 )
-        $first_jour_mois_rang=7 ; // jour de la semaine en chiffre (1=lun , 7=dim)
+    if ($first_jour_mois_rang == 0) {
+        $first_jour_mois_rang = 7;
+    }
+    // jour de la semaine en chiffre (1=lun , 7=dim)
 
-    if( $last_jour_mois_rang == 0 )
-        $last_jour_mois_rang=7 ; // jour de la semaine en chiffre (1=lun , 7=dim)
+    if ($last_jour_mois_rang == 0) {
+        $last_jour_mois_rang = 7;
+    }
+    // jour de la semaine en chiffre (1=lun , 7=dim)
 
     echo '<table class="calendrier_saisie_date_debut" cellpadding="0" cellspacing="0">
         <thead>
-        <tr align="center" bgcolor="'.$_SESSION['config']['light_grey_bgcolor'].'">
-        <td colspan=7 class="titre"> '.$mois_name.' '.$year.' </td>
+        <tr align="center" bgcolor="' . $_SESSION['config']['light_grey_bgcolor'] . '">
+        <td colspan=7 class="titre"> ' . $mois_name . ' ' . $year . ' </td>
         </tr>
-        <tr bgcolor="'.$_SESSION['config']['light_grey_bgcolor'].'">
-        <td class="cal-saisie2">'. _('lundi_1c') .'</td>
-        <td class="cal-saisie2">'. _('mardi_1c') .'</td>
-        <td class="cal-saisie2">'. _('mercredi_1c') .'</td>
-        <td class="cal-saisie2">'. _('jeudi_1c') .'</td>
-        <td class="cal-saisie2">'. _('vendredi_1c') .'</td>
-        <td class="cal-saisie2">'. _('samedi_1c') .'</td>
-        <td class="cal-saisie2">'. _('dimanche_1c') .'</td>
+        <tr bgcolor="' . $_SESSION['config']['light_grey_bgcolor'] . '">
+        <td class="cal-saisie2">' . _('lundi_1c') . '</td>
+        <td class="cal-saisie2">' . _('mardi_1c') . '</td>
+        <td class="cal-saisie2">' . _('mercredi_1c') . '</td>
+        <td class="cal-saisie2">' . _('jeudi_1c') . '</td>
+        <td class="cal-saisie2">' . _('vendredi_1c') . '</td>
+        <td class="cal-saisie2">' . _('samedi_1c') . '</td>
+        <td class="cal-saisie2">' . _('dimanche_1c') . '</td>
         </tr>
         </thead>
         <tbody>';
-    $start_nb_day_before = $first_jour_mois_rang -1;
-    $stop_nb_day_before = 7 - $last_jour_mois_rang ;
+    $start_nb_day_before = $first_jour_mois_rang - 1;
+    $stop_nb_day_before  = 7 - $last_jour_mois_rang;
 
-    for ( $i = - $start_nb_day_before; $i <= $nb_jours_mois + $stop_nb_day_before; $i ++) {
-        if ( ($i + $start_nb_day_before ) % 7 == 0)
+    for ($i = -$start_nb_day_before; $i <= $nb_jours_mois + $stop_nb_day_before; $i++) {
+        if (($i + $start_nb_day_before) % 7 == 0) {
             echo '<tr>';
-        $j_timestamp=mktime (0,0,0,$mois, $i +1 ,$year);
+        }
+
+        $j_timestamp     = mktime(0, 0, 0, $mois, $i + 1, $year);
         $td_second_class = get_td_class_of_the_day_in_the_week($j_timestamp);
-                if ($i < 0 || $i > $nb_jours_mois )
-                    echo '<td class="'.$td_second_class.'">-</td>';
-                else
-                    affiche_cellule_jour_cal_saisie($user_login, $j_timestamp, $td_second_class, $type_debut_fin);
-                if ( ($i + $start_nb_day_before ) % 7 == 6)
-                    echo '<tr>';
+        if ($i < 0 || $i > $nb_jours_mois) {
+            echo '<td class="' . $td_second_class . '">-</td>';
+        } else {
+            affiche_cellule_jour_cal_saisie($user_login, $j_timestamp, $td_second_class, $type_debut_fin);
+        }
+
+        if (($i + $start_nb_day_before) % 7 == 6) {
+            echo '<tr>';
+        }
+
     }
     echo '</tbody></table>';
 }
 
-
 // retourne le nom du jour de la semaine en francais sur 2 caracteres
 function get_j_name_fr_2c($timestamp)
 {
-    $jour_name_fr_2c=array(0=>'di',1=>'lu', 2=>'ma',3=>'me',4=>'je',5=>'ve',6=>'sa',);
-    $jour_num=date('w', $timestamp);
-    if (isset($jour_name_fr_2c[$jour_num]))
+    $jour_name_fr_2c = array(0 => 'di', 1 => 'lu', 2 => 'ma', 3 => 'me', 4 => 'je', 5 => 've', 6 => 'sa');
+    $jour_num        = date('w', $timestamp);
+    if (isset($jour_name_fr_2c[$jour_num])) {
         return $jour_name_fr_2c[$jour_num];
-    else
+    } else {
         return false;
+    }
+
 }
 
 function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet)
 {
-    $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-    $session=session_id();
+    $PHP_SELF     = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+    $session      = session_id();
     $new_date_fin = date('d/m/Y');
-    $return = '';
+    $return       = '';
 
     $return .= '<form NAME="dem_conges" action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '" method="POST">
         <div class="row">
@@ -80,27 +92,25 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
 
     $return .= '<input type="radio" name="new_demi_jour_deb" ';
 
-    if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-    {
+    if ($_SESSION['config']['rempli_auto_champ_nb_jours_pris']) {
         // attention : IE6 : bug avec les "OnChange" sur les boutons radio!!! (on remplace par OnClick)
-        if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) ) {
+        if ((isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE') != false)) {
             $return .= 'onClick="compter_jours();return true;" ';
         } else {
             $return .= 'onChange="compter_jours();return false;" ';
         }
     }
-    $return .= 'value="am" checked>&nbsp;' .  _('form_am');
+    $return .= 'value="am" checked>&nbsp;' . _('form_am');
     $return .= '<input type="radio" name="new_demi_jour_deb" ';
 
-    if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-    {
-        if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) ) {
+    if ($_SESSION['config']['rempli_auto_champ_nb_jours_pris']) {
+        if ((isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE') != false)) {
             $return .= 'onClick="compter_jours();return true;" ';
         } else {
             $return .= 'onChange="compter_jours();return false;" ';
         }
     }
-    $return .= 'value="pm">&nbsp;' .  _('form_pm');
+    $return .= 'value="pm">&nbsp;' . _('form_pm');
     $return .= '</div>';
     $return .= '</div>';
     $return .= '<div class="col-md-6">';
@@ -110,24 +120,22 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
     $return .= '</div>';
     $return .= '<input type="radio" name="new_demi_jour_fin" ';
 
-    if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-    {
+    if ($_SESSION['config']['rempli_auto_champ_nb_jours_pris']) {
         // attention : IE6 : bug avec les "OnChange" sur les boutons radio!!! (on remplace par OnClick)
-        if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) ) {
-            $return .= 'onClick="compter_jours();return true;" ' ;
+        if ((isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE') != false)) {
+            $return .= 'onClick="compter_jours();return true;" ';
         } else {
-            $return .= 'onChange="compter_jours();return false;" ' ;
+            $return .= 'onChange="compter_jours();return false;" ';
         }
     }
-    $return .= 'value="am">&nbsp;'. _('form_am');
+    $return .= 'value="am">&nbsp;' . _('form_am');
     $return .= '<input class="form-controm" type="radio" name="new_demi_jour_fin" ';
 
-    if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-    {
-        if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) ) {
-            $return .= 'onClick="compter_jours();return true;" ' ;
+    if ($_SESSION['config']['rempli_auto_champ_nb_jours_pris']) {
+        if ((isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE') != false)) {
+            $return .= 'onClick="compter_jours();return true;" ';
         } else {
-            $return .= 'onChange="compter_jours();return false;" ' ;
+            $return .= 'onChange="compter_jours();return false;" ';
         }
     }
     $return .= 'value="pm" checked>&nbsp;' . _('form_pm');
@@ -140,25 +148,24 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
     /* boutons radio */
     /*****************/
     // recup du tableau des types de conges
-    $tab_type_conges=recup_tableau_types_conges();
+    $tab_type_conges = recup_tableau_types_conges();
     // recup du tableau des types d'absence
-    $tab_type_absence=recup_tableau_types_absence();
+    $tab_type_absence = recup_tableau_types_absence();
     // recup d tableau des types de conges exceptionnels
-    $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
-    $already_checked = false;
+    $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
+    $already_checked               = false;
 
     $return .= '<div class="row type-conges">';
     // si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
     // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
     // OU si le user est un RH ou un admin
-    if( ( $_SESSION['config']['user_saisie_demande'] && $user_login==$_SESSION['userlogin'] ) || ( $_SESSION['config']['user_saisie_demande']==FALSE && $user_login!=$_SESSION['userlogin'] ) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin']) )
-    {
+    if (($_SESSION['config']['user_saisie_demande'] && $user_login == $_SESSION['userlogin']) || ($_SESSION['config']['user_saisie_demande'] == false && $user_login != $_SESSION['userlogin']) || is_hr($_SESSION['userlogin']) || is_admin($_SESSION['userlogin'])) {
         // congés
         $return .= '<div class="col-md-4">';
         $return .= '<label>' . _('divers_conges') . '</label>';
-        foreach($tab_type_conges as $id => $libelle) {
-            if($id==1) {
-                $return .= '<input type="radio" name="new_type" value="' . $id . '" checked>'. $libelle . '<br>';
+        foreach ($tab_type_conges as $id => $libelle) {
+            if ($id == 1) {
+                $return .= '<input type="radio" name="new_type" value="' . $id . '" checked>' . $libelle . '<br>';
                 $already_checked = true;
             } else {
                 $return .= '<input type="radio" name="new_type" value="' . $id . '">' . $libelle . '<br>';
@@ -170,12 +177,11 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
     // si le user a droit de saisir une mission ET si on est PAS dans une fenetre de responsable
     // OU si le resp a droit de saisir une mission ET si on est PAS dans une fenetre dd'utilisateur
     // OU si le resp a droit de saisir une mission ET si le resp est resp de lui meme
-    if( (($_SESSION['config']['user_saisie_mission'])&&($user_login==$_SESSION['userlogin'])) || (($_SESSION['config']['resp_saisie_mission'])&&($user_login!=$_SESSION['userlogin'])) || (($_SESSION['config']['resp_saisie_mission'])&&(is_resp_of_user($_SESSION['userlogin'], $user_login))) )
-        {
+    if ((($_SESSION['config']['user_saisie_mission']) && ($user_login == $_SESSION['userlogin'])) || (($_SESSION['config']['resp_saisie_mission']) && ($user_login != $_SESSION['userlogin'])) || (($_SESSION['config']['resp_saisie_mission']) && (is_resp_of_user($_SESSION['userlogin'], $user_login)))) {
         // absences
         $return .= '<div class="col-md-4">';
         $return .= '<label>' . _('divers_absences') . '</label>';
-        foreach($tab_type_absence as $id => $libelle) {
+        foreach ($tab_type_absence as $id => $libelle) {
             if (!$already_checked) {
                 $return .= '<input type="radio" name="new_type" value="' . $id . '" checked>' . $libelle . '<br>';
                 $already_checked = true;
@@ -188,13 +194,12 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
 
     // si le user a droit de saisir une demande de conges ET si on est PAS dans une fenetre de responsable
     // OU si le user n'a pas droit de saisir une demande de conges ET si on est dans une fenetre de responsable
-    if( ($_SESSION['config']['gestion_conges_exceptionnels']) && ((($_SESSION['config']['user_saisie_demande'])&&($user_login==$_SESSION['userlogin'])) || (($_SESSION['config']['user_saisie_demande']==FALSE)&&($user_login!=$_SESSION['userlogin'])) ) )
-    {
+    if (($_SESSION['config']['gestion_conges_exceptionnels']) && ((($_SESSION['config']['user_saisie_demande']) && ($user_login == $_SESSION['userlogin'])) || (($_SESSION['config']['user_saisie_demande'] == false) && ($user_login != $_SESSION['userlogin'])))) {
         // congés exceptionnels
         $return .= '<div class="col-md-4">';
         $return .= '<label>' . _('divers_conges_exceptionnels') . '</label>';
-        foreach($tab_type_conges_exceptionnels as $id => $libelle) {
-            if($id==1) {
+        foreach ($tab_type_conges_exceptionnels as $id => $libelle) {
+            if ($id == 1) {
                 $return .= '<input type="radio" name="new_type" value="' . $id . '" checked> ' . $libelle . '<br>';
             } else {
                 $return .= '<input type="radio" name="new_type" value="' . $id . '">' . $libelle . '<br>';
@@ -208,16 +213,17 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
     $return .= '<label>' . _('divers_comment_maj_1') . '</label><input class="form-control" type="text" name="new_comment" size="25" maxlength="30" value="">';
 
     // zones de texte
-    $return .= '<label>' . _('saisie_conges_nb_jours') .'&nbsp</label>';
-    if($_SESSION['config']['disable_saise_champ_nb_jours_pris']) { // zone de texte en readonly et grisée
-        $text_nb_jours ='<input type="text" name="new_nb_jours" size="10" maxlength="30" value="" style="background-color: #D4D4D4; " readonly="readonly">' ;
+    $return .= '<label>' . _('saisie_conges_nb_jours') . '&nbsp</label>';
+    if ($_SESSION['config']['disable_saise_champ_nb_jours_pris']) {
+        // zone de texte en readonly et grisée
+        $text_nb_jours = '<input type="text" name="new_nb_jours" size="10" maxlength="30" value="" style="background-color: #D4D4D4; " readonly="readonly">';
     } else {
-        $text_nb_jours ='<input type="text" name="new_nb_jours" size="10" maxlength="3" value="">' ;
+        $text_nb_jours = '<input type="text" name="new_nb_jours" size="10" maxlength="3" value="">';
     }
 
     $return .= $text_nb_jours;
 
-    if($_SESSION['config']['affiche_bouton_calcul_nb_jours_pris']) {
+    if ($_SESSION['config']['affiche_bouton_calcul_nb_jours_pris']) {
         $return .= '<input type="button" class="btn btn-success" onclick="compter_jours();return false;" value="' . _('saisie_conges_compter_jours') . '">';
     }
     $return .= '<p id="comment_nbj" style="color:red">&nbsp;</p>';
@@ -234,70 +240,59 @@ function saisie_nouveau_conges2($user_login, $year_calendrier_saisie_debut, $moi
 
 // initialisation des variables pour la navigation mois précédent / mois suivant
 // certains arguments sont passés par référence (avec &) car on change leur valeur
-function init_var_navigation_mois_year( $mois_calendrier_saisie_debut, $year_calendrier_saisie_debut, &$mois_calendrier_saisie_debut_prec, &$year_calendrier_saisie_debut_prec,    &$mois_calendrier_saisie_debut_suiv, &$year_calendrier_saisie_debut_suiv, $mois_calendrier_saisie_fin, $year_calendrier_saisie_fin, &$mois_calendrier_saisie_fin_prec, &$year_calendrier_saisie_fin_prec, &$mois_calendrier_saisie_fin_suiv, &$year_calendrier_saisie_fin_suiv )
+function init_var_navigation_mois_year($mois_calendrier_saisie_debut, $year_calendrier_saisie_debut, &$mois_calendrier_saisie_debut_prec, &$year_calendrier_saisie_debut_prec, &$mois_calendrier_saisie_debut_suiv, &$year_calendrier_saisie_debut_suiv, $mois_calendrier_saisie_fin, $year_calendrier_saisie_fin, &$mois_calendrier_saisie_fin_prec, &$year_calendrier_saisie_fin_prec, &$mois_calendrier_saisie_fin_suiv, &$year_calendrier_saisie_fin_suiv)
 {
-    if($mois_calendrier_saisie_debut==1)
-    {
-        $mois_calendrier_saisie_debut_prec=12;
-        $year_calendrier_saisie_debut_prec=$year_calendrier_saisie_debut-1 ;
+    if ($mois_calendrier_saisie_debut == 1) {
+        $mois_calendrier_saisie_debut_prec = 12;
+        $year_calendrier_saisie_debut_prec = $year_calendrier_saisie_debut - 1;
+    } else {
+        $mois_calendrier_saisie_debut_prec = $mois_calendrier_saisie_debut - 1;
+        $year_calendrier_saisie_debut_prec = $year_calendrier_saisie_debut;
     }
-    else
-    {
-        $mois_calendrier_saisie_debut_prec=$mois_calendrier_saisie_debut-1 ;
-        $year_calendrier_saisie_debut_prec=$year_calendrier_saisie_debut ;
-    }
-    if($mois_calendrier_saisie_debut==12)
-    {
-        $mois_calendrier_saisie_debut_suiv=1;
-        $year_calendrier_saisie_debut_suiv=$year_calendrier_saisie_debut+1 ;
-    }
-    else
-    {
-        $mois_calendrier_saisie_debut_suiv=$mois_calendrier_saisie_debut+1 ;
-        $year_calendrier_saisie_debut_suiv=$year_calendrier_saisie_debut ;
+    if ($mois_calendrier_saisie_debut == 12) {
+        $mois_calendrier_saisie_debut_suiv = 1;
+        $year_calendrier_saisie_debut_suiv = $year_calendrier_saisie_debut + 1;
+    } else {
+        $mois_calendrier_saisie_debut_suiv = $mois_calendrier_saisie_debut + 1;
+        $year_calendrier_saisie_debut_suiv = $year_calendrier_saisie_debut;
     }
 
-    if($mois_calendrier_saisie_fin==1)
-    {
-        $mois_calendrier_saisie_fin_prec=12;
-        $year_calendrier_saisie_fin_prec=$year_calendrier_saisie_fin-1 ;
+    if ($mois_calendrier_saisie_fin == 1) {
+        $mois_calendrier_saisie_fin_prec = 12;
+        $year_calendrier_saisie_fin_prec = $year_calendrier_saisie_fin - 1;
+    } else {
+        $mois_calendrier_saisie_fin_prec = $mois_calendrier_saisie_fin - 1;
+        $year_calendrier_saisie_fin_prec = $year_calendrier_saisie_fin;
     }
-    else
-    {
-        $mois_calendrier_saisie_fin_prec=$mois_calendrier_saisie_fin-1 ;
-        $year_calendrier_saisie_fin_prec=$year_calendrier_saisie_fin ;
-    }
-    if($mois_calendrier_saisie_fin==12)
-    {
-        $mois_calendrier_saisie_fin_suiv=1;
-        $year_calendrier_saisie_fin_suiv=$year_calendrier_saisie_fin+1 ;
-    }
-    else
-    {
-        $mois_calendrier_saisie_fin_suiv=$mois_calendrier_saisie_fin+1 ;
-        $year_calendrier_saisie_fin_suiv=$year_calendrier_saisie_fin ;
+    if ($mois_calendrier_saisie_fin == 12) {
+        $mois_calendrier_saisie_fin_suiv = 1;
+        $year_calendrier_saisie_fin_suiv = $year_calendrier_saisie_fin + 1;
+    } else {
+        $mois_calendrier_saisie_fin_suiv = $mois_calendrier_saisie_fin + 1;
+        $year_calendrier_saisie_fin_suiv = $year_calendrier_saisie_fin;
     }
 }
-
 
 // affiche une chaine représentant un decimal sans 0 à la fin ...
 // (un point separe les unités et les decimales et on ne considere que 2 decimales !!!)
 // ex : 10.00 devient 10  , 5.50 devient 5.5  , et 3.05 reste 3.05
 function affiche_decimal($str)
 {
-    $champs=explode('.', $str);
-    $int=$champs[0];
-    $decimal='00';
-    if (count($champs)>1)
+    $champs  = explode('.', $str);
+    $int     = $champs[0];
+    $decimal = '00';
+    if (count($champs) > 1) {
         $decimal = $champs[1];
-    if($decimal=='00')
-        return $int ;
-    elseif (preg_match('/[0-9][1-9]$/' , $decimal ))
+    }
+
+    if ($decimal == '00') {
+        return $int;
+    } elseif (preg_match('/[0-9][1-9]$/', $decimal)) {
         return $str;
-    elseif (preg_match('/([0-9]?)0?$/' , $decimal, $regs ))
-        return $int.'.'.$regs[1] ;
-    else {
-        echo 'ERREUR: affiche_decimal('.$str.') : '.$str.' n\'a pas le format attendu !!!!<br>';
+    } elseif (preg_match('/([0-9]?)0?$/', $decimal, $regs)) {
+        return $int . '.' . $regs[1];
+    } else {
+        echo 'ERREUR: affiche_decimal(' . $str . ') : ' . $str . ' n\'a pas le format attendu !!!!<br>';
         exit;
     }
 }
@@ -309,31 +304,27 @@ function verif_saisie_new_demande($new_debut, $new_demi_jour_deb, $new_fin, $new
     $verif = true;
 
     // leur champs doivent etre renseignés dans le formulaire
-    if( $new_debut == '' || $new_fin == '' || $new_nb_jours == '' )
-    {
-        echo '<br>'. _('verif_saisie_erreur_valeur_manque') .'<br>';
+    if ($new_debut == '' || $new_fin == '' || $new_nb_jours == '') {
+        echo '<br>' . _('verif_saisie_erreur_valeur_manque') . '<br>';
         $verif = false;
     }
 
-    if ( !preg_match('/([0-9]+)([\.\,]*[0-9]{1,2})*$/', $new_nb_jours) )
-    {
-        echo '<br>'. _('verif_saisie_erreur_nb_jours_bad') .'<br>';
+    if (!preg_match('/([0-9]+)([\.\,]*[0-9]{1,2})*$/', $new_nb_jours)) {
+        echo '<br>' . _('verif_saisie_erreur_nb_jours_bad') . '<br>';
         $verif = false;
-    } elseif ( preg_match('/([0-9]+)\,([0-9]{1,2})$/', $new_nb_jours, $reg)) {
-        $new_nb_jours=$reg[1].'.'.$reg[2]; // on remplace la virgule par un point pour les décimaux
+    } elseif (preg_match('/([0-9]+)\,([0-9]{1,2})$/', $new_nb_jours, $reg)) {
+        $new_nb_jours = $reg[1] . '.' . $reg[2]; // on remplace la virgule par un point pour les décimaux
     }
 
     // si la date de fin est antérieure à la date debut
-    if(strnatcmp($new_debut, $new_fin)>0)
-    {
-        echo '<br>'. _('verif_saisie_erreur_fin_avant_debut') .'<br>';
+    if (strnatcmp($new_debut, $new_fin) > 0) {
+        echo '<br>' . _('verif_saisie_erreur_fin_avant_debut') . '<br>';
         $verif = false;
     }
 
     // si la date debut et fin = même jour mais début=après midi et fin=matin !!
-    if( $new_debut == $new_fin && $new_demi_jour_deb=='pm' && $new_demi_jour_fin == 'am' )
-    {
-        echo '<br>'. _('verif_saisie_erreur_debut_apres_fin') .'<br>';
+    if ($new_debut == $new_fin && $new_demi_jour_deb == 'pm' && $new_demi_jour_fin == 'am') {
+        echo '<br>' . _('verif_saisie_erreur_debut_apres_fin') . '<br>';
         $verif = false;
     }
 
@@ -352,21 +343,20 @@ function verif_saisie_new_demande($new_debut, $new_demi_jour_deb, $new_fin, $new
 
     $conge = new \App\ProtoControllers\Employe\Conge();
     if ($conge->isChevauchement($_SESSION['userlogin'], $new_debut, $periodeDebut, $new_fin, $periodeFin)) {
-        echo '<br>'. _('demande_heure_chevauche_demande') .'<br>';
+        echo '<br>' . _('demande_heure_chevauche_demande') . '<br>';
         $verif = false;
     }
-    
+
     $tab_periode_calcul = make_tab_demi_jours_periode($new_debut, $new_fin, $new_demi_jour_deb, $new_demi_jour_fin);
-    if(verif_periode_chevauche_periode_user($new_debut, $new_fin, $_SESSION['userlogin'], "", $tab_periode_calcul, $new_comment)){
-        echo '<br>'._('calcul_nb_jours_commentaire') .'<br>';
+    if (verif_periode_chevauche_periode_user($new_debut, $new_fin, $_SESSION['userlogin'], "", $tab_periode_calcul, $new_comment)) {
+        echo '<br>' . _('calcul_nb_jours_commentaire') . '<br>';
         $verif = false;
     }
-    
+
     $new_comment = htmlentities($new_comment, ENT_QUOTES | ENT_HTML401);
 
     return $verif;
 }
-
 
 // renvoit la class de cellule du jour indiquée par le timestamp
 // (une classe pour les jours de semaine et une pour les jours de week end)
@@ -375,40 +365,43 @@ function get_td_class_of_the_day_in_the_week($timestamp_du_jour)
     $j_name = date('D', $timestamp_du_jour);
     $j_date = date('Y-m-d', $timestamp_du_jour);
 
-    if( ( $j_name=='Sat' && !$_SESSION['config']['samedi_travail'] ) || ($j_name=='Sun' && !$_SESSION['config']['dimanche_travail'] ) || est_chome($timestamp_du_jour) || est_ferme($timestamp_du_jour) )
+    if (($j_name == 'Sat' && !$_SESSION['config']['samedi_travail']) || ($j_name == 'Sun' && !$_SESSION['config']['dimanche_travail']) || est_chome($timestamp_du_jour) || est_ferme($timestamp_du_jour)) {
         return 'weekend';
-    else
+    } else {
         return 'semaine';
-}
+    }
 
+}
 
 // recup des infos ARTT ou Temps Partiel :
 // attention : les param $val_matin et $val_aprem sont passées par référence (avec &) car on change leur valeur
 function recup_infos_artt_du_jour($sql_login, $j_timestamp, &$val_matin, &$val_aprem, array $planningUser)
 {
-    $num_semaine = date('W', $j_timestamp);
+    $num_semaine     = date('W', $j_timestamp);
     $jour_name_fr_2c = get_j_name_fr_2c($j_timestamp); // nom du jour de la semaine en francais sur 2 caracteres
 
     // on ne cherche pas d'artt les samedis ou dimanches quand il ne sont pas travaillés (cf config de php_conges)
-    if ( ( $jour_name_fr_2c != 'sa' || $_SESSION['config']['samedi_travail'] )  && ( $jour_name_fr_2c != 'di' || $_SESSION['config']['dimanche_travail'] ) )
-    {
+    if (($jour_name_fr_2c != 'sa' || $_SESSION['config']['samedi_travail']) && ($jour_name_fr_2c != 'di' || $_SESSION['config']['dimanche_travail'])) {
         // verif si le jour fait l'objet d'un echange ....
-        $date_j            = date('Y-m-d', $j_timestamp);
-        $sql_echange_rtt = 'SELECT e_absence FROM conges_echange_rtt WHERE e_login="'.\includes\SQL::quote($sql_login).'" AND e_date_jour="'.\includes\SQL::quote($date_j).'" ';
+        $date_j          = date('Y-m-d', $j_timestamp);
+        $sql_echange_rtt = 'SELECT e_absence FROM conges_echange_rtt WHERE e_login="' . \includes\SQL::quote($sql_login) . '" AND e_date_jour="' . \includes\SQL::quote($date_j) . '" ';
         $res_echange_rtt = \includes\SQL::query($sql_echange_rtt);
         $num_echange_rtt = $res_echange_rtt->num_rows;
         // si le jour est l'objet d'un echange, on tient compte de l'échange
-        if( $num_echange_rtt != 0 )
-        {
+        if ($num_echange_rtt != 0) {
             $result_echange_rtt = $res_echange_rtt->fetch_array();
-            if ( in_array($result_echange_rtt['e_absence'] , array( 'J' , 'M') ) )
+            if (in_array($result_echange_rtt['e_absence'], array('J', 'M'))) {
                 $val_matin = 'Y';
-            else
+            } else {
                 $val_matin = 'N';
-            if ( in_array($result_echange_rtt['e_absence'] , array( 'J' , 'A') ) )
+            }
+
+            if (in_array($result_echange_rtt['e_absence'], array('J', 'A'))) {
                 $val_aprem = 'Y';
-            else
+            } else {
                 $val_aprem = 'N';
+            }
+
         } else {
             /* Sinon, on s'appuie sur le planning normalement */
             $realWeekType = \utilisateur\Fonctions::getRealWeekType($planningUser, $num_semaine);
@@ -418,7 +411,7 @@ function recup_infos_artt_du_jour($sql_login, $j_timestamp, &$val_matin, &$val_a
                 $val_aprem = 'Y';
             } else {
                 $planningWeek = $planningUser[$realWeekType];
-                $jourId = date('N', $j_timestamp);
+                $jourId       = date('N', $j_timestamp);
                 if (!\utilisateur\Fonctions::isWorkingDay($planningWeek, $jourId)) {
                     /* Si le jour n'est pas travaillé */
                     $val_matin = 'Y';
@@ -426,14 +419,13 @@ function recup_infos_artt_du_jour($sql_login, $j_timestamp, &$val_matin, &$val_a
                 } else {
                     /* Vérification si le créneau est travaillé */
                     $planningDay = $planningWeek[$jourId];
-                    $val_matin = (\utilisateur\Fonctions::isWorkingMorning($planningDay)) ? 'N' : 'Y';
-                    $val_aprem = (\utilisateur\Fonctions::isWorkingAfternoon($planningDay)) ? 'N' : 'Y';
+                    $val_matin   = (\utilisateur\Fonctions::isWorkingMorning($planningDay)) ? 'N' : 'Y';
+                    $val_aprem   = (\utilisateur\Fonctions::isWorkingAfternoon($planningDay)) ? 'N' : 'Y';
                 }
             }
         }
     }
 }
-
 
 // recup des infos ARTT ou Temps Partiel :
 // attention : les param $val_matin et $val_aprem sont passées par référence (avec &) car on change leur valeur
@@ -445,23 +437,20 @@ function recup_infos_artt_du_jour_from_tab($sql_login, $j_timestamp, &$val_matin
     // qui contient lui même un tableau ($tab_echange) contenant les infos des echanges de rtt pour ce
     // jour et ce login (valeur du matin + valeur de l'apres midi ('Y' si rtt, 'N' sinon) )
 
-    $num_semaine = date('W', $j_timestamp);
+    $num_semaine     = date('W', $j_timestamp);
     $jour_name_fr_2c = get_j_name_fr_2c($j_timestamp); // nom du jour de la semaine en francais sur 2 caracteres
 
     // on ne cherche pas d'artt les samedis ou dimanches quand il ne sont pas travaillés (cf config de php_conges)
-    if ( ( $jour_name_fr_2c != 'sa' || $_SESSION['config']['samedi_travail'] )  && ( $jour_name_fr_2c != 'di' || $_SESSION['config']['dimanche_travail'] ) )
-    {
+    if (($jour_name_fr_2c != 'sa' || $_SESSION['config']['samedi_travail']) && ($jour_name_fr_2c != 'di' || $_SESSION['config']['dimanche_travail'])) {
         // verif si le jour fait l'objet d'un echange ....
         // si le jour est l'objet d'un echange, on tient compte de l'échange
         $date_j = date('Y-m-d', $j_timestamp);
-        if(isset($tab_rtt_echange[$date_j]) && array_key_exists($sql_login, $tab_rtt_echange[$date_j]))   // si la periode correspond au user que l'on est en train de traiter
+        if (isset($tab_rtt_echange[$date_j]) && array_key_exists($sql_login, $tab_rtt_echange[$date_j])) // si la periode correspond au user que l'on est en train de traiter
         {
-            $tab_day = $tab_rtt_echange[$date_j];  // on recup le tableau du jour
+            $tab_day   = $tab_rtt_echange[$date_j]; // on recup le tableau du jour
             $val_matin = $tab_day[$sql_login]["val_matin"];
             $val_aprem = $tab_day[$sql_login]["val_aprem"];
-        }
-        else
-        {
+        } else {
             /* Sinon, on s'appuie sur le planning normalement */
             $realWeekType = \utilisateur\Fonctions::getRealWeekType($planningUser, $num_semaine);
             if (NIL_INT === $realWeekType) {
@@ -470,7 +459,7 @@ function recup_infos_artt_du_jour_from_tab($sql_login, $j_timestamp, &$val_matin
                 $val_aprem = 'Y';
             } else {
                 $planningWeek = $planningUser[$realWeekType];
-                $jourId = date('N', $j_timestamp);
+                $jourId       = date('N', $j_timestamp);
                 if (!\utilisateur\Fonctions::isWorkingDay($planningWeek, $jourId)) {
                     /* Si le jour n'est pas travaillé */
                     $val_matin = 'Y';
@@ -478,8 +467,8 @@ function recup_infos_artt_du_jour_from_tab($sql_login, $j_timestamp, &$val_matin
                 } else {
                     /* Vérification si le créneau est travaillé */
                     $planningDay = $planningWeek[$jourId];
-                    $val_matin = (\utilisateur\Fonctions::isWorkingMorning($planningDay)) ? 'N' : 'Y';
-                    $val_aprem = (\utilisateur\Fonctions::isWorkingAfternoon($planningDay)) ? 'N' : 'Y';
+                    $val_matin   = (\utilisateur\Fonctions::isWorkingMorning($planningDay)) ? 'N' : 'Y';
+                    $val_aprem   = (\utilisateur\Fonctions::isWorkingAfternoon($planningDay)) ? 'N' : 'Y';
                 }
             }
         }
@@ -490,31 +479,28 @@ function recup_infos_artt_du_jour_from_tab($sql_login, $j_timestamp, &$val_matin
 //  (attention : le $nombre est passé par référence car on le modifie si besoin)
 function verif_saisie_decimal(&$nombre)
 {
-    $nombre = number_format(floatval($nombre), 1, '.', '' );
+    $nombre = number_format(floatval($nombre), 1, '.', '');
     return true;
 }
-
-
 
 // donne la date en francais (dans la langue voulue)(meme formats que la fonction PHP date() cf manuel php)
 function date_fr($code, $timestmp)
 {
-    $les_mois_longs  = array('pas_de_zero',  _('janvier') ,  _('fevrier') ,  _('mars') ,  _('avril') , _('mai') ,  _('juin') ,  _('juillet') ,  _('aout') , _('septembre') ,  _('octobre') ,  _('novembre') ,  _('decembre') );
-    $les_jours_longs  = array( _('dimanche') ,  _('lundi') ,  _('mardi') ,  _('mercredi') , _('jeudi') ,  _('vendredi') ,  _('samedi') );
-    $les_jours_courts = array( _('dimanche_short') ,  _('lundi_short') ,  _('mardi_short') , _('mercredi_short') ,  _('jeudi_short') ,  _('vendredi_short') ,  _('samedi_short') );
+    $les_mois_longs   = array('pas_de_zero', _('janvier'), _('fevrier'), _('mars'), _('avril'), _('mai'), _('juin'), _('juillet'), _('aout'), _('septembre'), _('octobre'), _('novembre'), _('decembre'));
+    $les_jours_longs  = array(_('dimanche'), _('lundi'), _('mardi'), _('mercredi'), _('jeudi'), _('vendredi'), _('samedi'));
+    $les_jours_courts = array(_('dimanche_short'), _('lundi_short'), _('mardi_short'), _('mercredi_short'), _('jeudi_short'), _('vendredi_short'), _('samedi_short'));
 
-    switch ($code)
-    {
+    switch ($code) {
         case 'F':
-            return $les_mois_longs[ date('n', $timestmp) ];
+            return $les_mois_longs[date('n', $timestmp)];
             break;
 
         case 'l':
-            return $les_jours_longs[ date('w', $timestmp) ];
+            return $les_jours_longs[date('w', $timestmp)];
             break;
 
         case 'D':
-            return $les_jours_courts[ date('w', $timestmp) ];
+            return $les_jours_courts[date('w', $timestmp)];
             break;
 
         default:
@@ -522,8 +508,6 @@ function date_fr($code, $timestmp)
             break;
     }
 }
-
-
 
 // envoi d'un message d'avertissement
 // parametre 1=login de l'expéditeur
@@ -535,75 +519,75 @@ function alerte_mail($login_expediteur, $destinataire, $num_periode, $objet)
 
     /*********************************************/
     // recup des infos concernant l'expéditeur ....
-    $mail_array        = find_email_adress_for_user($login_expediteur);
-    $mail_sender_name    = $mail_array[0];
-    $mail_sender_addr    = $mail_array[1];
+    $mail_array       = find_email_adress_for_user($login_expediteur);
+    $mail_sender_name = $mail_array[0];
+    $mail_sender_addr = $mail_array[1];
 
     /*********************************************/
     // recherche des infos concernant le destinataire ...
     // recherche du login du (des) destinataire(s) dans la base
-    $dest_mail  = '';
-    if( $destinataire == ':responsable:' )  // c'est un message au responsable
+    $dest_mail = '';
+    if ($destinataire == ':responsable:') // c'est un message au responsable
     {
-        $tab_resp   = get_tab_resp_du_user($login_expediteur);
-        foreach($tab_resp as $item_login => $item_presence)
-        {
+        $tab_resp = get_tab_resp_du_user($login_expediteur);
+        foreach ($tab_resp as $item_login => $item_presence) {
             // recherche de l'adresse mail du (des) responsable(s) :
             $mail_array_dest = find_email_adress_for_user($item_login);
-            $mail_dest_name = $mail_array_dest[0];
-            $mail_dest_addr = $mail_array_dest[1];
+            $mail_dest_name  = $mail_array_dest[0];
+            $mail_dest_addr  = $mail_array_dest[1];
 
-            if( $mail_dest_addr == '' )
+            if ($mail_dest_addr == '') {
                 echo "<b>ERROR : $mail_dest_name : no mail address !</b><br>\n";
-            else
-            {
+            } else {
                 // on change l'objet si c'est un "new_demande" à un resp absent et qu'on gere les absence de resp !
-                if( $_SESSION['config']['gestion_cas_absence_responsable'] && $item_presence == 'absent' && $objet == 'new_demande' )
-                    $new_objet  = 'new_demande_resp_absent';
-                else
-                    $new_objet  = $objet;
+                if ($_SESSION['config']['gestion_cas_absence_responsable'] && $item_presence == 'absent' && $objet == 'new_demande') {
+                    $new_objet = 'new_demande_resp_absent';
+                } else {
+                    $new_objet = $objet;
+                }
 
                 constuct_and_send_mail($new_objet, $mail_sender_name, $mail_sender_addr, $mail_dest_name, $mail_dest_addr, $num_periode);
             }
         }
 
-    }
-    else   // c'est un message du responsale à un user
+    } else // c'est un message du responsale à un user
     {
-        $dest_login        = $destinataire ;
-        $mail_array_dest    = find_email_adress_for_user($dest_login);
-        $mail_dest_name     = $mail_array_dest[0];
-        $mail_dest_addr     = $mail_array_dest[1];
+        $dest_login      = $destinataire;
+        $mail_array_dest = find_email_adress_for_user($dest_login);
+        $mail_dest_name  = $mail_array_dest[0];
+        $mail_dest_addr  = $mail_array_dest[1];
 
-        if( $mail_dest_addr == '' )
+        if ($mail_dest_addr == '') {
             echo "<b>ERROR : $mail_dest_name : no mail address !</b><br>\n";
-        else
+        } else {
             constuct_and_send_mail($objet, $mail_sender_name, $mail_sender_addr, $mail_dest_name, $mail_dest_addr, $num_periode);
+        }
 
         /****************************/
-        if( $objet == 'valid_conges' )  // c'est un mail de première validation de demande : il faut faire une copie au(x) grand(s) responsable(s)
+        if ($objet == 'valid_conges') // c'est un mail de première validation de demande : il faut faire une copie au(x) grand(s) responsable(s)
         {
             // on recup la liste des grands resp du user
-            $tab_grd_resp   = array();
+            $tab_grd_resp = array();
             get_tab_grd_resp_du_user($dest_login, $tab_grd_resp);
 
-            if( count($tab_grd_resp) != 0 ) {
-                foreach($tab_grd_resp as $item_login) {
+            if (count($tab_grd_resp) != 0) {
+                foreach ($tab_grd_resp as $item_login) {
                     // recherche de l'adresse mail du (des) responsable(s) :
                     $mail_array_dest = find_email_adress_for_user($item_login);
-                    $mail_dest_name = $mail_array_dest[0];
-                    $mail_dest_addr = $mail_array_dest[1];
+                    $mail_dest_name  = $mail_array_dest[0];
+                    $mail_dest_addr  = $mail_array_dest[1];
 
-                    if( $mail_dest_addr == '' )
+                    if ($mail_dest_addr == '') {
                         echo "<b>ERROR : $mail_dest_name : no mail address !</b><br>\n";
-                    else
+                    } else {
                         constuct_and_send_mail($objet, $mail_sender_name, $mail_sender_addr, $mail_dest_name, $mail_dest_addr, $num_periode);
+                    }
+
                 }
             }
         }
     }
 }
-
 
 // construit et envoie le mail
 function constuct_and_send_mail($objet, $mail_sender_name, $mail_sender_addr, $mail_dest_name, $mail_dest_addr, $num_periode)
@@ -612,10 +596,10 @@ function constuct_and_send_mail($objet, $mail_sender_name, $mail_sender_addr, $m
     // init du mail
     $mail = new \PHPMailer();
 
-    if (file_exists(CONFIG_PATH .'config_SMTP.php')) {
-        include CONFIG_PATH .'config_SMTP.php';
+    if (file_exists(CONFIG_PATH . 'config_SMTP.php')) {
+        include CONFIG_PATH . 'config_SMTP.php';
 
-        if(!empty($config_SMTP_host)) {
+        if (!empty($config_SMTP_host)) {
             $mail->IsSMTP();
             $mail->Host = $config_SMTP_host;
             $mail->Port = $config_SMTP_port;
@@ -628,74 +612,70 @@ function constuct_and_send_mail($objet, $mail_sender_name, $mail_sender_addr, $m
             if (!empty($config_SMTP_sec)) {
                 $mail->SMTPSecure = $config_SMTP_sec;
             } else {
-            	 $mail->SMTPAutoTLS = false;
+                $mail->SMTPAutoTLS = false;
             }
         }
-    }
-    else
-    {
-        if(file_exists('/usr/sbin/sendmail'))
-            $mail->IsSendmail();   // send message using the $Sendmail program
-        elseif(file_exists('/var/qmail/bin/sendmail'))
-            $mail->IsQmail(); // send message using the qmail MTA
-        else
-            $mail->IsMail(); // send message using PHP mail() function
+    } else {
+        if (file_exists('/usr/sbin/sendmail')) {
+            $mail->IsSendmail();
+        }
+        // send message using the $Sendmail program
+        elseif (file_exists('/var/qmail/bin/sendmail')) {
+            $mail->IsQmail();
+        }
+        // send message using the qmail MTA
+        else {
+            $mail->IsMail();
+        }
+        // send message using PHP mail() function
     }
 
     // initialisation du langage utilisé par php_mailer
-    $mail->SetLanguage( 'fr', ROOT_PATH . 'vendor/phpmailer/phpmailer/language/');
-    $mail->FromName    = $mail_sender_name;
-    $mail->From        = $mail_sender_addr;
+    $mail->SetLanguage('fr', ROOT_PATH . 'vendor/phpmailer/phpmailer/language/');
+    $mail->FromName = $mail_sender_name;
+    $mail->From     = $mail_sender_addr;
     $mail->AddAddress($mail_dest_addr);
 
     /*********************************************/
     // recup des infos de l'absence
-    if ($num_periode == "test")
-    {
+    if ($num_periode == "test") {
         // affiche : "23 / 01 / 2008 (am)"
         $sql_date_deb = "01 / 01 / 2001 (am)";
         // affiche : "23 / 01 / 2008 (am)"
-        $sql_date_fin = "02 / 01 / 2001 (am)";
-        $sql_nb_jours = 2;
-        $sql_commentaire = "Test comment";
+        $sql_date_fin     = "02 / 01 / 2001 (am)";
+        $sql_nb_jours     = 2;
+        $sql_commentaire  = "Test comment";
         $sql_type_absence = "cp";
-        $mail->SMTPDebug = 3; // Much easier if something fails
-    }
-    else
-    {
+        $mail->SMTPDebug  = 3; // Much easier if something fails
+    } else {
         $select_abs = 'SELECT conges_periode.p_date_deb,conges_periode.p_demi_jour_deb,conges_periode.p_date_fin,conges_periode.p_demi_jour_fin,conges_periode.p_nb_jours,conges_periode.p_commentaire,conges_type_absence.ta_libelle
-                FROM conges_periode, conges_type_absence WHERE conges_periode.p_num='.$num_periode.' AND conges_periode.p_type = conges_type_absence.ta_id;';
-        $res_abs = \includes\SQL::query($select_abs);
-        $rec_abs = $res_abs->fetch_array();
+                FROM conges_periode, conges_type_absence WHERE conges_periode.p_num=' . $num_periode . ' AND conges_periode.p_type = conges_type_absence.ta_id;';
+        $res_abs      = \includes\SQL::query($select_abs);
+        $rec_abs      = $res_abs->fetch_array();
         $tab_date_deb = explode('-', $rec_abs['p_date_deb']);
         // affiche : "23 / 01 / 2008 (am)"
-        $sql_date_deb = $tab_date_deb[2]." / ".$tab_date_deb[1]." / ".$tab_date_deb[0]." (".$rec_abs["p_demi_jour_deb"].")" ;
-        $tab_date_fin= explode("-", $rec_abs["p_date_fin"]);
+        $sql_date_deb = $tab_date_deb[2] . " / " . $tab_date_deb[1] . " / " . $tab_date_deb[0] . " (" . $rec_abs["p_demi_jour_deb"] . ")";
+        $tab_date_fin = explode("-", $rec_abs["p_date_fin"]);
         // affiche : "23 / 01 / 2008 (am)"
-        $sql_date_fin = $tab_date_fin[2]." / ".$tab_date_fin[1]." / ".$tab_date_fin[0]." (".$rec_abs["p_demi_jour_fin"].")" ;
-        $sql_nb_jours = $rec_abs["p_nb_jours"];
-        $sql_commentaire = $rec_abs["p_commentaire"];
+        $sql_date_fin     = $tab_date_fin[2] . " / " . $tab_date_fin[1] . " / " . $tab_date_fin[0] . " (" . $rec_abs["p_demi_jour_fin"] . ")";
+        $sql_nb_jours     = $rec_abs["p_nb_jours"];
+        $sql_commentaire  = $rec_abs["p_commentaire"];
         $sql_type_absence = $rec_abs["ta_libelle"];
     }
 
     /*********************************************/
     // construction des sujets et corps des messages
-    if($objet=="valid_conges")
-    {
-        $key1="mail_prem_valid_conges_sujet" ;
-        $key2="mail_prem_valid_conges_contenu" ;
+    if ($objet == "valid_conges") {
+        $key1 = "mail_prem_valid_conges_sujet";
+        $key2 = "mail_prem_valid_conges_contenu";
+    } elseif ($objet == "accept_conges") {
+        $key1 = "mail_valid_conges_sujet";
+        $key2 = "mail_valid_conges_contenu";
+    } else {
+        $key1 = "mail_" . $objet . "_sujet";
+        $key2 = "mail_" . $objet . "_contenu";
     }
-    elseif($objet=="accept_conges")
-    {
-        $key1="mail_valid_conges_sujet" ;
-        $key2="mail_valid_conges_contenu" ;
-    }
-    else
-    {
-        $key1="mail_".$objet."_sujet" ;
-        $key2="mail_".$objet."_contenu" ;
-    }
-    $sujet = $_SESSION['config'][$key1];
+    $sujet   = $_SESSION['config'][$key1];
     $contenu = $_SESSION['config'][$key2];
     $contenu = str_replace("__URL_ACCUEIL_CONGES__", $_SESSION['config']['URL_ACCUEIL_CONGES'], $contenu);
     $contenu = str_replace("__SENDER_NAME__", $mail_sender_name, $contenu);
@@ -708,101 +688,90 @@ function constuct_and_send_mail($objet, $mail_sender_name, $mail_sender_addr, $m
     $contenu = str_replace("__TYPE_ABSENCE__", $sql_type_absence, $contenu);
 
     // construction du corps du mail
-    $mail->Subject = stripslashes(utf8_decode($sujet ));
-    $mail->Body = stripslashes(utf8_decode($contenu ));
-
+    $mail->Subject = stripslashes(utf8_decode($sujet));
+    $mail->Body    = stripslashes(utf8_decode($contenu));
 
     /*********************************************/
     // ENVOI du mail
-    if(!isset($mail_dest_addr))
-    {
+    if (!isset($mail_dest_addr)) {
         echo "<b>ERROR : No recipient address for the message!</b><br>\n";
         echo "<b>Message was not sent </b><br>";
-    }
-    else
-    {
-        if(!$mail->Send())
-        {
+    } else {
+        if (!$mail->Send()) {
             echo "<b>Message was not sent </b><br>";
-            echo "<b>Mailer Error: " . $mail->ErrorInfo."</b><br>";
+            echo "<b>Mailer Error: " . $mail->ErrorInfo . "</b><br>";
         }
     }
 }
-
-
 
 // recuperation du mail d'un user
 // renvoit un tableau a 2 valeurs : prenom+nom et email
 function find_email_adress_for_user($login)
 {
 
-    $found_mail=array();
+    $found_mail = array();
 
-    if($_SESSION['config']['where_to_find_user_email']=="ldap") // recherche du mail du user dans un annuaire LDAP
+    if ($_SESSION['config']['where_to_find_user_email'] == "ldap") // recherche du mail du user dans un annuaire LDAP
     {
         // cnx à l'annuaire ldap :
         $ds = ldap_connect($_SESSION['config']['ldap_server']);
-        if($_SESSION['config']['ldap_protocol_version'] != 0)
-        {
-            ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, $_SESSION['config']['ldap_protocol_version']) ;
-			// Support Active Directory
-			ldap_set_option($ds, LDAP_OPT_REFERRALS, 0);
+        if ($_SESSION['config']['ldap_protocol_version'] != 0) {
+            ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, $_SESSION['config']['ldap_protocol_version']);
+            // Support Active Directory
+            ldap_set_option($ds, LDAP_OPT_REFERRALS, 0);
         }
-        if ($_SESSION['config']['ldap_user'] == "")
-             $bound = ldap_bind($ds);
-        else $bound = ldap_bind($ds, $_SESSION['config']['ldap_user'], $_SESSION['config']['ldap_pass']);
+        if ($_SESSION['config']['ldap_user'] == "") {
+            $bound = ldap_bind($ds);
+        } else {
+            $bound = ldap_bind($ds, $_SESSION['config']['ldap_user'], $_SESSION['config']['ldap_pass']);
+        }
 
         // recherche des entrées correspondantes au "login" passé en paramètre :
-        $filter = "(".$_SESSION['config']['ldap_login']."=".$login.")";
+        $filter = "(" . $_SESSION['config']['ldap_login'] . "=" . $login . ")";
 
         $sr   = ldap_search($ds, $_SESSION['config']['searchdn'], $filter);
-        $data = ldap_get_entries($ds,$sr);
+        $data = ldap_get_entries($ds, $sr);
 
-        foreach ($data as $info)
-        {
-            $found_mail=array();
+        foreach ($data as $info) {
+            $found_mail = array();
             // On récupère le nom et le mail de la personne.
             // Utilisation de la fonction utf8_decode pour corriger les caractères accentués
             // (qnd les noms ou prénoms ont des accents, "ç", ...
 
             // Les champs LDAP utilisés, bien que censés être uniformes, sont ceux d'un AD 2003.
-            $ldap_prenom= $_SESSION['config']['ldap_prenom'];
+            $ldap_prenom = $_SESSION['config']['ldap_prenom'];
             $ldap_nom    = $_SESSION['config']['ldap_nom'];
-            $ldap_mail    = $_SESSION['config']['ldap_mail'];
-            $nom    = utf8_decode($info[$ldap_prenom][0])." ".strtoupper(utf8_decode($info[$ldap_nom][0])) ;
-            $addr    = $info[$ldap_mail][0] ;
-            array_push($found_mail, $nom) ;
-            array_push($found_mail, $addr) ;
+            $ldap_mail   = $_SESSION['config']['ldap_mail'];
+            $nom         = utf8_decode($info[$ldap_prenom][0]) . " " . strtoupper(utf8_decode($info[$ldap_nom][0]));
+            $addr        = $info[$ldap_mail][0];
+            array_push($found_mail, $nom);
+            array_push($found_mail, $addr);
         }
-    }
-    elseif($_SESSION['config']['where_to_find_user_email']=="dbconges") // recherche du mail du user dans la base db_conges
+    } elseif ($_SESSION['config']['where_to_find_user_email'] == "dbconges") // recherche du mail du user dans la base db_conges
     {
-        $req = 'SELECT u_nom, u_prenom, u_email FROM conges_users WHERE u_login="'.\includes\SQL::quote($login).'" ';
+        $req = 'SELECT u_nom, u_prenom, u_email FROM conges_users WHERE u_login="' . \includes\SQL::quote($login) . '" ';
         $res = \includes\SQL::query($req);
         $rec = $res->fetch_array();
 
-        $sql_nom = $rec["u_nom"];
+        $sql_nom    = $rec["u_nom"];
         $sql_prenom = $rec["u_prenom"];
-        $sql_email = $rec["u_email"];
+        $sql_email  = $rec["u_email"];
 
-        array_push($found_mail, $sql_prenom." ".strtoupper($sql_nom)) ;
-        array_push($found_mail, $sql_email) ;
+        array_push($found_mail, $sql_prenom . " " . strtoupper($sql_nom));
+        array_push($found_mail, $sql_email);
 
+    } else {
+        return false;
     }
-    else
-    {
-        return FALSE;
-    }
-    return $found_mail ;
+    return $found_mail;
 }
-
 
 /**************************************************/
 /* recup des échanges de rtt de chaque jour du mois pour tous les users et stockage dans 1 tableau de tableaux */
 /**************************************************/
-function recup_tableau_rtt_echange($mois, $first_jour, $year,  $tab_logins = false)
+function recup_tableau_rtt_echange($mois, $first_jour, $year, $tab_logins = false)
 {
-    $tab_rtt_echange=array();
+    $tab_rtt_echange = array();
     //tableau indexé dont la clé est la date sous forme yyyy-mm-dd
     //il contient pour chaque clé (chaque jour): un tableau indéxé ($tab_jour_rtt_echange) (clé= login)
     // qui contient lui même un tableau ($tab_echange) contenant les infos des echanges de rtt pour ce
@@ -810,36 +779,35 @@ function recup_tableau_rtt_echange($mois, $first_jour, $year,  $tab_logins = fal
 
     // construction du tableau $tab_rtt_echange:
 
-    $date_deb   = date("Y-m-d", mktime (0,0,0,$mois, $first_jour, $year) );
-    $date_fin   = date("Y-m-d", mktime (0,0,0,$mois + 1 , $first_jour, $year) );
+    $date_deb = date("Y-m-d", mktime(0, 0, 0, $mois, $first_jour, $year));
+    $date_fin = date("Y-m-d", mktime(0, 0, 0, $mois + 1, $first_jour, $year));
 
-    $sql    = 'SELECT e_login, e_absence, e_date_jour FROM conges_echange_rtt WHERE e_date_jour >= "'.\includes\SQL::quote($date_deb).'" AND  e_date_jour < "'.\includes\SQL::quote($date_fin).'"'.($tab_logins !== false ? 'AND e_login IN (\''.implode('\', \'', $tab_logins).'\')' : '' ).';';
+    $sql    = 'SELECT e_login, e_absence, e_date_jour FROM conges_echange_rtt WHERE e_date_jour >= "' . \includes\SQL::quote($date_deb) . '" AND  e_date_jour < "' . \includes\SQL::quote($date_fin) . '"' . ($tab_logins !== false ? 'AND e_login IN (\'' . implode('\', \'', $tab_logins) . '\')' : '') . ';';
     $result = \includes\SQL::query($sql);
-    while($l = $result->fetch_array()) {
-        $tab_echange = array();
-        $tab_echange["val_matin"] = ($l["e_absence"]=='J' || $l["e_absence"]=='M' ? 'Y' : 'N');
-        $tab_echange["val_aprem"] = ($l["e_absence"]=='J' || $l["e_absence"]=='A' ? 'Y' : 'N');
-        $tab_rtt_echange[ $l['e_date_jour'] ][ $l["e_login"] ] = $tab_echange;
+    while ($l = $result->fetch_array()) {
+        $tab_echange                                       = array();
+        $tab_echange["val_matin"]                          = ($l["e_absence"] == 'J' || $l["e_absence"] == 'M' ? 'Y' : 'N');
+        $tab_echange["val_aprem"]                          = ($l["e_absence"] == 'J' || $l["e_absence"] == 'A' ? 'Y' : 'N');
+        $tab_rtt_echange[$l['e_date_jour']][$l["e_login"]] = $tab_echange;
     }
 
     return $tab_rtt_echange;
 }
-
 
 // affiche une liste déroulante des jours du mois : la variable est $new_jour
 function affiche_selection_new_jour($default)
 {
     $return = '';
     $return .= '<select class="form-control" name="new_jour">';
-    for($i=1; $i<10; $i++) {
-        if($default=="0$i") {
+    for ($i = 1; $i < 10; $i++) {
+        if ($default == "0$i") {
             $return .= '<option value="0' . $i . '" selected >0' . $i . '</option>';
         } else {
             $return .= '<option value="0' . $i . '">0' . $i . '</option>';
         }
     }
-    for($i=10; $i<32; $i++) {
-        if($default=="$i") {
+    for ($i = 10; $i < 32; $i++) {
+        if ($default == "$i") {
             $return .= '<option value="' . $i . '" selected >' . $i . '</option>';
         } else {
             $return .= '<option value="' . $i . '">' . $i . '</option>';
@@ -854,16 +822,16 @@ function affiche_selection_new_mois($default)
 {
     $return = '';
     $return .= '<select class="form-control" name="new_mois" >';
-    for($i=1; $i<10; $i++) {
+    for ($i = 1; $i < 10; $i++) {
         $return .= $default . ' : ' . $i . '<br>';
-        if($default=="0$i") {
+        if ($default == "0$i") {
             $return .= '<option value="0' . $i . '" selected >0' . $i . '</option>';
         } else {
             $return .= '<option value="0' . $i . '">0' . $i . '</option>';
         }
     }
-    for($i=10; $i<13; $i++) {
-        if($default=="$i") {
+    for ($i = 10; $i < 13; $i++) {
+        if ($default == "$i") {
             $return .= '<option value="' . $i . '" selected >' . $i . '</option>';
         } else {
             $return .= '<option value="' . $i . '">' . $i . '</option>';
@@ -878,8 +846,8 @@ function affiche_selection_new_year($an_debut, $an_fin, $default)
 {
     $return = '';
     $return .= '<select class="form-control" name="new_year">';
-    for($i=$an_debut; $i<$an_fin+1; $i++) {
-        if($default=="$i") {
+    for ($i = $an_debut; $i < $an_fin + 1; $i++) {
+        if ($default == "$i") {
             $return .= '<option value="' . $i . '" selected >' . $i . '</option>';
         } else {
             $return .= '<option value="' . $i . '">' . $i . '</option>';
@@ -892,20 +860,19 @@ function affiche_selection_new_year($an_debut, $an_fin, $default)
 // met la date aaaa-mm-jj dans le format jj-mm-aaaa
 function eng_date_to_fr($une_date)
 {
- return substr($une_date, 8)."-".substr($une_date, 5, 2)."-".substr($une_date, 0, 4);
+    return substr($une_date, 8) . "-" . substr($une_date, 5, 2) . "-" . substr($une_date, 0, 4);
 
 }
-
 
 // affichage de la cellule correspondant au jour dans les calendrier de saisie (demande de conges, etc ...)
 function affiche_cellule_jour_cal_saisie($login, $j_timestamp, $td_second_class, $result)
 {
-    $date_j=date('Y-m-d', $j_timestamp);
-    $j=date('d', $j_timestamp);
-    $class_am='travail_am';
-    $class_pm='travail_pm';
-    $val_matin='';
-    $val_aprem='';
+    $date_j       = date('Y-m-d', $j_timestamp);
+    $j            = date('d', $j_timestamp);
+    $class_am     = 'travail_am';
+    $class_pm     = 'travail_pm';
+    $val_matin    = '';
+    $val_aprem    = '';
     $planningUser = \utilisateur\Fonctions::getUserPlanning($login);
 
     // recup des infos ARTT ou Temps Partiel :
@@ -913,43 +880,40 @@ function affiche_cellule_jour_cal_saisie($login, $j_timestamp, $td_second_class,
     recup_infos_artt_du_jour($login, $j_timestamp, $val_matin, $val_aprem, $planningUser);
 
     //## AFICHAGE ##
-    if($val_matin=='Y')
-    {
-        $class_am='rtt_am';
+    if ($val_matin == 'Y') {
+        $class_am = 'rtt_am';
     }
-    if($val_aprem=='Y')
-    {
+    if ($val_aprem == 'Y') {
         $class_pm = 'rtt_pm';
     }
 
-
-    $jour_today=date('j');
-    $mois_today=date('m');
-    $year_today=date('Y');
-    $timestamp_today = mktime (0,0,0,$mois_today,$jour_today,$year_today);
+    $jour_today      = date('j');
+    $mois_today      = date('m');
+    $year_today      = date('Y');
+    $timestamp_today = mktime(0, 0, 0, $mois_today, $jour_today, $year_today);
     // si la saisie de conges pour une periode passée est interdite : pas de case à cocher dans les dates avant aujourd'hui
-    if( $_SESSION['config']['interdit_saisie_periode_date_passee']  && $j_timestamp < $timestamp_today )
-        echo '<td  class="cal-saisie '.$td_second_class.' '.$class_am.' '.$class_pm.'">'.$j.'</td>';
-    else
-    {
-        echo '<td  class="cal-saisie '.$td_second_class.' '.$class_am.' '.$class_pm.'">'.$j.'<input type="radio" name="'.$result.'" ';
-        if($_SESSION['config']['rempli_auto_champ_nb_jours_pris'])
-        {
+    if ($_SESSION['config']['interdit_saisie_periode_date_passee'] && $j_timestamp < $timestamp_today) {
+        echo '<td  class="cal-saisie ' . $td_second_class . ' ' . $class_am . ' ' . $class_pm . '">' . $j . '</td>';
+    } else {
+        echo '<td  class="cal-saisie ' . $td_second_class . ' ' . $class_am . ' ' . $class_pm . '">' . $j . '<input type="radio" name="' . $result . '" ';
+        if ($_SESSION['config']['rempli_auto_champ_nb_jours_pris']) {
             // attention : IE6 : bug avec les "OnChange" sur les boutons radio!!! (on remplace par OnClick)
-            if( (isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE')!=FALSE) )
+            if ((isset($_SERVER['HTTP_USER_AGENT'])) && (stristr($_SERVER['HTTP_USER_AGENT'], 'MSIE') != false)) {
                 echo 'onClick="compter_jours();return true;" ';
-            else
+            } else {
                 echo 'onChange="compter_jours();return false;" ';
+            }
+
         }
-        echo ' value="'.$date_j.'"></td>';
+        echo ' value="' . $date_j . '"></td>';
     }
 }
 
 // recup du nom d'un groupe grace à son group_id
 function get_group_name_from_id($groupe_id)
 {
-    $req_name='SELECT g_groupename FROM conges_groupe WHERE g_gid='.\includes\SQL::quote($groupe_id);
-    $ReqLog_name = \includes\SQL::query($req_name);
+    $req_name      = 'SELECT g_groupename FROM conges_groupe WHERE g_gid=' . \includes\SQL::quote($groupe_id);
+    $ReqLog_name   = \includes\SQL::query($req_name);
     $resultat_name = $ReqLog_name->fetch_array();
     return $resultat_name["g_groupename"];
 }
@@ -957,12 +921,11 @@ function get_group_name_from_id($groupe_id)
 // recup du nom d'un groupe grace à son group_id
 function get_groups_name()
 {
-    $sql    = 'SELECT g_gid, g_groupename FROM conges_groupe;';
-    $requete    = \includes\SQL::query($sql);
-    $tab = array();
-    while( $l = $requete->fetch_array() )
-    {
-        $tab[ $l['g_gid'] ] = $l['g_groupename'];
+    $sql     = 'SELECT g_gid, g_groupename FROM conges_groupe;';
+    $requete = \includes\SQL::query($sql);
+    $tab     = array();
+    while ($l = $requete->fetch_array()) {
+        $tab[$l['g_gid']] = $l['g_groupename'];
     }
     return $tab;
 }
@@ -973,65 +936,67 @@ function get_groups_name()
 function get_list_all_users_du_resp($resp_login)
 {
 
-    $list_users="";
-    $sql1="SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' AND u_login!='$resp_login'";
-    $sql1 = $sql1." AND  ( u_resp_login='$resp_login' " ;
-    if($_SESSION['config']['gestion_groupes'] )
-    {
-        $list_users_group=get_list_users_des_groupes_du_resp_sauf_resp($resp_login);
-        if($list_users_group!="")
-            $sql1=$sql1." OR u_login IN ($list_users_group) ";
+    $list_users = "";
+    $sql1       = "SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' AND u_login!='$resp_login'";
+    $sql1       = $sql1 . " AND  ( u_resp_login='$resp_login' ";
+    if ($_SESSION['config']['gestion_groupes']) {
+        $list_users_group = get_list_users_des_groupes_du_resp_sauf_resp($resp_login);
+        if ($list_users_group != "") {
+            $sql1 = $sql1 . " OR u_login IN ($list_users_group) ";
+        }
+
     }
 
-    $sql1=$sql1." ) " ;
-    $sql1 = $sql1." ORDER BY u_login " ;
+    $sql1    = $sql1 . " ) ";
+    $sql1    = $sql1 . " ORDER BY u_login ";
     $ReqLog1 = \includes\SQL::query($sql1);
 
-    while ($resultat1 = $ReqLog1->fetch_array())
-    {
-        $current_login=$resultat1["u_login"];
-        if($list_users=="")
-            $list_users="'$current_login'";
-        else
-            $list_users=$list_users.", '$current_login'";
+    while ($resultat1 = $ReqLog1->fetch_array()) {
+        $current_login = $resultat1["u_login"];
+        if ($list_users == "") {
+            $list_users = "'$current_login'";
+        } else {
+            $list_users = $list_users . ", '$current_login'";
+        }
+
     }
 
     /************************************/
     // gestion des absence des responsables :
     // on recup la liste des users des resp absents, dont $resp_login est responsable
-    if($_SESSION['config']['gestion_cas_absence_responsable'])
-    {
+    if ($_SESSION['config']['gestion_cas_absence_responsable']) {
         // recup liste des resp absents, dont $resp_login est responsable
-        $sql_2='SELECT DISTINCT(u_login) FROM conges_users WHERE u_is_resp=\'Y\' AND u_login!="'.\includes\SQL::quote($resp_login).'" AND u_login!=\'conges\' AND u_login!=\'admin\'';
-        $sql_2 = $sql_2." AND  ( u_resp_login='$resp_login' " ;
+        $sql_2 = 'SELECT DISTINCT(u_login) FROM conges_users WHERE u_is_resp=\'Y\' AND u_login!="' . \includes\SQL::quote($resp_login) . '" AND u_login!=\'conges\' AND u_login!=\'admin\'';
+        $sql_2 = $sql_2 . " AND  ( u_resp_login='$resp_login' ";
 
-        if($_SESSION['config']['gestion_groupes'] )
-        {
-            $list_users_group=get_list_users_des_groupes_du_resp_sauf_resp($resp_login);
-            if($list_users_group!="")
-                $sql_2=$sql_2." OR u_login IN ($list_users_group) ";
+        if ($_SESSION['config']['gestion_groupes']) {
+            $list_users_group = get_list_users_des_groupes_du_resp_sauf_resp($resp_login);
+            if ($list_users_group != "") {
+                $sql_2 = $sql_2 . " OR u_login IN ($list_users_group) ";
+            }
+
         }
 
-        $sql_2=$sql_2." ) " ;
-        $sql_2 = $sql_2." ORDER BY u_login " ;
+        $sql_2 = $sql_2 . " ) ";
+        $sql_2 = $sql_2 . " ORDER BY u_login ";
 
         $ReqLog_2 = \includes\SQL::query($sql_2);
 
         // on va verifier si les resp récupérés sont absents (si oui, c'est $resp_login qui traite leurs users
-        while ($resultat_2 = $ReqLog_2->fetch_array())
-        {
-            $current_resp=$resultat_2["u_login"];
+        while ($resultat_2 = $ReqLog_2->fetch_array()) {
+            $current_resp = $resultat_2["u_login"];
             // verif dans la base si le current_resp est absent :
-            $req = 'SELECT p_num FROM conges_periode WHERE p_login = "'.\includes\SQL::quote($current_resp).'" AND p_etat = \'ok\' AND TO_DAYS(conges_periode.p_date_deb) <= TO_DAYS(NOW()) AND TO_DAYS(conges_periode.p_date_fin) >= TO_DAYS(NOW())';
+            $req      = 'SELECT p_num FROM conges_periode WHERE p_login = "' . \includes\SQL::quote($current_resp) . '" AND p_etat = \'ok\' AND TO_DAYS(conges_periode.p_date_deb) <= TO_DAYS(NOW()) AND TO_DAYS(conges_periode.p_date_fin) >= TO_DAYS(NOW())';
             $ReqLog_3 = \includes\SQL::query($req);
 
             // si le current resp est absent : on recup la liste de ses users pour les traiter .....
-            if ($ReqLog_3->num_rows!=0)
-            {
-                if($list_users=="")
-                    $list_users=get_list_all_users_du_resp($current_resp);
-                else
-                    $list_users=$list_users.", ".get_list_all_users_du_resp($current_resp);
+            if ($ReqLog_3->num_rows != 0) {
+                if ($list_users == "") {
+                    $list_users = get_list_all_users_du_resp($current_resp);
+                } else {
+                    $list_users = $list_users . ", " . get_list_all_users_du_resp($current_resp);
+                }
+
             }
         }
 
@@ -1045,11 +1010,12 @@ function get_list_all_users_du_resp($resp_login)
 // renvoit une liste de login entre quotes et séparés par des virgules
 function get_list_users_du_groupe($group_id)
 {
-    $list_users=array();
-    $sql1='SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid = '.intval($group_id).' ORDER BY gu_login ';
-    $ReqLog1 = \includes\SQL::query($sql1);
-    while ($resultat1 = $ReqLog1->fetch_array())
-        $list_users[] = "'".\includes\SQL::quote($resultat1["gu_login"])."'";
+    $list_users = array();
+    $sql1       = 'SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid = ' . intval($group_id) . ' ORDER BY gu_login ';
+    $ReqLog1    = \includes\SQL::query($sql1);
+    while ($resultat1 = $ReqLog1->fetch_array()) {
+        $list_users[] = "'" . \includes\SQL::quote($resultat1["gu_login"]) . "'";
+    }
 
     $list_users = implode(' , ', $list_users);
     return $list_users;
@@ -1059,19 +1025,19 @@ function get_list_users_du_groupe($group_id)
 // renvoit une liste de group_id séparés par des virgules
 function get_list_groupes_du_resp($resp_login)
 {
-    $list_group="";
-    $sql1='SELECT gr_gid FROM conges_groupe_resp WHERE gr_login="'.\includes\SQL::quote($resp_login).'" ORDER BY gr_gid';
-    $ReqLog1 = \includes\SQL::query($sql1);
+    $list_group = "";
+    $sql1       = 'SELECT gr_gid FROM conges_groupe_resp WHERE gr_login="' . \includes\SQL::quote($resp_login) . '" ORDER BY gr_gid';
+    $ReqLog1    = \includes\SQL::query($sql1);
 
-    if($ReqLog1->num_rows !=0)
-    {
-        while ($resultat1 = $ReqLog1->fetch_array())
-        {
-            $current_group=$resultat1["gr_gid"];
-            if($list_group=="")
-                $list_group="$current_group";
-            else
-                $list_group=$list_group.", $current_group";
+    if ($ReqLog1->num_rows != 0) {
+        while ($resultat1 = $ReqLog1->fetch_array()) {
+            $current_group = $resultat1["gr_gid"];
+            if ($list_group == "") {
+                $list_group = "$current_group";
+            } else {
+                $list_group = $list_group . ", $current_group";
+            }
+
         }
     }
     return $list_group;
@@ -1081,19 +1047,19 @@ function get_list_groupes_du_resp($resp_login)
 // renvoit une liste de group_id séparés par des virgules
 function get_list_groupes_du_grand_resp($resp_login)
 {
-    $list_group="";
-    $sql1='SELECT ggr_gid FROM conges_groupe_grd_resp WHERE ggr_login="'.\includes\SQL::quote($resp_login).'" ORDER BY ggr_gid';
-    $ReqLog1 = \includes\SQL::query($sql1);
+    $list_group = "";
+    $sql1       = 'SELECT ggr_gid FROM conges_groupe_grd_resp WHERE ggr_login="' . \includes\SQL::quote($resp_login) . '" ORDER BY ggr_gid';
+    $ReqLog1    = \includes\SQL::query($sql1);
 
-    if($ReqLog1->num_rows!=0)
-    {
-        while ($resultat1 = $ReqLog1->fetch_array())
-        {
-            $current_group=$resultat1["ggr_gid"];
-            if($list_group=="")
-                $list_group="$current_group";
-            else
-                $list_group=$list_group.", $current_group";
+    if ($ReqLog1->num_rows != 0) {
+        while ($resultat1 = $ReqLog1->fetch_array()) {
+            $current_group = $resultat1["ggr_gid"];
+            if ($list_group == "") {
+                $list_group = "$current_group";
+            } else {
+                $list_group = $list_group . ", $current_group";
+            }
+
         }
     }
     return $list_group;
@@ -1103,13 +1069,14 @@ function get_list_groupes_du_grand_resp($resp_login)
 function get_list_login_du_grand_resp($resp_login)
 {
     $list_logins = array();
-    $sql1='SELECT gu_login FROM conges_groupe_grd_resp JOIN conges_groupe_users ON ggr_gid = gu_gid WHERE ggr_login="'.\includes\SQL::quote($resp_login).'";';
-    $ReqLog1 = \includes\SQL::query($sql1);
+    $sql1        = 'SELECT gu_login FROM conges_groupe_grd_resp JOIN conges_groupe_users ON ggr_gid = gu_gid WHERE ggr_login="' . \includes\SQL::quote($resp_login) . '";';
+    $ReqLog1     = \includes\SQL::query($sql1);
 
-    if($ReqLog1->num_rows!=0)
-    {
-        while ($resultat1 = $ReqLog1->fetch_array())
-                $list_logins[] = $resultat1["gu_login"];
+    if ($ReqLog1->num_rows != 0) {
+        while ($resultat1 = $ReqLog1->fetch_array()) {
+            $list_logins[] = $resultat1["gu_login"];
+        }
+
     }
     return $list_logins;
 }
@@ -1118,17 +1085,18 @@ function get_list_login_du_grand_resp($resp_login)
 // renvoit une liste de gid séparés par des virgules
 function get_list_groupes_double_valid()
 {
-    $list_groupes_double_valid="";
-    $sql1="SELECT g_gid FROM conges_groupe WHERE g_double_valid='Y' ORDER BY g_gid ";
-    $ReqLog1 = \includes\SQL::query($sql1);
+    $list_groupes_double_valid = "";
+    $sql1                      = "SELECT g_gid FROM conges_groupe WHERE g_double_valid='Y' ORDER BY g_gid ";
+    $ReqLog1                   = \includes\SQL::query($sql1);
 
-    while ($resultat1 = $ReqLog1->fetch_array())
-    {
-        $current_gid=$resultat1["g_gid"];
-        if($list_groupes_double_valid=="")
-            $list_groupes_double_valid="$current_gid";
-        else
-            $list_groupes_double_valid=$list_groupes_double_valid.", $current_gid";
+    while ($resultat1 = $ReqLog1->fetch_array()) {
+        $current_gid = $resultat1["g_gid"];
+        if ($list_groupes_double_valid == "") {
+            $list_groupes_double_valid = "$current_gid";
+        } else {
+            $list_groupes_double_valid = $list_groupes_double_valid . ", $current_gid";
+        }
+
     }
     return $list_groupes_double_valid;
 
@@ -1138,21 +1106,22 @@ function get_list_groupes_double_valid()
 // renvoit une liste de gid séparés par des virgules
 function get_list_groupes_double_valid_du_resp($resp_login)
 {
-    $list_groupes_double_valid_du_resp="";
-    $list_groups=get_list_groupes_du_resp($resp_login);
+    $list_groupes_double_valid_du_resp = "";
+    $list_groups                       = get_list_groupes_du_resp($resp_login);
 
-    if($list_groups!="") // si $resp_login est responsable d'au moins un groupe
+    if ($list_groups != "") // si $resp_login est responsable d'au moins un groupe
     {
-        $sql1='SELECT DISTINCT(g_gid) FROM conges_groupe WHERE g_double_valid=\'Y\' AND g_gid IN ('.\includes\SQL::quote($list_groups).') ORDER BY g_gid ';
+        $sql1    = 'SELECT DISTINCT(g_gid) FROM conges_groupe WHERE g_double_valid=\'Y\' AND g_gid IN (' . \includes\SQL::quote($list_groups) . ') ORDER BY g_gid ';
         $ReqLog1 = \includes\SQL::query($sql1);
 
-        while ($resultat1 = $ReqLog1->fetch_array())
-        {
-            $current_gid=$resultat1["g_gid"];
-            if($list_groupes_double_valid_du_resp=="")
-                $list_groupes_double_valid_du_resp="$current_gid";
-            else
-                $list_groupes_double_valid_du_resp=$list_groupes_double_valid_du_resp.", $current_gid";
+        while ($resultat1 = $ReqLog1->fetch_array()) {
+            $current_gid = $resultat1["g_gid"];
+            if ($list_groupes_double_valid_du_resp == "") {
+                $list_groupes_double_valid_du_resp = "$current_gid";
+            } else {
+                $list_groupes_double_valid_du_resp = $list_groupes_double_valid_du_resp . ", $current_gid";
+            }
+
         }
     }
     return $list_groupes_double_valid_du_resp;
@@ -1164,18 +1133,19 @@ function get_list_groupes_double_valid_du_resp($resp_login)
 function get_list_groupes_double_valid_du_grand_resp($resp_login)
 {
 
-    $list_groupes_double_valid_du_grand_resp="";
+    $list_groupes_double_valid_du_grand_resp = "";
 
-    $sql1='SELECT DISTINCT(ggr_gid) FROM conges_groupe_grd_resp WHERE ggr_login="'.\includes\SQL::quote($resp_login).'" ORDER BY ggr_gid ';
+    $sql1    = 'SELECT DISTINCT(ggr_gid) FROM conges_groupe_grd_resp WHERE ggr_login="' . \includes\SQL::quote($resp_login) . '" ORDER BY ggr_gid ';
     $ReqLog1 = \includes\SQL::query($sql1);
 
-    while ($resultat1 = $ReqLog1->fetch_array())
-    {
-        $current_gid=$resultat1["ggr_gid"];
-        if($list_groupes_double_valid_du_grand_resp=="")
-            $list_groupes_double_valid_du_grand_resp="$current_gid";
-        else
-            $list_groupes_double_valid_du_grand_resp=$list_groupes_double_valid_du_grand_resp.", $current_gid";
+    while ($resultat1 = $ReqLog1->fetch_array()) {
+        $current_gid = $resultat1["ggr_gid"];
+        if ($list_groupes_double_valid_du_grand_resp == "") {
+            $list_groupes_double_valid_du_grand_resp = "$current_gid";
+        } else {
+            $list_groupes_double_valid_du_grand_resp = $list_groupes_double_valid_du_grand_resp . ", $current_gid";
+        }
+
     }
     return $list_groupes_double_valid_du_grand_resp;
 }
@@ -1184,15 +1154,17 @@ function get_list_groupes_double_valid_du_grand_resp($resp_login)
 // renvoit une liste de login entre quotes et séparés par des virgules
 function get_list_users_des_groupes_du_user($user_login)
 {
-    $list_users=array();
-    $list_groups=get_list_groupes_du_user($user_login);
-    if($list_groups!="") // si $user_login est membre d'au moins un groupe
+    $list_users  = array();
+    $list_groups = get_list_groupes_du_user($user_login);
+    if ($list_groups != "") // si $user_login est membre d'au moins un groupe
     {
-        $sql1='SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid IN ('.$list_groups.') ORDER BY gu_login ';
+        $sql1    = 'SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid IN (' . $list_groups . ') ORDER BY gu_login ';
         $ReqLog1 = \includes\SQL::query($sql1);
 
-        while ($resultat1 = $ReqLog1->fetch_array())
-            $list_users[] = '"'.\includes\SQL::quote($resultat1["gu_login"]).'"';
+        while ($resultat1 = $ReqLog1->fetch_array()) {
+            $list_users[] = '"' . \includes\SQL::quote($resultat1["gu_login"]) . '"';
+        }
+
     }
     $list_users = implode(' , ', $list_users);
     return $list_users;
@@ -1202,12 +1174,14 @@ function get_list_users_des_groupes_du_user($user_login)
 // renvoit une liste de group_id séparés par des virgules
 function get_list_groupes_du_user($user_login)
 {
-    $list_group=array();
-    $sql1='SELECT gu_gid FROM conges_groupe_users WHERE gu_login="'.\includes\SQL::quote($user_login).'" ORDER BY gu_gid';
-    $ReqLog1 = \includes\SQL::query($sql1);
+    $list_group = array();
+    $sql1       = 'SELECT gu_gid FROM conges_groupe_users WHERE gu_login="' . \includes\SQL::quote($user_login) . '" ORDER BY gu_gid';
+    $ReqLog1    = \includes\SQL::query($sql1);
 
-    while ($resultat1 = $ReqLog1->fetch_array())
+    while ($resultat1 = $ReqLog1->fetch_array()) {
         $list_group[] = $resultat1["gu_gid"];
+    }
+
     $list_group = implode(' , ', $list_group);
     return $list_group;
 }
@@ -1216,21 +1190,21 @@ function get_list_groupes_du_user($user_login)
 // renvoit une liste de login entre quotes et séparés par des virgules
 function get_list_all_users()
 {
-    $list_users="";
-    $sql1="SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_login " ;
-    $ReqLog1 = \includes\SQL::query($sql1);
+    $list_users = "";
+    $sql1       = "SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_login ";
+    $ReqLog1    = \includes\SQL::query($sql1);
 
-    while ($resultat1 = $ReqLog1->fetch_array())
-    {
-        $current_login=$resultat1["u_login"];
-        if($list_users=="")
-            $list_users="'$current_login'";
-        else
-            $list_users=$list_users.", '$current_login'";
+    while ($resultat1 = $ReqLog1->fetch_array()) {
+        $current_login = $resultat1["u_login"];
+        if ($list_users == "") {
+            $list_users = "'$current_login'";
+        } else {
+            $list_users = $list_users . ", '$current_login'";
+        }
+
     }
     return $list_users;
 }
-
 
 // recup de la liste des groupes (tous)
 // renvoit une liste de group_id séparés par des virgules
@@ -1239,47 +1213,46 @@ function get_list_all_groupes()
     $list_group = array();
 
     // on select dans conges_groupe_users pour ne récupérer QUE les groupes qui ont des users !!
-    $sql1="SELECT DISTINCT(gu_gid) FROM conges_groupe_users ORDER BY gu_gid";
+    $sql1    = "SELECT DISTINCT(gu_gid) FROM conges_groupe_users ORDER BY gu_gid";
     $ReqLog1 = \includes\SQL::query($sql1);
 
-    while ($resultat1 = $ReqLog1->fetch_array())
+    while ($resultat1 = $ReqLog1->fetch_array()) {
         $list_group[] = $resultat1["gu_gid"];
+    }
 
-    return implode(',',$list_group);
+    return implode(',', $list_group);
 }
-
 
 // construit le tableau des responsables d'un user
 // le login du user est passé en paramêtre ainsi que le tableau (vide) des resp
 //renvoit un tableau indexé de resp_login => "absent" ou "present"
 function get_tab_resp_du_user($user_login)
 {
-    $tab_resp=array();
+    $tab_resp = array();
     // recup du resp indiqué dans la table users (sauf s'il est resp de lui meme)
-    $req = 'SELECT u_resp_login FROM conges_users WHERE u_login=\''.\includes\SQL::quote($user_login).'\';';
+    $req = 'SELECT u_resp_login FROM conges_users WHERE u_login=\'' . \includes\SQL::quote($user_login) . '\';';
     $res = \includes\SQL::query($req);
     $rec = $res->fetch_array();
-    if ($rec['u_resp_login'] !== NULL)
-        $tab_resp[$rec['u_resp_login']]="present";
+    if ($rec['u_resp_login'] !== null) {
+        $tab_resp[$rec['u_resp_login']] = "present";
+    }
 
     // recup des resp des groupes du user
-    if($_SESSION['config']['gestion_groupes'])
-    {
-        $list_groups=get_list_groupes_du_user($user_login);
-        if($list_groups!="")
-        {
-            $tab_gid=explode(",", $list_groups);
-            foreach($tab_gid as $gid)
-            {
-                $gid=trim($gid);
-                $sql2='SELECT gr_login FROM conges_groupe_resp WHERE gr_gid=' . \includes\SQL::quote($gid) . ' AND gr_login!=\'' . \includes\SQL::quote($user_login) . '\'';
+    if ($_SESSION['config']['gestion_groupes']) {
+        $list_groups = get_list_groupes_du_user($user_login);
+        if ($list_groups != "") {
+            $tab_gid = explode(",", $list_groups);
+            foreach ($tab_gid as $gid) {
+                $gid     = trim($gid);
+                $sql2    = 'SELECT gr_login FROM conges_groupe_resp WHERE gr_gid=' . \includes\SQL::quote($gid) . ' AND gr_login!=\'' . \includes\SQL::quote($user_login) . '\'';
                 $ReqLog1 = \includes\SQL::query($sql2);
 
-                while ($resultat1 = $ReqLog1->fetch_array())
-                {
+                while ($resultat1 = $ReqLog1->fetch_array()) {
                     //attention à ne pas mettre 2 fois le meme resp dans le tableau
-                    if (in_array($resultat1["gr_login"], $tab_resp)==FALSE)
-                        $tab_resp[$resultat1["gr_login"]]="present";
+                    if (in_array($resultat1["gr_login"], $tab_resp) == false) {
+                        $tab_resp[$resultat1["gr_login"]] = "present";
+                    }
+
                 }
             }
         }
@@ -1288,38 +1261,35 @@ function get_tab_resp_du_user($user_login)
     /************************************/
     // gestion des absence des responsables :
     // on verifie que les resp sont présents, si tous absent, on cherhe les resp des resp, et ainsi de suite ....
-    if($_SESSION['config']['gestion_cas_absence_responsable'])
-    {
+    if ($_SESSION['config']['gestion_cas_absence_responsable']) {
         // on va verifier si les resp récupérés sont absents
-        $nb_present=count($tab_resp);
-        foreach ($tab_resp as $current_resp => $presence )
-        {
+        $nb_present = count($tab_resp);
+        foreach ($tab_resp as $current_resp => $presence) {
             // verif dans la base si le current_resp est absent :
             $req = 'SELECT p_num
                      FROM conges_periode
-                     WHERE p_login =\''.\includes\SQL::quote($current_resp).'\'
+                     WHERE p_login =\'' . \includes\SQL::quote($current_resp) . '\'
                      AND p_etat = \'ok\'
                      AND TO_DAYS(conges_periode.p_date_deb) <= TO_DAYS(NOW())
                      AND TO_DAYS(conges_periode.p_date_fin) >= TO_DAYS(NOW())';
             $ReqLog_3 = \includes\SQL::query($req);
-            if($ReqLog_3->num_rows!=0)
-            {
-                $nb_present=$nb_present-1;
-                $tab_resp[$current_resp]="absent";
+            if ($ReqLog_3->num_rows != 0) {
+                $nb_present              = $nb_present - 1;
+                $tab_resp[$current_resp] = "absent";
             }
         }
 
         //si aucun resp present on recupere les resp du resp
-        if($nb_present==0)
-        {
-            $new_tab_resp=array();
-            foreach ($tab_resp as $current_resp => $presence)
-            {
+        if ($nb_present == 0) {
+            $new_tab_resp = array();
+            foreach ($tab_resp as $current_resp => $presence) {
                 // attention ,on evite le cas ou le user est son propre resp (sinon on boucle infiniment)
-                if($current_resp != $user_login)
-                    $new_tab_resp = array_merge  ( $new_tab_resp , get_tab_resp_du_user($current_resp));
+                if ($current_resp != $user_login) {
+                    $new_tab_resp = array_merge($new_tab_resp, get_tab_resp_du_user($current_resp));
+                }
+
             }
-            $tab_resp = array_merge  ( $tab_resp, $new_tab_resp);
+            $tab_resp = array_merge($tab_resp, $new_tab_resp);
         }
     }
     // FIN gestion des absence des responsables :
@@ -1328,58 +1298,53 @@ function get_tab_resp_du_user($user_login)
     return $tab_resp;
 }
 
-
 // construit le tableau des grands responsables d'un user
 // (tab des grd resp des groupes à double_valid dont le user fait partie
 // le login du user est passé en paramêtre ainsi que le tableau (vide) des resp
 function get_tab_grd_resp_du_user($user_login, &$tab_grd_resp)
 {
     // recup des resp des groupes du user
-    if($_SESSION['config']['gestion_groupes'])
-    {
-        $list_groups=get_list_groupes_du_user($user_login);
-        if($list_groups!="")
-        {
-            $tab_gid=explode(",", $list_groups);
-            foreach($tab_gid as $gid)
-            {
-                $gid=trim($gid);
-                $sql1='SELECT ggr_login FROM conges_groupe_grd_resp WHERE ggr_gid='.\includes\SQL::quote($gid);
+    if ($_SESSION['config']['gestion_groupes']) {
+        $list_groups = get_list_groupes_du_user($user_login);
+        if ($list_groups != "") {
+            $tab_gid = explode(",", $list_groups);
+            foreach ($tab_gid as $gid) {
+                $gid     = trim($gid);
+                $sql1    = 'SELECT ggr_login FROM conges_groupe_grd_resp WHERE ggr_gid=' . \includes\SQL::quote($gid);
                 $ReqLog1 = \includes\SQL::query($sql1);
 
-                while ($resultat1 = $ReqLog1->fetch_array())
-                {
+                while ($resultat1 = $ReqLog1->fetch_array()) {
                     //attention à ne pas mettre 2 fois le meme resp dans le tableau
-                    if (in_array($resultat1["ggr_login"], $tab_grd_resp)==FALSE)
-                        $tab_grd_resp[]=$resultat1["ggr_login"];
+                    if (in_array($resultat1["ggr_login"], $tab_grd_resp) == false) {
+                        $tab_grd_resp[] = $resultat1["ggr_login"];
+                    }
+
                 }
             }
         }
     }
 }
 
-
 function valid_ldap_user($username)
 {
 /* fonction utilisée avec le mode d'authentification ldap.
-   En effet, si un utilisateur (enregistré dans le ldap) tente de se
+En effet, si un utilisateur (enregistré dans le ldap) tente de se
 connecter alors qu'il n'a pas de compte dans
-   la base, il n'y a aucun message qui lui indique !
+la base, il n'y a aucun message qui lui indique !
 
-   Retourne TRUE, si tout est ok... ($username dans la table conges_users)
-   False, sinon
+Retourne TRUE, si tout est ok... ($username dans la table conges_users)
+False, sinon
 
-*/
+ */
     // connexion MySQL + selection de la database sur le serveur
 
-    $req = 'SELECT COUNT(*) FROM conges_users WHERE u_login="'.\includes\SQL::quote($username).'";';
+    $req = 'SELECT COUNT(*) FROM conges_users WHERE u_login="' . \includes\SQL::quote($username) . '";';
     $res = \includes\SQL::query($req);
     $cpt = $res->fetch_array();
     $cpt = $cpt[0];
 
-    return ( $cpt != 0 );
+    return ($cpt != 0);
 }
-
 
 /**
  * verifie si un user est responsable ou pas
@@ -1406,16 +1371,15 @@ function is_hr($login)
 function is_active($login)
 {
     static $sql_is_active = array();
-    if (!isset($sql_is_active[$login]))
-    {
+    if (!isset($sql_is_active[$login])) {
         // recup de qq infos sur le user
-        $select_info='SELECT u_is_active FROM conges_users WHERE u_login="'.\includes\SQL::quote($login).'";';
-        $ReqLog_info = \includes\SQL::query($select_info);
-        $resultat_info = $ReqLog_info->fetch_array();
-        $sql_is_active[$login]=$resultat_info["u_is_active"];
+        $select_info           = 'SELECT u_is_active FROM conges_users WHERE u_login="' . \includes\SQL::quote($login) . '";';
+        $ReqLog_info           = \includes\SQL::query($select_info);
+        $resultat_info         = $ReqLog_info->fetch_array();
+        $sql_is_active[$login] = $resultat_info["u_is_active"];
     }
 
-    return ($sql_is_active[$login]=='Y');
+    return ($sql_is_active[$login] == 'Y');
 }
 
 // verifie si un user est responsable d'un second user
@@ -1425,27 +1389,24 @@ function is_resp_of_user($resp_login, $user_login)
     return is_resp_direct_of_user($resp_login, $user_login) || is_resp_group_of_user($resp_login, $user_login) || is_gr_group_of_user($resp_login, $user_login);
 }
 
-
 function is_resp_direct_of_user($resp_login, $user_login)
 {
 
-    $select_info='SELECT u_resp_login FROM conges_users WHERE u_login=\''.\includes\SQL::quote($user_login).'\';';
-    $ReqLog_info = \includes\SQL::query($select_info);
-    $resultat_info = $ReqLog_info->fetch_array();
-    $sql_resp_login=$resultat_info["u_resp_login"];
-    return ($resp_login==$sql_resp_login);
+    $select_info    = 'SELECT u_resp_login FROM conges_users WHERE u_login=\'' . \includes\SQL::quote($user_login) . '\';';
+    $ReqLog_info    = \includes\SQL::query($select_info);
+    $resultat_info  = $ReqLog_info->fetch_array();
+    $sql_resp_login = $resultat_info["u_resp_login"];
+    return ($resp_login == $sql_resp_login);
 }
-
 
 function is_resp_group_of_user($resp_login, $user_login)
 {
-    if ( $_SESSION['config']['gestion_groupes'] )
-    {
+    if ($_SESSION['config']['gestion_groupes']) {
         $ReqLog_info = \includes\SQL::query('SELECT count(*)
                 FROM `conges_groupe_users`
                 JOIN conges_groupe_resp ON gr_gid = gu_gid
-                WHERE gu_login = \''.\includes\SQL::quote($user_login).'\'
-                AND gr_login = \''.\includes\SQL::quote($resp_login).'\';');
+                WHERE gu_login = \'' . \includes\SQL::quote($user_login) . '\'
+                AND gr_login = \'' . \includes\SQL::quote($resp_login) . '\';');
         $resultat_info = $ReqLog_info->fetch_array();
         return ($resultat_info[0] != 0);
     }
@@ -1454,14 +1415,13 @@ function is_resp_group_of_user($resp_login, $user_login)
 
 function is_gr_group_of_user($resp_login, $user_login)
 {
-    if ( $_SESSION['config']['gestion_groupes'] && $_SESSION['config']['double_validation_conges'])
-    {
+    if ($_SESSION['config']['gestion_groupes'] && $_SESSION['config']['double_validation_conges']) {
 
         $ReqLog_info = \includes\SQL::query('SELECT count(*)
                 FROM `conges_groupe_users`
                 JOIN conges_groupe_grd_resp ON ggr_gid = gu_gid
-                WHERE gu_login = \''.\includes\SQL::quote($user_login).'\'
-                AND ggr_login = \''.\includes\SQL::quote($resp_login).'\';');
+                WHERE gu_login = \'' . \includes\SQL::quote($user_login) . '\'
+                AND ggr_login = \'' . \includes\SQL::quote($resp_login) . '\';');
         $resultat_info = $ReqLog_info->fetch_array();
         return ($resultat_info[0] != 0);
     }
@@ -1483,54 +1443,58 @@ function is_admin($login)
 function insert_dans_periode($login, $date_deb, $demi_jour_deb, $date_fin, $demi_jour_fin, $nb_jours, $commentaire, $id_type_abs, $etat, $id_fermeture)
 {
     // Récupération du + grand p_num (+ grand numero identifiant de conges)
-    $sql1 = "SELECT max(p_num) FROM conges_periode" ;
+    $sql1    = "SELECT max(p_num) FROM conges_periode";
     $ReqLog1 = \includes\SQL::query($sql1);
-    if ( $num_new_demande = $ReqLog1->fetch_row() )
-        $num_new_demande = $num_new_demande[0] +1;
-    else
+    if ($num_new_demande = $ReqLog1->fetch_row()) {
+        $num_new_demande = $num_new_demande[0] + 1;
+    } else {
         $num_new_demande = 1;
+    }
 
-    $sql2 = "INSERT INTO conges_periode SET p_login='$login',p_date_deb='$date_deb', p_demi_jour_deb='$demi_jour_deb',p_date_fin='$date_fin', p_demi_jour_fin='$demi_jour_fin', p_nb_jours='$nb_jours', p_commentaire='".\includes\SQL::quote($commentaire)."', p_type='$id_type_abs', p_etat='$etat', ";
+    $sql2 = "INSERT INTO conges_periode SET p_login='$login',p_date_deb='$date_deb', p_demi_jour_deb='$demi_jour_deb',p_date_fin='$date_fin', p_demi_jour_fin='$demi_jour_fin', p_nb_jours='$nb_jours', p_commentaire='" . \includes\SQL::quote($commentaire) . "', p_type='$id_type_abs', p_etat='$etat', ";
 
-    if($id_fermeture!=0)
-        $sql2 = $sql2." p_fermeture_id='$id_fermeture' ," ;
-    if($etat=="demande")
-        $sql2 = $sql2." p_date_demande=NOW() ," ;
-    else
-        $sql2 = $sql2." p_date_traitement=NOW() ," ;
+    if ($id_fermeture != 0) {
+        $sql2 = $sql2 . " p_fermeture_id='$id_fermeture' ,";
+    }
 
-    $sql2 = $sql2." p_num='$num_new_demande' " ;
+    if ($etat == "demande") {
+        $sql2 = $sql2 . " p_date_demande=NOW() ,";
+    } else {
+        $sql2 = $sql2 . " p_date_traitement=NOW() ,";
+    }
+
+    $sql2   = $sql2 . " p_num='$num_new_demande' ";
     $result = \includes\SQL::query($sql2);
 
-    if($id_fermeture!=0)
+    if ($id_fermeture != 0) {
         $comment_log = "saisie de fermeture num $num_new_demande (type $id_type_abs) pour $login ($nb_jours jours) (de $date_deb $demi_jour_deb à $date_fin $demi_jour_fin)";
-    elseif($etat=="demande")
+    } elseif ($etat == "demande") {
         $comment_log = "demande de conges num $num_new_demande (type $id_type_abs) pour $login ($nb_jours jours) (de $date_deb $demi_jour_deb à $date_fin $demi_jour_fin)";
-    else
+    } else {
         $comment_log = "saisie de conges num $num_new_demande (type $id_type_abs) pour $login ($nb_jours jours) (de $date_deb $demi_jour_deb à $date_fin $demi_jour_fin)";
+    }
 
     log_action($num_new_demande, $etat, $login, $comment_log);
 
-    if($result)
+    if ($result) {
         return $num_new_demande;
-    else
+    } else {
         return 0;
-}
+    }
 
+}
 
 // remplit le tableau global des jours feries a partir de la database
 function init_tab_jours_feries()
 {
-    if (empty($_SESSION['tab_j_feries']))
-    {
-        $_SESSION['tab_j_feries']=array();
+    if (empty($_SESSION['tab_j_feries'])) {
+        $_SESSION['tab_j_feries'] = array();
 
-        $sql_select='SELECT jf_date FROM conges_jours_feries;';
+        $sql_select = 'SELECT jf_date FROM conges_jours_feries;';
         $res_select = \includes\SQL::query($sql_select);
 
-        while( $row = $res_select->fetch_array())
-        {
-            $_SESSION['tab_j_feries'][]=$row['jf_date'];
+        while ($row = $res_select->fetch_array()) {
+            $_SESSION['tab_j_feries'][] = $row['jf_date'];
         }
     }
 }
@@ -1538,184 +1502,233 @@ function init_tab_jours_feries()
 // renvoit TRUE si le jour est chomé (férié), sinon FALSE (verifie dans le tableau global $_SESSION["tab_j_feries"]
 function est_chome($timestamp)
 {
-    $j_date=date("Y-m-d", $timestamp);
-    if(isset($_SESSION["tab_j_feries"]))
+    $j_date = date("Y-m-d", $timestamp);
+    if (isset($_SESSION["tab_j_feries"])) {
         return in_array($j_date, $_SESSION["tab_j_feries"]);
-    else
-        return FALSE;
+    } else {
+        return false;
+    }
+
 }
 
 // initialise le tableau des variables de config (renvoit un tableau)
 function init_config_tab()
 {
     static $userlogin = null;
-    static $result = null;
-    if ($result === null || $userlogin != $_SESSION['userlogin'])
-    {
+    static $result    = null;
+    if ($result === null || $userlogin != $_SESSION['userlogin']) {
 
-        include ROOT_PATH .'version.php';
-        include_once CONFIG_PATH .'dbconnect.php';
+        include ROOT_PATH . 'version.php';
+        include_once CONFIG_PATH . 'dbconnect.php';
         $tab = array();
-
 
         /******************************************/
         //  recup des variables de version.php
-        if(isset($config_php_conges_version)) $tab['php_conges_version'] = $config_php_conges_version ;
-        if(isset($config_url_site_web_php_conges)) $tab['url_site_web_php_conges'] = $config_url_site_web_php_conges ;
+        if (isset($config_php_conges_version)) {
+            $tab['php_conges_version'] = $config_php_conges_version;
+        }
+
+        if (isset($config_url_site_web_php_conges)) {
+            $tab['url_site_web_php_conges'] = $config_url_site_web_php_conges;
+        }
 
         /******************************************/
         //  recup des variables de la table conges_appli
         $sql_appli = "SELECT appli_variable, appli_valeur FROM conges_appli;";
-        $req_appli = \includes\SQL::query($sql_appli) ;
+        $req_appli = \includes\SQL::query($sql_appli);
 
-        while ($data_appli = $req_appli->fetch_array())
-        {
-            $key    = $data_appli[0];
-            $value    = $data_appli[1];
-            $tab[$key]    = $value;
+        while ($data_appli = $req_appli->fetch_array()) {
+            $key       = $data_appli[0];
+            $value     = $data_appli[1];
+            $tab[$key] = $value;
         }
 
         /******************************************/
         //  recup des variables de la table conges_config
 
         $sql_config = "SELECT conf_nom, conf_valeur, conf_type FROM conges_config;";
-        $req_config = \includes\SQL::query($sql_config) ;
+        $req_config = \includes\SQL::query($sql_config);
 
-        while ($data = $req_config->fetch_array())
-        {
-            $key    = $data[0];
-            $value    = $data[1];
-            $type    = $data[2];
+        while ($data = $req_config->fetch_array()) {
+            $key   = $data[0];
+            $value = $data[1];
+            $type  = $data[2];
 
-            if($value == "FALSE")
+            if ($value == "FALSE") {
                 $value = false;
-            elseif($value == "TRUE")
+            } elseif ($value == "TRUE") {
                 $value = true;
-            elseif($type == "path")
-                $value =  ROOT_PATH ."/".$value ;
+            } elseif ($type == "path") {
+                $value = ROOT_PATH . "/" . $value;
+            }
 
             $tab[$key] = $value;
         }
 
-
         /******************************************/
         //  recup des mails dans  la table conges_mail
         $sql_mail = "SELECT mail_nom, mail_subject, mail_body FROM conges_mail;";
-        $req_mail = \includes\SQL::query($sql_mail) ;
+        $req_mail = \includes\SQL::query($sql_mail);
 
-        while ($data_mail = $req_mail->fetch_array())
-        {
-            $mail_nom    = $data_mail[0];
-            $key1    = $mail_nom."_sujet";
-            $key2    = $mail_nom."_contenu";
-            $sujet    = $data_mail[1];
-            $corps    = $data_mail[2];
-            $tab[$key1] = $sujet ;
-            $tab[$key2] = $corps ;
+        while ($data_mail = $req_mail->fetch_array()) {
+            $mail_nom   = $data_mail[0];
+            $key1       = $mail_nom . "_sujet";
+            $key2       = $mail_nom . "_contenu";
+            $sujet      = $data_mail[1];
+            $corps      = $data_mail[2];
+            $tab[$key1] = $sujet;
+            $tab[$key2] = $corps;
         }
 
         /******************************************/
         //  config_ldap.php
-        if (file_exists(CONFIG_PATH .'config_ldap.php'))
-        {
-            include CONFIG_PATH .'config_ldap.php';
-            if(isset($config_ldap_protocol_version))
-                $tab['ldap_protocol_version'] = $config_ldap_protocol_version ;
-            else
+        if (file_exists(CONFIG_PATH . 'config_ldap.php')) {
+            include CONFIG_PATH . 'config_ldap.php';
+            if (isset($config_ldap_protocol_version)) {
+                $tab['ldap_protocol_version'] = $config_ldap_protocol_version;
+            } else {
                 $tab['ldap_protocol_version'] = 0;
+            }
 
-            if(isset($config_ldap_server))    $tab['ldap_server']    = $config_ldap_server ;
-            if(isset($config_ldap_bupsvr))    $tab['ldap_bupsvr']    = $config_ldap_bupsvr ;
-            if(isset($config_basedn))    $tab['basedn']        = $config_basedn ;
-            if(isset($config_ldap_user))    $tab['ldap_user']    = $config_ldap_user ;
-            if(isset($config_ldap_pass))    $tab['ldap_pass']    = $config_ldap_pass ;
-            if(isset($config_searchdn))    $tab['searchdn']    = $config_searchdn ;
-            if(isset($config_ldap_prenom))    $tab['ldap_prenom']    = $config_ldap_prenom ;
-            if(isset($config_ldap_nom))    $tab['ldap_nom']    = $config_ldap_nom ;
-            if(isset($config_ldap_mail))    $tab['ldap_mail']    = $config_ldap_mail ;
-            if(isset($config_ldap_login))    $tab['ldap_login']    = $config_ldap_login ;
-            if(isset($config_ldap_nomaff))    $tab['ldap_nomaff']    = $config_ldap_nomaff ;
-            if(isset($config_ldap_filtre))    $tab['ldap_filtre']    = $config_ldap_filtre ;
-            if(isset($config_ldap_filrech))    $tab['ldap_filrech']    = $config_ldap_filrech ;
-            if(isset($config_ldap_filtre_complet)) $tab['ldap_filtre_complet']  = $config_ldap_filtre_complet ;
+            if (isset($config_ldap_server)) {
+                $tab['ldap_server'] = $config_ldap_server;
+            }
+
+            if (isset($config_ldap_bupsvr)) {
+                $tab['ldap_bupsvr'] = $config_ldap_bupsvr;
+            }
+
+            if (isset($config_basedn)) {
+                $tab['basedn'] = $config_basedn;
+            }
+
+            if (isset($config_ldap_user)) {
+                $tab['ldap_user'] = $config_ldap_user;
+            }
+
+            if (isset($config_ldap_pass)) {
+                $tab['ldap_pass'] = $config_ldap_pass;
+            }
+
+            if (isset($config_searchdn)) {
+                $tab['searchdn'] = $config_searchdn;
+            }
+
+            if (isset($config_ldap_prenom)) {
+                $tab['ldap_prenom'] = $config_ldap_prenom;
+            }
+
+            if (isset($config_ldap_nom)) {
+                $tab['ldap_nom'] = $config_ldap_nom;
+            }
+
+            if (isset($config_ldap_mail)) {
+                $tab['ldap_mail'] = $config_ldap_mail;
+            }
+
+            if (isset($config_ldap_login)) {
+                $tab['ldap_login'] = $config_ldap_login;
+            }
+
+            if (isset($config_ldap_nomaff)) {
+                $tab['ldap_nomaff'] = $config_ldap_nomaff;
+            }
+
+            if (isset($config_ldap_filtre)) {
+                $tab['ldap_filtre'] = $config_ldap_filtre;
+            }
+
+            if (isset($config_ldap_filrech)) {
+                $tab['ldap_filrech'] = $config_ldap_filrech;
+            }
+
+            if (isset($config_ldap_filtre_complet)) {
+                $tab['ldap_filtre_complet'] = $config_ldap_filtre_complet;
+            }
+
         }
 
         /******************************************/
         //  config_CAS.php
-        if (file_exists(CONFIG_PATH .'config_CAS.php'))
-        {
-            include CONFIG_PATH .'config_CAS.php';
-            if(isset($config_CAS_host))    $tab['CAS_host']    = $config_CAS_host ;
-            if(isset($config_CAS_portNumber)) $tab['CAS_portNumber'] = $config_CAS_portNumber ;
-            if(isset($config_CAS_URI))    $tab['CAS_URI']        = $config_CAS_URI ;
-            if(isset($config_CAS_CACERT))    $tab['CAS_CACERT']        = $config_CAS_CACERT ;
+        if (file_exists(CONFIG_PATH . 'config_CAS.php')) {
+            include CONFIG_PATH . 'config_CAS.php';
+            if (isset($config_CAS_host)) {
+                $tab['CAS_host'] = $config_CAS_host;
+            }
+
+            if (isset($config_CAS_portNumber)) {
+                $tab['CAS_portNumber'] = $config_CAS_portNumber;
+            }
+
+            if (isset($config_CAS_URI)) {
+                $tab['CAS_URI'] = $config_CAS_URI;
+            }
+
+            if (isset($config_CAS_CACERT)) {
+                $tab['CAS_CACERT'] = $config_CAS_CACERT;
+            }
+
         }
 
         /******************************************/
         //  recup de qq infos sur le user
-        if(isset($_SESSION['userlogin']))
-        {
-            $sql_user = "SELECT u_nom, u_prenom, u_is_resp, u_is_admin, u_is_hr, u_is_active FROM conges_users WHERE u_login='".$_SESSION['userlogin']."' ";
-            $req_user = \includes\SQL::query($sql_user) ;
+        if (isset($_SESSION['userlogin'])) {
+            $sql_user = "SELECT u_nom, u_prenom, u_is_resp, u_is_admin, u_is_hr, u_is_active FROM conges_users WHERE u_login='" . $_SESSION['userlogin'] . "' ";
+            $req_user = \includes\SQL::query($sql_user);
 
-            if($data_user = $req_user->fetch_array())
-            {
-                $_SESSION['u_nom']    = $data_user[0] ;
-                $_SESSION['u_prenom']    = $data_user[1] ;
-                $_SESSION['is_resp']    = $data_user[2] ;
-                $_SESSION['is_admin']    = $data_user[3] ;
-                $_SESSION['is_hr']    = $data_user[4] ;
-                $_SESSION['is_active']    = $data_user[5] ;
+            if ($data_user = $req_user->fetch_array()) {
+                $_SESSION['u_nom']     = $data_user[0];
+                $_SESSION['u_prenom']  = $data_user[1];
+                $_SESSION['is_resp']   = $data_user[2];
+                $_SESSION['is_admin']  = $data_user[3];
+                $_SESSION['is_hr']     = $data_user[4];
+                $_SESSION['is_active'] = $data_user[5];
             }
         }
 
         /******************************************/
         $result = $tab;
-        if (isset($_SESSION['userlogin']))
+        if (isset($_SESSION['userlogin'])) {
             $userlogin = $_SESSION['userlogin'];
+        }
+
     }
     return $result;
 }
 
-
-
-
 // Récupère le contenu d une variable $_GET / $_POST
-function getpost_variable($variable, $default="")
+function getpost_variable($variable, $default = "")
 {
-   $valeur = (isset($_POST[$variable]) ? $_POST[$variable]  : (isset($_GET[$variable]) ? $_GET[$variable]   : $default));
+    $valeur = (isset($_POST[$variable]) ? $_POST[$variable] : (isset($_GET[$variable]) ? $_GET[$variable] : $default));
 
-   return   $valeur;
+    return $valeur;
 }
-
 
 // recup TRUE si le user a "u_see_all" à 'Y' dans la table users, FALSE sinon
 function get_user_see_all($login)
 {
 
-    $request = 'SELECT u_see_all FROM conges_users WHERE u_login="'.\includes\SQL::quote($login).'";';
-    $data = \includes\SQL::query($request);
+    $request = 'SELECT u_see_all FROM conges_users WHERE u_login="' . \includes\SQL::quote($login) . '";';
+    $data    = \includes\SQL::query($request);
 
-    if($l = $data->fetch_array())
-    {
+    if ($l = $data->fetch_array()) {
         $see_all = $l['u_see_all'];
         return ($see_all == 'Y');
+    } else {
+        return false;
     }
-    else
-        return FALSE;
-}
 
+}
 
 // recup dans un tableau des types de conges
 function recup_tableau_types_conges()
 {
-    $result = array();
+    $result  = array();
     $request = 'SELECT ta_id, ta_libelle FROM conges_type_absence WHERE ta_type=\'conges\';';
-    $data   = \includes\SQL::query($request);
+    $data    = \includes\SQL::query($request);
 
-    while ($l = $data->fetch_array())
-    {
-        $id = $l['ta_id'];
+    while ($l = $data->fetch_array()) {
+        $id          = $l['ta_id'];
         $result[$id] = $l['ta_libelle'];
     }
     return $result;
@@ -1724,13 +1737,12 @@ function recup_tableau_types_conges()
 // recup dans un tableau des types d'absence
 function recup_tableau_types_absence()
 {
-    $result = array();
+    $result  = array();
     $request = 'SELECT ta_id, ta_libelle FROM conges_type_absence WHERE ta_type=\'absences\';';
-    $data   = \includes\SQL::query($request);
+    $data    = \includes\SQL::query($request);
 
-    while ($l = $data->fetch_array())
-    {
-        $id = $l['ta_id'];
+    while ($l = $data->fetch_array()) {
+        $id          = $l['ta_id'];
         $result[$id] = $l['ta_libelle'];
     }
     return $result;
@@ -1739,33 +1751,34 @@ function recup_tableau_types_absence()
 // recup dans un tableau des types de conges exceptionnels
 function recup_tableau_types_conges_exceptionnels()
 {
-    $result = array();
+    $result  = array();
     $request = 'SELECT ta_id, ta_libelle FROM conges_type_absence WHERE ta_type=\'conges_exceptionnels\';';
-    $data   = \includes\SQL::query($request);
+    $data    = \includes\SQL::query($request);
 
-    while ($l = $data->fetch_array())
-    {
-        $id = $l['ta_id'];
+    while ($l = $data->fetch_array()) {
+        $id          = $l['ta_id'];
         $result[$id] = $l['ta_libelle'];
     }
     return $result;
 }
 
 // recup dans un tableau de tableau les infos des types de conges et absences
-function recup_tableau_tout_types_abs( )
+function recup_tableau_tout_types_abs()
 {
     $result = array();
-    if ( $_SESSION['config']['gestion_conges_exceptionnels'] ) // on prend tout les types de conges
+    if ($_SESSION['config']['gestion_conges_exceptionnels']) // on prend tout les types de conges
+    {
         $request = 'SELECT ta_id, ta_type, ta_libelle, ta_short_libelle FROM conges_type_absence;';
-    else // on prend tout les types de conges SAUF les conges exceptionnels
+    } else // on prend tout les types de conges SAUF les conges exceptionnels
+    {
         $request = 'SELECT ta_id, ta_type, ta_libelle, ta_short_libelle FROM conges_type_absence WHERE conges_type_absence.ta_type != \'conges_exceptionnels\';';
+    }
 
     $data = \includes\SQL::query($request);
 
-    while ($resultat_cong = $data->fetch_array())
-    {
-        $id = $resultat_cong['ta_id'];
-        $result[$id] = array('type' =>  $resultat_cong['ta_type'],'libelle' => $resultat_cong['ta_libelle'],'short_libelle' =>  $resultat_cong['ta_short_libelle'],);
+    while ($resultat_cong = $data->fetch_array()) {
+        $id          = $resultat_cong['ta_id'];
+        $result[$id] = array('type' => $resultat_cong['ta_type'], 'libelle' => $resultat_cong['ta_libelle'], 'short_libelle' => $resultat_cong['ta_short_libelle']);
     }
     return $result;
 }
@@ -1775,49 +1788,54 @@ function recup_tableau_conges_for_user($login, $hide_conges_exceptionnels)
 {
     // on pourrait tout faire en un seule select, mais cela bug si on change la prise en charge des conges exceptionnels en cours d'utilisation ...
 
-    if ($_SESSION['config']['gestion_conges_exceptionnels'] && ! $hide_conges_exceptionnels) // on prend tout les types de conges
-        $request = 'SELECT ta_libelle, su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_id = conges_solde_user.su_abs_id AND su_login = "'.\includes\SQL::quote($login).'" ORDER BY su_abs_id ASC;';
-    else // on prend tout les types de conges SAUF les conges exceptionnels
-        $request = 'SELECT ta_libelle, su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_type != \'conges_exceptionnels\' AND conges_type_absence.ta_id = conges_solde_user.su_abs_id AND su_login = "'.\includes\SQL::quote($login).'" ORDER BY su_abs_id ASC;';
+    if ($_SESSION['config']['gestion_conges_exceptionnels'] && !$hide_conges_exceptionnels) // on prend tout les types de conges
+    {
+        $request = 'SELECT ta_libelle, su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_id = conges_solde_user.su_abs_id AND su_login = "' . \includes\SQL::quote($login) . '" ORDER BY su_abs_id ASC;';
+    } else // on prend tout les types de conges SAUF les conges exceptionnels
+    {
+        $request = 'SELECT ta_libelle, su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_type != \'conges_exceptionnels\' AND conges_type_absence.ta_id = conges_solde_user.su_abs_id AND su_login = "' . \includes\SQL::quote($login) . '" ORDER BY su_abs_id ASC;';
+    }
 
-    $data   = \includes\SQL::query($request);
+    $data = \includes\SQL::query($request);
 
     $result = array();
 
-    while ($l = $data->fetch_array())
-    {
-        $sql_id = $l['ta_libelle'];
-        $result[$sql_id] = array('nb_an' => affiche_decimal($l['su_nb_an']),'solde' => affiche_decimal($l['su_solde']),'reliquat' => affiche_decimal($l['su_reliquat']),);
+    while ($l = $data->fetch_array()) {
+        $sql_id          = $l['ta_libelle'];
+        $result[$sql_id] = array('nb_an' => affiche_decimal($l['su_nb_an']), 'solde' => affiche_decimal($l['su_solde']), 'reliquat' => affiche_decimal($l['su_reliquat']));
     }
 
     return $result;
 }
 
 // recup dans un tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-function recup_tableau_conges_for_users( $hide_conges_exceptionnels, $logins = false)
+function recup_tableau_conges_for_users($hide_conges_exceptionnels, $logins = false)
 {
     // on pourrait tout faire en un seule select, mais cela bug si on change la prise en charge des conges exceptionnels en cours d'utilisation ...
 
-    if ($logins === false)
+    if ($logins === false) {
         $logins = '';
-    else
-        $logins = ' AND su_login IN ( \''.implode('\', \'',$logins).'\') ';
+    } else {
+        $logins = ' AND su_login IN ( \'' . implode('\', \'', $logins) . '\') ';
+    }
 
-    if ($_SESSION['config']['gestion_conges_exceptionnels'] && ! $hide_conges_exceptionnels) // on prend tout les types de conges
-        $request = 'SELECT su_login, ta_libelle,  su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_id = conges_solde_user.su_abs_id '.$logins.' ORDER BY ta_type , su_abs_id ASC';
-    else // on prend tout les types de conges SAUF les conges exceptionnels
-        $request = 'SELECT su_login, ta_libelle, su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_type != \'conges_exceptionnels\' AND conges_type_absence.ta_id = conges_solde_user.su_abs_id '.$logins.' ORDER BY su_abs_id ASC';
+    if ($_SESSION['config']['gestion_conges_exceptionnels'] && !$hide_conges_exceptionnels) // on prend tout les types de conges
+    {
+        $request = 'SELECT su_login, ta_libelle,  su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_id = conges_solde_user.su_abs_id ' . $logins . ' ORDER BY ta_type , su_abs_id ASC';
+    } else // on prend tout les types de conges SAUF les conges exceptionnels
+    {
+        $request = 'SELECT su_login, ta_libelle, su_nb_an, su_solde, su_reliquat FROM conges_solde_user, conges_type_absence WHERE conges_type_absence.ta_type != \'conges_exceptionnels\' AND conges_type_absence.ta_id = conges_solde_user.su_abs_id ' . $logins . ' ORDER BY su_abs_id ASC';
+    }
 
     $data = \includes\SQL::query($request);
 
-    $result=array();
-    while ($l = $data->fetch_array())
-    {
-        $tab=array();
-        $tab['nb_an'] = affiche_decimal($l['su_nb_an']);
-        $tab['solde'] = affiche_decimal($l['su_solde']);
-        $tab['reliquat'] = affiche_decimal($l['su_reliquat']);
-        $result[ $l['su_login'] ][ $l['ta_libelle'] ]   = $tab;
+    $result = array();
+    while ($l = $data->fetch_array()) {
+        $tab                                      = array();
+        $tab['nb_an']                             = affiche_decimal($l['su_nb_an']);
+        $tab['solde']                             = affiche_decimal($l['su_solde']);
+        $tab['reliquat']                          = affiche_decimal($l['su_reliquat']);
+        $result[$l['su_login']][$l['ta_libelle']] = $tab;
     }
     return $result;
 }
@@ -1825,28 +1843,28 @@ function recup_tableau_conges_for_users( $hide_conges_exceptionnels, $logins = f
 // affichage du tableau récapitulatif des solde de congés d'un user
 function affiche_tableau_bilan_conges_user($login)
 {
-    $request = 'SELECT u_quotite FROM conges_users where u_login = "'. \includes\SQL::quote($login).'";';
-    $ReqLog = \includes\SQL::query($request) ;
-    $resultat = $ReqLog->fetch_array();
-    $sql_quotite=$resultat['u_quotite'];
-    $return = '';
+    $request     = 'SELECT u_quotite FROM conges_users where u_login = "' . \includes\SQL::quote($login) . '";';
+    $ReqLog      = \includes\SQL::query($request);
+    $resultat    = $ReqLog->fetch_array();
+    $sql_quotite = $resultat['u_quotite'];
+    $return      = '';
 
     // recup dans un tableau de tableaux les nb et soldes de conges d'un user
     $tab_cong_user = recup_tableau_conges_for_user($login, true);
 
     // recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
     if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-        $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
+        $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
     }
 
     $return .= '<table class="table table-hover table-responsive table-condensed table-bordered">';
     $return .= '<thead>';
-    $return .= '<tr><td></td><td colspan="' . (count($tab_cong_user) * 2 ) . '">SOLDES</td></tr>';
+    $return .= '<tr><td></td><td colspan="' . (count($tab_cong_user) * 2) . '">SOLDES</td></tr>';
     $return .= '<tr>';
-    $return .= '<th class="titre">'. _('divers_quotite') .'</th>';
+    $return .= '<th class="titre">' . _('divers_quotite') . '</th>';
 
-    foreach($tab_cong_user as $id => $val) {
-        if ($_SESSION['config']['gestion_conges_exceptionnels'] && in_array($id,$tab_type_conges_exceptionnels)) {
+    foreach ($tab_cong_user as $id => $val) {
+        if ($_SESSION['config']['gestion_conges_exceptionnels'] && in_array($id, $tab_type_conges_exceptionnels)) {
             $return .= '<th class="solde">' . $id . '</th>';
         } else {
             $return .= '<th class="annuel">' . $id . ' / ' . _('divers_an_maj') . '</th><th class="solde">' . $id . '</th>';
@@ -1857,8 +1875,8 @@ function affiche_tableau_bilan_conges_user($login)
     $return .= '<tbody>';
     $return .= '<tr>';
     $return .= '<td class="quotite">' . $sql_quotite . '%</td>';
-    foreach($tab_cong_user as $id => $val) {
-        if ($_SESSION['config']['gestion_conges_exceptionnels']  && in_array($id,$tab_type_conges_exceptionnels)) {
+    foreach ($tab_cong_user as $id => $val) {
+        if ($_SESSION['config']['gestion_conges_exceptionnels'] && in_array($id, $tab_type_conges_exceptionnels)) {
             $return .= '<td class="solde">' . $val['solde'] . ($val['reliquat'] > 0 ? ' (' . _('dont_reliquat') . ' ' . $val['reliquat'] . ')' : '') . '</td>';
         } else {
             $return .= '<td class="annuel">' . $val['nb_an'] . '</td><td class="solde">' . $val['solde'] . ($val['reliquat'] > 0 ? ' (' . _('dont_reliquat') . ' ' . $val['reliquat'] . ')' : '') . '</td>';
@@ -1874,149 +1892,143 @@ function affiche_tableau_bilan_conges_user($login)
 // renvoit FALSE si erreur
 function recup_infos_du_user($login, $list_groups_double_valid)
 {
-    $tab=array();
+    $tab  = array();
     $sql1 = 'SELECT * FROM conges_users ' .
-            'WHERE u_login="'.\includes\SQL::quote($login).'";';
-    $ReqLog = \includes\SQL::query($sql1) ;
+    'WHERE u_login="' . \includes\SQL::quote($login) . '";';
+    $ReqLog = \includes\SQL::query($sql1);
 
-    if($resultat = $ReqLog->fetch_array())
-    {
-        $tab_user=array();
-        $tab_user['login']    = $resultat['u_login'];;
-        $tab_user['nom']    = $resultat['u_nom'];
-        $tab_user['prenom']    = $resultat['u_prenom'];
-        $tab_user['is_resp']    = $resultat['u_is_resp'];
-        $tab_user['resp_login']    = $resultat['u_resp_login'];
-        $tab_user['is_admin']    = $resultat['u_is_admin'];
-        $tab_user['is_hr']    = $resultat['u_is_hr'];
+    if ($resultat = $ReqLog->fetch_array()) {
+        $tab_user                 = array();
+        $tab_user['login']        = $resultat['u_login'];
+        $tab_user['nom']          = $resultat['u_nom'];
+        $tab_user['prenom']       = $resultat['u_prenom'];
+        $tab_user['is_resp']      = $resultat['u_is_resp'];
+        $tab_user['resp_login']   = $resultat['u_resp_login'];
+        $tab_user['is_admin']     = $resultat['u_is_admin'];
+        $tab_user['is_hr']        = $resultat['u_is_hr'];
         $tab_user['is_active']    = $resultat['u_is_active'];
-        $tab_user['see_all']    = $resultat['u_see_all'];
-        $tab_user['passwd']    = $resultat['u_passwd'];
-        $tab_user['quotite']    = $resultat['u_quotite'];
-        $tab_user['solde_heure']    = $resultat['u_heure_solde'];
-        $tab_user['email']    = $resultat['u_email'];
+        $tab_user['see_all']      = $resultat['u_see_all'];
+        $tab_user['passwd']       = $resultat['u_passwd'];
+        $tab_user['quotite']      = $resultat['u_quotite'];
+        $tab_user['solde_heure']  = $resultat['u_heure_solde'];
+        $tab_user['email']        = $resultat['u_email'];
         $tab_user['num_exercice'] = $resultat['u_num_exercice'];
         $tab_user['planningId']   = $resultat['planning_id'];
-        $tab_user['conges']    = recup_tableau_conges_for_user($login, false);
+        $tab_user['conges']       = recup_tableau_conges_for_user($login, false);
 
         $tab_user['double_valid'] = "N";
 
         // on regarde ici si le user est dans un groupe qui fait l'objet d'une double validation
-        if($_SESSION['config']['double_validation_conges'])
-        {
-            if($list_groups_double_valid!="") // si $resp_login est responsable d'au moins un groupe a double validation
+        if ($_SESSION['config']['double_validation_conges']) {
+            if ($list_groups_double_valid != "") // si $resp_login est responsable d'au moins un groupe a double validation
             {
-                $sql1='SELECT gu_login FROM conges_groupe_users WHERE gu_login="'.\includes\SQL::quote($login).'" AND gu_gid IN ('.$list_groups_double_valid.') ORDER BY gu_gid, gu_login;';
+                $sql1    = 'SELECT gu_login FROM conges_groupe_users WHERE gu_login="' . \includes\SQL::quote($login) . '" AND gu_gid IN (' . $list_groups_double_valid . ') ORDER BY gu_gid, gu_login;';
                 $ReqLog1 = \includes\SQL::query($sql1);
 
-                if($ReqLog1->num_rows  !=0)
+                if ($ReqLog1->num_rows != 0) {
                     $tab_user['double_valid'] = 'Y';
+                }
+
             }
         }
-        return $tab_user ;
+        return $tab_user;
+    } else {
+        return false;
     }
-    else
-        return FALSE;
+
 }
 
 // renvoit un tableau de tableau contenant les informations de tous les users
 function recup_infos_all_users()
 {
-    $tab=array();
-    $list_groupes_double_validation=get_list_groupes_double_valid();
-    $sql1 = "SELECT u_login FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_nom";
-    $ReqLog = \includes\SQL::query($sql1);
+    $tab                            = array();
+    $list_groupes_double_validation = get_list_groupes_double_valid();
+    $sql1                           = "SELECT u_login FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_nom";
+    $ReqLog                         = \includes\SQL::query($sql1);
 
-    while ($resultat =$ReqLog->fetch_array())
-    {
-        $tab_user=array();
-        $sql_login=$resultat["u_login"];
+    while ($resultat = $ReqLog->fetch_array()) {
+        $tab_user  = array();
+        $sql_login = $resultat["u_login"];
 
         $tab[$sql_login] = recup_infos_du_user($sql_login, $list_groupes_double_validation);
     }
-    return $tab ;
+    return $tab;
 }
 
 // renvoit un tableau de tableau contenant les informations de tous les users d'un groupe donné
 function recup_infos_all_users_du_groupe($group_id)
 {
-    $tab=array();
+    $tab = array();
     // recup de la liste de tous les users du groupe ...
-    $list_all_users_du_groupe = get_list_users_du_groupe($group_id);
-    $list_groupes_double_validation=get_list_groupes_double_valid();
-    if(strlen($list_all_users_du_groupe)!=0)
-    {
-        $tab_users_du_groupe=explode(",", $list_all_users_du_groupe);
-        foreach($tab_users_du_groupe as $current_login)
-        {
-            $current_login = trim($current_login);
-            $current_login = trim($current_login, "\'");  // on enleve les quotes qui ont été ajouté lors de la creation de la liste
+    $list_all_users_du_groupe       = get_list_users_du_groupe($group_id);
+    $list_groupes_double_validation = get_list_groupes_double_valid();
+    if (strlen($list_all_users_du_groupe) != 0) {
+        $tab_users_du_groupe = explode(",", $list_all_users_du_groupe);
+        foreach ($tab_users_du_groupe as $current_login) {
+            $current_login       = trim($current_login);
+            $current_login       = trim($current_login, "\'"); // on enleve les quotes qui ont été ajouté lors de la creation de la liste
             $tab[$current_login] = recup_infos_du_user($current_login, $list_groupes_double_validation);
         }
     }
-    return $tab ;
+    return $tab;
 }
 
 // renvoit un tableau de tableau contenant les informations de tous les users dont $login est responsable
 function recup_infos_all_users_du_resp($login)
 {
-    $tab=array();
+    $tab = array();
 
     // recup de la liste de tous les users du resp ...
     $list_all_users_du_resp = get_list_all_users_du_resp($login);
 
     // recup de la liste des groupes à double validation, dont $login est responsable
     // (servira à dire pour chaque user s'il est dans un de ces groupe ou non , donc s'il fait l'objet d'une double valid ou non )
-    $list_groups_double_valid_du_resp=get_list_groupes_double_valid_du_resp($login);
+    $list_groups_double_valid_du_resp = get_list_groupes_double_valid_du_resp($login);
 
-    if(strlen($list_all_users_du_resp)!=0)
-    {
-        $tab_users_du_resp=explode(",", $list_all_users_du_resp);
-        foreach($tab_users_du_resp as $current_login)
-        {
+    if (strlen($list_all_users_du_resp) != 0) {
+        $tab_users_du_resp = explode(",", $list_all_users_du_resp);
+        foreach ($tab_users_du_resp as $current_login) {
             $current_login = trim($current_login);
-            $current_login = trim($current_login, "\'");  // on enleve les quotes qui ont été ajouté lors de la creation de la liste
+            $current_login = trim($current_login, "\'"); // on enleve les quotes qui ont été ajouté lors de la creation de la liste
 
             $tab[$current_login] = recup_infos_du_user($current_login, $list_groups_double_valid_du_resp);
         }
     }
 
-    return $tab ;
+    return $tab;
 }
 
 // renvoit un tableau de tableau contenant les informations de tous les users dont $login est GRAND responsable
 function recup_infos_all_users_du_grand_resp($login)
 {
-    $tab=array();
-    $list_groups_double_valid=get_list_groupes_double_valid_du_grand_resp($login);
+    $tab                      = array();
+    $list_groups_double_valid = get_list_groupes_double_valid_du_grand_resp($login);
 
-    if($list_groups_double_valid!="")
-    {
+    if ($list_groups_double_valid != "") {
         // recup de la liste des users des groupes de la liste $list_groups_double_valid
-        $sql_users = 'SELECT DISTINCT(gu_login) FROM conges_groupe_users, conges_users WHERE gu_gid IN ('.\includes\SQL::quote($list_groups_double_valid).') AND gu_login=u_login ORDER BY u_nom;';
-        $ReqLog_users = \includes\SQL::query($sql_users) ;
-        $list_all_users_dbl_valid="";
-        while ($resultat_users =$ReqLog_users->fetch_array())
-        {
-            $current_login=$resultat_users["gu_login"];
-            if($list_all_users_dbl_valid=="")
-                $list_all_users_dbl_valid="'$current_login'";
-            else
-                $list_all_users_dbl_valid=$list_all_users_dbl_valid.", '$current_login'";
+        $sql_users                = 'SELECT DISTINCT(gu_login) FROM conges_groupe_users, conges_users WHERE gu_gid IN (' . \includes\SQL::quote($list_groups_double_valid) . ') AND gu_login=u_login ORDER BY u_nom;';
+        $ReqLog_users             = \includes\SQL::query($sql_users);
+        $list_all_users_dbl_valid = "";
+        while ($resultat_users = $ReqLog_users->fetch_array()) {
+            $current_login = $resultat_users["gu_login"];
+            if ($list_all_users_dbl_valid == "") {
+                $list_all_users_dbl_valid = "'$current_login'";
+            } else {
+                $list_all_users_dbl_valid = $list_all_users_dbl_valid . ", '$current_login'";
+            }
+
         }
 
-        if($list_all_users_dbl_valid!="")
-        {
-            $tab_users_du_resp=explode(",", $list_all_users_dbl_valid);
-            foreach($tab_users_du_resp as $current_login)
-            {
-                $current_login = trim($current_login);
-                $current_login = trim($current_login, "\'");  // on enleve les qote qui on été ajouté lors de la creation de la liste
+        if ($list_all_users_dbl_valid != "") {
+            $tab_users_du_resp = explode(",", $list_all_users_dbl_valid);
+            foreach ($tab_users_du_resp as $current_login) {
+                $current_login       = trim($current_login);
+                $current_login       = trim($current_login, "\'"); // on enleve les qote qui on été ajouté lors de la creation de la liste
                 $tab[$current_login] = recup_infos_du_user($current_login, $list_groups_double_valid);
             }
         }
     }
-    return $tab ;
+    return $tab;
 }
 
 // execute sequentiellement les requètes d'un fichier .sql
@@ -2024,22 +2036,21 @@ function execute_sql_file($file)
 {
     // lecture du fichier SQL
     // et execution de chaque ligne ....
-    $lines = file ($file);
-    $sql_requete="";
-    foreach ($lines as $line_num => $line)
-    {
-        $line=trim($line);
-        if( (substr($line, 0, 1)!="#") && ($line!="") )  //on ne prend pas les lignes de commentaire
+    $lines       = file($file);
+    $sql_requete = "";
+    foreach ($lines as $line_num => $line) {
+        $line = trim($line);
+        if ((substr($line, 0, 1) != "#") && ($line != "")) //on ne prend pas les lignes de commentaire
         {
-            $sql_requete = $sql_requete.$line ;
-            if(substr($sql_requete, -1, 1)==";") // alors la requete est finie !
+            $sql_requete = $sql_requete . $line;
+            if (substr($sql_requete, -1, 1) == ";") // alors la requete est finie !
             {
-                $result = \includes\SQL::query($sql_requete);
-                $sql_requete="";
+                $result      = \includes\SQL::query($sql_requete);
+                $sql_requete = "";
             }
         }
     }
-    return TRUE;
+    return true;
 }
 
 // verif des droits du user à afficher la page qu'il demande (pour éviter les hacks par bricolage d'URL)
@@ -2049,14 +2060,13 @@ function verif_droits_user($session, $niveau_droits)
     $niveau_droits = strtolower($niveau_droits);
 
     // verif si $_SESSION['is_admin'] ou $_SESSION['is_resp'] ou $_SESSION['is_hr'] =="N" ou $_SESSION['is_active'] =="N"
-    if($_SESSION[$niveau_droits]=="N")
-    {
+    if ($_SESSION[$niveau_droits] == "N") {
         // on recupere les variable utiles pour le suite :
-        $url_accueil_conges = $_SESSION['config']['URL_ACCUEIL_CONGES'] ;
-        $lang_divers_acces_page_interdit =  _('divers_acces_page_interdit') ;
-        $lang_divers_user_disconnected    =  _('divers_user_disconnected') ;
-        $lang_divers_veuillez        =  _('divers_veuillez') ;
-        $lang_divers_vous_authentifier    =  _('divers_vous_authentifier') ;
+        $url_accueil_conges              = $_SESSION['config']['URL_ACCUEIL_CONGES'];
+        $lang_divers_acces_page_interdit = _('divers_acces_page_interdit');
+        $lang_divers_user_disconnected   = _('divers_user_disconnected');
+        $lang_divers_veuillez            = _('divers_veuillez');
+        $lang_divers_vous_authentifier   = _('divers_vous_authentifier');
 
         // on delete la session et on renvoit sur l'authentification (page d'accueil)
         session_delete($session);
@@ -2070,23 +2080,22 @@ function verif_droits_user($session, $niveau_droits)
     }
 }
 
-
 // on lit le contenu du répertoire lang et on parse les nom de ficher (ex lang_fr_francais.php)
-function affiche_select_from_lang_directory( $select_name, $default )
+function affiche_select_from_lang_directory($select_name, $default)
 {
     $return = '';
-    if(empty($select_name)){
+    if (empty($select_name)) {
         $select_name = 'lang';
     }
-    if(empty($default)){
+    if (empty($default)) {
         $default = 'fr_FR';
     }
     $return .= '<select id="' . $select_name . '" name="' . $select_name . '" class="form-control">';
-    $langs = glob( LOCALE_PATH .'*' );
-    $return .= 'langs = ' . var_export( $langs, true );
-    foreach($langs as $lang ) {
+    $langs = glob(LOCALE_PATH . '*');
+    $return .= 'langs = ' . var_export($langs, true);
+    foreach ($langs as $lang) {
         $lang = basename($lang);
-        if( $lang == $default ) {
+        if ($lang == $default) {
             $return .= '<option value="' . $lang . '" selected >' . $lang . '</option>';
         } else {
             $return .= '<option value="' . $lang . '">' . $lang . '</option>';
@@ -2102,12 +2111,13 @@ function log_action($num_periode, $etat_periode, $login_pour, $comment)
 {
     $comment = htmlentities($comment, ENT_QUOTES | ENT_HTML401);
 
-    if(isset($_SESSION['userlogin']))
-        $user = $_SESSION['userlogin'] ;
-    else
+    if (isset($_SESSION['userlogin'])) {
+        $user = $_SESSION['userlogin'];
+    } else {
         $user = "inconnu";
+    }
 
-    $sql1 = 'INSERT INTO conges_logs SET log_p_num="'.\includes\SQL::quote($num_periode).'",log_user_login_par="'.\includes\SQL::quote($user).'",log_user_login_pour="'.\includes\SQL::quote($login_pour).'",log_etat="'.\includes\SQL::quote($etat_periode).'",log_comment="'.\includes\SQL::quote($comment).'",log_date=NOW()';
+    $sql1   = 'INSERT INTO conges_logs SET log_p_num="' . \includes\SQL::quote($num_periode) . '",log_user_login_par="' . \includes\SQL::quote($user) . '",log_user_login_pour="' . \includes\SQL::quote($login_pour) . '",log_etat="' . \includes\SQL::quote($etat_periode) . '",log_comment="' . \includes\SQL::quote($comment) . '",log_date=NOW()';
     $result = \includes\SQL::query($sql1);
 
     return $result;
@@ -2116,122 +2126,125 @@ function log_action($num_periode, $etat_periode, $login_pour, $comment)
 // remplit le tableau global des jours feries a partir de la database
 function init_tab_jours_fermeture($user)
 {
-    $_SESSION["tab_j_fermeture"]=array();
-    $sql_select='SELECT DISTINCT jf_date FROM conges_jours_fermeture, conges_groupe_users WHERE gu_login="'.\includes\SQL::quote($user).'" AND gu_gid=jf_gid';
-    $res_select = \includes\SQL::query($sql_select);
+    $_SESSION["tab_j_fermeture"] = array();
+    $sql_select                  = 'SELECT DISTINCT jf_date FROM conges_jours_fermeture, conges_groupe_users WHERE gu_login="' . \includes\SQL::quote($user) . '" AND gu_gid=jf_gid';
+    $res_select                  = \includes\SQL::query($sql_select);
 
-    while( $row = $res_select->fetch_array())
-        $_SESSION["tab_j_fermeture"][]=$row["jf_date"];
+    while ($row = $res_select->fetch_array()) {
+        $_SESSION["tab_j_fermeture"][] = $row["jf_date"];
+    }
+
 }
 
 // renvoit TRUE si le jour est fermé (fermeture), sinon FALSE (verifie dans le tableau global $_SESSION["tab_j_fermeture"]
 function est_ferme($timestamp)
 {
-    $j_date=date("Y-m-d", $timestamp);
-    if(isset($_SESSION["tab_j_fermeture"]))
+    $j_date = date("Y-m-d", $timestamp);
+    if (isset($_SESSION["tab_j_fermeture"])) {
         return in_array($j_date, $_SESSION["tab_j_fermeture"]);
-    else
-        return FALSE;
+    } else {
+        return false;
+    }
+
 }
 
 // renvoit le "su_reliquat" pour un user et un type de conges donné
 function get_reliquat_user_conges($login, $type_abs)
 {
-    $select_info='SELECT su_reliquat FROM conges_solde_user WHERE su_login="'.\includes\SQL::quote($login).'" AND su_abs_id="'.\includes\SQL::quote($type_abs).'"';
-    $ReqLog_info = \includes\SQL::query($select_info);
+    $select_info   = 'SELECT su_reliquat FROM conges_solde_user WHERE su_login="' . \includes\SQL::quote($login) . '" AND su_abs_id="' . \includes\SQL::quote($type_abs) . '"';
+    $ReqLog_info   = \includes\SQL::query($select_info);
     $resultat_info = $ReqLog_info->fetch_array();
-    $sql_reliquat=$resultat_info["su_reliquat"];
+    $sql_reliquat  = $resultat_info["su_reliquat"];
 
     return $sql_reliquat;
 }
 
 /*  si date_fin_conges < date_limite_reliquat => alors on décompte dans reliquats
-    si date_debut_conges > date_limite_reliquat => alors on ne décompte pas dans reliquats
-    si gonges demandé est à cheval sur la date_limite_reliquat => il faut decompter le nb_jours_pris du solde, puis il faut
-    calculer le nb_jours_avant pris avant la date limite, et on le decompte des reliquats, et calculer le nb_jours_apres
-    d'apres la date limite et ne pas le décompter des reliquats !!!
-*/
+si date_debut_conges > date_limite_reliquat => alors on ne décompte pas dans reliquats
+si gonges demandé est à cheval sur la date_limite_reliquat => il faut decompter le nb_jours_pris du solde, puis il faut
+calculer le nb_jours_avant pris avant la date limite, et on le decompte des reliquats, et calculer le nb_jours_apres
+d'apres la date limite et ne pas le décompter des reliquats !!!
+ */
 function soustrait_solde_et_reliquat_user($user_login, $num_current_periode, $user_nb_jours_pris, $type_abs, $date_deb, $demi_jour_deb, $date_fin, $demi_jour_fin)
 {
 
     $VerifDec = verif_saisie_decimal($user_nb_jours_pris);
 
     //si on autorise les reliquats
-    if($_SESSION['config']['autorise_reliquats_exercice'])
-    {
+    if ($_SESSION['config']['autorise_reliquats_exercice']) {
         //recup du reliquat du user pour ce type d'absence
-        $reliquat=get_reliquat_user_conges($user_login, $type_abs);
+        $reliquat = get_reliquat_user_conges($user_login, $type_abs);
         //echo "reliquat = $reliquat<br>\n";
         // s'il y a une date limite d'utilisationdes reliquats (au format jj-mm)
-        if($_SESSION['config']['jour_mois_limite_reliquats']!=0)
-        {
+        if ($_SESSION['config']['jour_mois_limite_reliquats'] != 0) {
             //si date_fin_conges < date_limite_reliquat => alors on décompte dans reliquats
-            if($date_fin < $_SESSION['config']['date_limite_reliquats'])
-            {
-                if($reliquat>$user_nb_jours_pris)
-                    $new_reliquat = $reliquat-$user_nb_jours_pris;
-                else
+            if ($date_fin < $_SESSION['config']['date_limite_reliquats']) {
+                if ($reliquat > $user_nb_jours_pris) {
+                    $new_reliquat = $reliquat - $user_nb_jours_pris;
+                } else {
                     $new_reliquat = 0;
+                }
+
             }
             //si date_debut_conges > date_limite_reliquat => alors on ne décompte pas dans reliquats
-            elseif($date_deb >= $_SESSION['config']['date_limite_reliquats'])
-            {
+            elseif ($date_deb >= $_SESSION['config']['date_limite_reliquats']) {
                 $new_reliquat = $reliquat;
             }
             //si conges demandé est à cheval sur la date_limite_reliquat => il faut decompter le nb_jours_pris du solde, puis il faut
             //calculer le nb_jours_avant pris avant la date limite, et on le decompte des reliquats, et calculer le nb_jours_apres
             //d'apres la data limite et ne pas le décompter des reliquats !!!
-            else
-            {
-                include_once 'fonctions_calcul.php' ;
-                $comment="calcul reliquat -> date limite" ;
-                $nb_reliquats_a_deduire = compter($user_login, $num_current_periode, $date_deb, $_SESSION['config']['date_limite_reliquats'], $demi_jour_deb, "pm", $comment );
+            else {
+                include_once 'fonctions_calcul.php';
+                $comment                = "calcul reliquat -> date limite";
+                $nb_reliquats_a_deduire = compter($user_login, $num_current_periode, $date_deb, $_SESSION['config']['date_limite_reliquats'], $demi_jour_deb, "pm", $comment);
 
-                if($reliquat > $nb_reliquats_a_deduire)
+                if ($reliquat > $nb_reliquats_a_deduire) {
                     $new_reliquat = $reliquat - $nb_reliquats_a_deduire;
-                else
+                } else {
                     $new_reliquat = 0;
+                }
+
             }
         }
         // s'il n'y a pas de date limite d'utilisation des reliquats
-        else
-        {
-            if($reliquat>$user_nb_jours_pris)
-                $new_reliquat = $reliquat-$user_nb_jours_pris;
-            else
+        else {
+            if ($reliquat > $user_nb_jours_pris) {
+                $new_reliquat = $reliquat - $user_nb_jours_pris;
+            } else {
                 $new_reliquat = 0;
+            }
+
         }
         $VerifDec = verif_saisie_decimal($user_nb_jours_pris);
         $VerifDec = verif_saisie_decimal($new_reliquat);
-        $sql2 = 'UPDATE conges_solde_user SET su_solde=su_solde-'.\includes\SQL::quote($user_nb_jours_pris).', su_reliquat='.\includes\SQL::quote($new_reliquat).' WHERE su_login="'.\includes\SQL::quote($user_login).'"  AND su_abs_id='.\includes\SQL::quote($type_abs).' ';
-    }
-    else
-    {
+        $sql2     = 'UPDATE conges_solde_user SET su_solde=su_solde-' . \includes\SQL::quote($user_nb_jours_pris) . ', su_reliquat=' . \includes\SQL::quote($new_reliquat) . ' WHERE su_login="' . \includes\SQL::quote($user_login) . '"  AND su_abs_id=' . \includes\SQL::quote($type_abs) . ' ';
+    } else {
         $VerifDec = verif_saisie_decimal($user_nb_jours_pris);
         $VerifDec = verif_saisie_decimal($new_reliquat);
-        $sql2 = 'UPDATE conges_solde_user SET su_solde=su_solde-'.\includes\SQL::quote($user_nb_jours_pris).' WHERE su_login=\''.\includes\SQL::quote($user_login).'\'  AND su_abs_id=\''.$type_abs.'\' ';
+        $sql2     = 'UPDATE conges_solde_user SET su_solde=su_solde-' . \includes\SQL::quote($user_nb_jours_pris) . ' WHERE su_login=\'' . \includes\SQL::quote($user_login) . '\'  AND su_abs_id=\'' . $type_abs . '\' ';
     }
-    $ReqLog2 = \includes\SQL::query($sql2) ;
+    $ReqLog2 = \includes\SQL::query($sql2);
 }
 
 // recup de la liste des users des groupes dont $resp_login est responsable mais ne remonte pas les autres responsables
 // renvoit une liste de login entre quotes et séparés par des virgules
 function get_list_users_des_groupes_du_resp_sauf_resp($resp_login)
 {
-    $list_users_des_groupes_du_resp_sauf_resp="";
-    $list_groups=get_list_groupes_du_resp($resp_login);
-    if($list_groups!="") // si $resp_login est responsable d'au moins un groupe
+    $list_users_des_groupes_du_resp_sauf_resp = "";
+    $list_groups                              = get_list_groupes_du_resp($resp_login);
+    if ($list_groups != "") // si $resp_login est responsable d'au moins un groupe
     {
-        $sql1="SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid IN ($list_groups) AND gu_login NOT IN (SELECT gr_login FROM conges_groupe_resp WHERE gr_gid IN ($list_groups)) ORDER BY gu_login ";
+        $sql1    = "SELECT DISTINCT(gu_login) FROM conges_groupe_users WHERE gu_gid IN ($list_groups) AND gu_login NOT IN (SELECT gr_login FROM conges_groupe_resp WHERE gr_gid IN ($list_groups)) ORDER BY gu_login ";
         $ReqLog1 = \includes\SQL::query($sql1);
 
-        while ($resultat1 = $ReqLog1->fetch_array())
-        {
-            $current_login=$resultat1["gu_login"];
-            if($list_users_des_groupes_du_resp_sauf_resp=="")
-                $list_users_des_groupes_du_resp_sauf_resp="'$current_login'";
-            else
-                $list_users_des_groupes_du_resp_sauf_resp=$list_users_des_groupes_du_resp_sauf_resp.", '$current_login'";
+        while ($resultat1 = $ReqLog1->fetch_array()) {
+            $current_login = $resultat1["gu_login"];
+            if ($list_users_des_groupes_du_resp_sauf_resp == "") {
+                $list_users_des_groupes_du_resp_sauf_resp = "'$current_login'";
+            } else {
+                $list_users_des_groupes_du_resp_sauf_resp = $list_users_des_groupes_du_resp_sauf_resp . ", '$current_login'";
+            }
+
         }
     }
     return $list_users_des_groupes_du_resp_sauf_resp;
@@ -2239,7 +2252,8 @@ function get_list_users_des_groupes_du_resp_sauf_resp($resp_login)
 
 /*--------- ajout fonction probesys -------------------*/
 //date au format d/m/Y -> Y-m-d
-function convert_date($date){
+function convert_date($date)
+{
     $date_component = explode('/', $date);
     $date_component = array_reverse($date_component);
 
@@ -2247,24 +2261,26 @@ function convert_date($date){
 }
 
 //date au format d/m/Y -> d-m-Y
-function revert_date($date){
+function revert_date($date)
+{
     $date_component = explode('-', $date);
 
     return implode('/', $date_component);
 }
 
 //date au format d/m/Y
-function get_nb_jour($date_deb, $date_fin, $demi_jour_deb, $demi_jour_fin){
+function get_nb_jour($date_deb, $date_fin, $demi_jour_deb, $demi_jour_fin)
+{
     $date_deb = new DateTime($date_deb); //inclusive
     $date_fin = new DateTime($date_fin); //exclusive
-    $diff = $date_deb->diff($date_fin);
-    $diff = $diff->format("%a");
+    $diff     = $date_deb->diff($date_fin);
+    $diff     = $diff->format("%a");
 
-    if($demi_jour_deb == 'am' && $demi_jour_fin =='pm') {
+    if ($demi_jour_deb == 'am' && $demi_jour_fin == 'pm') {
         $diff = $diff + 1;
     }
 
-    if($demi_jour_deb == $demi_jour_fin) {
+    if ($demi_jour_deb == $demi_jour_fin) {
         $diff = $diff + 0.5;
     }
 

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -25,7 +25,7 @@ class Fonctions
         /***********************************/
         // AFFICHAGE TABLEAU (premiere ligne)
         $return = '';
-        $return .= '<h2>'. _('hr_traite_user_etat_conges') . '</H2>';
+        $return .= '<h2>' . _('hr_traite_user_etat_conges') . '</H2>';
         $return .= '<table cellpadding="2" class="tablo" width="80%">';
         $return .= '<thead>';
         $return .= '<tr>';
@@ -33,23 +33,23 @@ class Fonctions
         $return .= '<th>' . _('divers_prenom_maj') . '</th>';
         $return .= '<th>' . _('divers_quotite_maj_1') . '</th>';
         $nb_colonnes = 3;
-        foreach($tab_type_cong as $id_conges => $libelle) {
+        foreach ($tab_type_cong as $id_conges => $libelle) {
             // cas d'une absence ou d'un congé
             $return .= '<th>' . $libelle . ' / ' . _('divers_an_maj') . '</th>';
-            $return .= '<th>'. _('divers_solde_maj') . ' ' . $libelle . '</th>';
+            $return .= '<th>' . _('divers_solde_maj') . ' ' . $libelle . '</th>';
             $nb_colonnes += 2;
         }
         // conges exceptionnels
         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-            foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
-                $return .= '<th>'. _('divers_solde_maj') . ' ' . $libelle . '</th>';
+            foreach ($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
+                $return .= '<th>' . _('divers_solde_maj') . ' ' . $libelle . '</th>';
                 $nb_colonnes += 1;
             }
         }
-        $return .= '<th>'. _('solde_heure') .'</th>' ;
+        $return .= '<th>' . _('solde_heure') . '</th>';
         $return .= '<th></th>';
         $nb_colonnes += 1;
-        if($_SESSION['config']['editions_papier']) {
+        if ($_SESSION['config']['editions_papier']) {
             $return .= '<th></th>';
             $nb_colonnes += 1;
         }
@@ -63,47 +63,46 @@ class Fonctions
         // AFFICHAGE DE USERS DIRECTS DU RESP
 
         // Récup dans un tableau de tableau des informations de tous les users dont $_SESSION['userlogin'] est responsable
-        $tab_all_users=\hr\Fonctions::recup_infos_all_users_du_hr($_SESSION['userlogin']);
+        $tab_all_users = \hr\Fonctions::recup_infos_all_users_du_hr($_SESSION['userlogin']);
 
-        if(count($tab_all_users)==0) {
+        if (count($tab_all_users) == 0) {
             // si le tableau est vide (resp sans user !!) on affiche une alerte !
-            $return .= '<tr><td class="histo" colspan="' . $nb_colonnes . '">' .  _('resp_etat_aucun_user') . '</td></tr>';
+            $return .= '<tr><td class="histo" colspan="' . $nb_colonnes . '">' . _('resp_etat_aucun_user') . '</td></tr>';
         } else {
             //$i = true;
-            foreach($tab_all_users as $current_login => $tab_current_user) {
+            foreach ($tab_all_users as $current_login => $tab_current_user) {
                 //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-                $tab_conges=$tab_current_user['conges'];
-                $text_affich_user="<a href=\"hr_index.php?session=$session&onglet=traite_user&user_login=$current_login\" title=\""._('resp_etat_users_afficher')."\"><i class=\"fa fa-eye\"></i></a>" ;
-                $text_edit_papier="<a href=\"../edition/edit_user.php?session=$session&user_login=$current_login\" target=\"_blank\" title=\""._('resp_etat_users_imprim')."\"><i class=\"fa fa-file-text\"></i></a>";
-                if($tab_current_user['is_active'] == "Y" || $_SESSION['config']['print_disable_users'] == 'TRUE') {
+                $tab_conges       = $tab_current_user['conges'];
+                $text_affich_user = "<a href=\"hr_index.php?session=$session&onglet=traite_user&user_login=$current_login\" title=\"" . _('resp_etat_users_afficher') . "\"><i class=\"fa fa-eye\"></i></a>";
+                $text_edit_papier = "<a href=\"../edition/edit_user.php?session=$session&user_login=$current_login\" target=\"_blank\" title=\"" . _('resp_etat_users_imprim') . "\"><i class=\"fa fa-file-text\"></i></a>";
+                if ($tab_current_user['is_active'] == "Y" || $_SESSION['config']['print_disable_users'] == 'TRUE') {
                     $return .= '<tr>';
                 } else {
                     $return .= '<tr class="hidden">';
                 }
                 $return .= '<td>' . $tab_current_user['nom'] . '</td><td>' . $tab_current_user['prenom'] . '</td><td>' . $tab_current_user['quotite'] . '%</td>';
-                foreach($tab_type_cong as $id_conges => $libelle) {
+                foreach ($tab_type_cong as $id_conges => $libelle) {
                     $nbAn = isset($tab_conges[$libelle]['nb_an'])
-                        ? $tab_conges[$libelle]['nb_an']
-                        : 0;
+                    ? $tab_conges[$libelle]['nb_an']
+                    : 0;
                     $solde = isset($tab_conges[$libelle]['solde'])
-                        ? $tab_conges[$libelle]['solde']
-                        : 0;
-                    $return .= '<td>'.$nbAn.'</td>';
-                    $return .= '<td>'. $solde .'</td>';
+                    ? $tab_conges[$libelle]['solde']
+                    : 0;
+                    $return .= '<td>' . $nbAn . '</td>';
+                    $return .= '<td>' . $solde . '</td>';
                 }
                 if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-                    foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle)
-                    {
+                    foreach ($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
                         $solde = isset($tab_conges[$libelle]['solde'])
-                            ? $tab_conges[$libelle]['solde']
-                            : 0;
-                        $return .= '<td>' . $solde .'</td>';
+                        ? $tab_conges[$libelle]['solde']
+                        : 0;
+                        $return .= '<td>' . $solde . '</td>';
                     }
                 }
                 $soldeHeure = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($current_login)['u_heure_solde'];
                 $return .= '<td>' . \App\Helpers\Formatter::timestamp2Duree($soldeHeure) . '</td>';
                 $return .= '<td>' . $text_affich_user . '</td>';
-                if($_SESSION['config']['editions_papier']) {
+                if ($_SESSION['config']['editions_papier']) {
                     $return .= '<td>' . $text_edit_papier . '</td>';
                 }
 
@@ -129,56 +128,59 @@ class Fonctions
     public static function traite_all_demande_en_cours($tab_bt_radio, $tab_text_refus)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
-        while($elem_tableau = each($tab_bt_radio)) {
+        while ($elem_tableau = each($tab_bt_radio)) {
             $champs             = explode("--", $elem_tableau['value']);
             $user_login         = $champs[0];
             $user_nb_jours_pris = $champs[1];
-            $type_abs           = $champs[2];   // id du type de conges demandé
+            $type_abs           = $champs[2]; // id du type de conges demandé
             $date_deb           = $champs[3];
             $demi_jour_deb      = $champs[4];
             $date_fin           = $champs[5];
             $demi_jour_fin      = $champs[6];
             $reponse            = $champs[7];
 
-            $numero             = $elem_tableau['key'];
-            $numero_int         = (int) $numero;
+            $numero     = $elem_tableau['key'];
+            $numero_int = (int) $numero;
             $return .= $numero . '---' . $user_login . '---' . $user_nb_jours_pris . '---' . $reponse . '<br>';
 
             /* Modification de la table conges_periode */
-            if(strcmp($reponse, "OK")==0) {
+            if (strcmp($reponse, "OK") == 0) {
                 /* UPDATE table "conges_periode" */
-                $sql1 = 'UPDATE conges_periode SET p_etat=\'ok\', p_date_traitement=NOW() WHERE p_num="'.\includes\SQL::quote($numero_int).'" AND ( p_etat=\'valid\' OR p_etat=\'demande\' );' ;
+                $sql1 = 'UPDATE conges_periode SET p_etat=\'ok\', p_date_traitement=NOW() WHERE p_num="' . \includes\SQL::quote($numero_int) . '" AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
                 /* On valide l'UPDATE dans la table "conges_periode" ! */
-                $ReqLog1 = \includes\SQL::query($sql1) ;
-                if ($ReqLog1 && \includes\SQL::getVar('affected_rows') ) {
+                $ReqLog1 = \includes\SQL::query($sql1);
+                if ($ReqLog1 && \includes\SQL::getVar('affected_rows')) {
                     // Log de l'action
-                    log_action($numero_int,"ok", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $reponse");
+                    log_action($numero_int, "ok", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $reponse");
 
                     /* UPDATE table "conges_solde_user" (jours restants) */
                     soustrait_solde_et_reliquat_user($user_login, $numero_int, $user_nb_jours_pris, $type_abs, $date_deb, $demi_jour_deb, $date_fin, $demi_jour_fin);
 
                     //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                    if($_SESSION['config']['mail_valid_conges_alerte_user'])
+                    if ($_SESSION['config']['mail_valid_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "accept_conges");
+                    }
+
                 }
-            } elseif(strcmp($reponse, "not_OK")==0) {
+            } elseif (strcmp($reponse, "not_OK") == 0) {
                 // recup du motif de refus
-                $motif_refus=addslashes($tab_text_refus[$numero_int]);
-                $sql1 = 'UPDATE conges_periode SET p_etat=\'refus\', p_motif_refus=\''.$motif_refus.'\', p_date_traitement=NOW() WHERE p_num="'.\includes\SQL::quote($numero_int).'" AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
+                $motif_refus = addslashes($tab_text_refus[$numero_int]);
+                $sql1        = 'UPDATE conges_periode SET p_etat=\'refus\', p_motif_refus=\'' . $motif_refus . '\', p_date_traitement=NOW() WHERE p_num="' . \includes\SQL::quote($numero_int) . '" AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
 
                 /* On valide l'UPDATE dans la table ! */
-                $ReqLog1 = \includes\SQL::query($sql1) ;
+                $ReqLog1 = \includes\SQL::query($sql1);
                 if ($ReqLog1 && \includes\SQL::getVar('affected_rows')) {
                     // Log de l'action
-                    log_action($numero_int,"refus", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : refus");
-
+                    log_action($numero_int, "refus", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : refus");
 
                     //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                    if($_SESSION['config']['mail_refus_conges_alerte_user'])
+                    if ($_SESSION['config']['mail_refus_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "refus_conges");
+                    }
+
                 }
             }
         }
@@ -191,18 +193,18 @@ class Fonctions
 
     public static function affiche_all_demandes_en_cours($tab_type_conges)
     {
-        $return = '';
+        $return   = '';
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $count1=0;
-        $count2=0;
+        $session  = session_id();
+        $count1   = 0;
+        $count2   = 0;
 
         $tab_type_all_abs = recup_tableau_tout_types_abs();
 
         // recup du tableau des types de conges (seulement les conges exceptionnels)
-        $tab_type_conges_exceptionnels=array();
+        $tab_type_conges_exceptionnels = array();
         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-            $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
+            $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
         }
 
         /*********************************/
@@ -210,17 +212,17 @@ class Fonctions
         /*********************************/
 
         // Récup dans un tableau de tableau des informations de tous les users
-        $tab_all_users=recup_infos_all_users();
+        $tab_all_users = recup_infos_all_users();
 
         // si tableau des users du resp n'est pas vide
-        if( count($tab_all_users)!=0 ) {
+        if (count($tab_all_users) != 0) {
             // constitution de la liste (séparé par des virgules) des logins ...
-            $list_users="";
-            foreach($tab_all_users as $current_login => $tab_current_user) {
-                if($list_users=="") {
-                    $list_users= "'$current_login'" ;
+            $list_users = "";
+            foreach ($tab_all_users as $current_login => $tab_current_user) {
+                if ($list_users == "") {
+                    $list_users = "'$current_login'";
                 } else {
-                    $list_users=$list_users.", '$current_login'" ;
+                    $list_users = $list_users . ", '$current_login'";
                 }
             }
         }
@@ -234,18 +236,18 @@ class Fonctions
         /*********************************/
 
         // si tableau des users n'est pas vide :)
-        if( count($tab_all_users)!=0 ) {
+        if (count($tab_all_users) != 0) {
 
             // Récup des demandes en cours pour les users :
             $sql1 = "SELECT p_num, p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_date_demande, p_date_traitement FROM conges_periode ";
-            $sql1=$sql1." WHERE p_etat =\"demande\" ";
-            $sql1=$sql1." AND p_login IN ($list_users) ";
-            $sql1=$sql1." ORDER BY p_num";
+            $sql1 = $sql1 . " WHERE p_etat =\"demande\" ";
+            $sql1 = $sql1 . " AND p_login IN ($list_users) ";
+            $sql1 = $sql1 . " ORDER BY p_num";
 
-            $ReqLog1 = \includes\SQL::query($sql1) ;
+            $ReqLog1 = \includes\SQL::query($sql1);
 
             $count1 = $ReqLog1->num_rows;
-            if($count1!=0) {
+            if ($count1 != 0) {
                 // AFFICHAGE TABLEAU DES DEMANDES EN COURS
                 $return .= '<h3>' . _('resp_traite_demandes_titre_tableau_1') . '</h3>';
                 $return .= '<table cellpadding="2" class="table table-hover table-responsive table-condensed table-striped">';
@@ -254,67 +256,67 @@ class Fonctions
                 $return .= '<th>' . _('divers_nom_maj_1') . '<br>' . _('divers_prenom_maj_1') . '</th>';
                 $return .= '<th>' . _('divers_quotite_maj_1') . '</th>';
                 $return .= '<th>' . _('divers_type_maj_1') . '</th>';
-                $return .= '<th>' . _('divers_debut_maj_1') .'</th>';
+                $return .= '<th>' . _('divers_debut_maj_1') . '</th>';
                 $return .= '<th>' . _('divers_fin_maj_1') . '</th>';
                 $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
                 $return .= '<th>' . _('resp_traite_demandes_nb_jours') . '</th>';
                 $return .= '<th>' . _('divers_solde') . '</th>';
-                $return .= '<th>'. _('divers_accepter_maj_1') .'</th>' ;
-                $return .= '<th>'. _('divers_refuser_maj_1') .'</th>' ;
+                $return .= '<th>' . _('divers_accepter_maj_1') . '</th>';
+                $return .= '<th>' . _('divers_refuser_maj_1') . '</th>';
                 $return .= '<th>' . _('resp_traite_demandes_attente') . '</th>';
-                $return .= '<th>'. _('resp_traite_demandes_motif_refus') . '</th>';
-                if( $_SESSION['config']['affiche_date_traitement'] ) {
+                $return .= '<th>' . _('resp_traite_demandes_motif_refus') . '</th>';
+                if ($_SESSION['config']['affiche_date_traitement']) {
                     $return .= '<th>' . _('divers_date_traitement') . '</th>';
                 }
                 $return .= '</tr>';
-                $return .= '</thead>' ;
-                $return .= '<tbody>' ;
-                $i = true;
-                $tab_bt_radio=array();
+                $return .= '</thead>';
+                $return .= '<tbody>';
+                $i            = true;
+                $tab_bt_radio = array();
                 while ($resultat1 = $ReqLog1->fetch_array()) {
                     /** sur la ligne ,   **/
                     /** le 1er bouton radio est <input type="radio" name="tab_bt_radio[valeur de p_num]" value="[valeur de p_login]--[valeur p_nb_jours]--$type--OK"> */
                     /**  et le 2ieme est <input type="radio" name="tab_bt_radio[valeur de p_num]" value="[valeur de p_login]--[valeur p_nb_jours]--$type--not_OK"> */
                     /**  et le 3ieme est <input type="radio" name="tab_bt_radio[valeur de p_num]" value="[valeur de p_login]--[valeur p_nb_jours]--$type--RIEN"> */
 
-                    $sql_p_date_deb         = $resultat1["p_date_deb"];
-                    $sql_p_date_fin         = $resultat1["p_date_fin"];
-                    $sql_p_date_deb_fr      = eng_date_to_fr($resultat1["p_date_deb"]);
-                    $sql_p_date_fin_fr      = eng_date_to_fr($resultat1["p_date_fin"]);
-                    $sql_p_demi_jour_deb    = $resultat1["p_demi_jour_deb"] ;
-                    $sql_p_demi_jour_fin    = $resultat1["p_demi_jour_fin"] ;
-                    $sql_p_commentaire      = $resultat1["p_commentaire"];
-                    $sql_p_num              = $resultat1["p_num"];
-                    $sql_p_login            = $resultat1["p_login"];
-                    $sql_p_nb_jours         = affiche_decimal($resultat1["p_nb_jours"]);
-                    $sql_p_type             = $resultat1["p_type"];
-                    $sql_p_date_demande     = $resultat1["p_date_demande"];
-                    $sql_p_date_traitement  = $resultat1["p_date_traitement"];
+                    $sql_p_date_deb        = $resultat1["p_date_deb"];
+                    $sql_p_date_fin        = $resultat1["p_date_fin"];
+                    $sql_p_date_deb_fr     = eng_date_to_fr($resultat1["p_date_deb"]);
+                    $sql_p_date_fin_fr     = eng_date_to_fr($resultat1["p_date_fin"]);
+                    $sql_p_demi_jour_deb   = $resultat1["p_demi_jour_deb"];
+                    $sql_p_demi_jour_fin   = $resultat1["p_demi_jour_fin"];
+                    $sql_p_commentaire     = $resultat1["p_commentaire"];
+                    $sql_p_num             = $resultat1["p_num"];
+                    $sql_p_login           = $resultat1["p_login"];
+                    $sql_p_nb_jours        = affiche_decimal($resultat1["p_nb_jours"]);
+                    $sql_p_type            = $resultat1["p_type"];
+                    $sql_p_date_demande    = $resultat1["p_date_demande"];
+                    $sql_p_date_traitement = $resultat1["p_date_traitement"];
 
-                    if($sql_p_demi_jour_deb=="am") {
-                        $demi_j_deb="mat";
+                    if ($sql_p_demi_jour_deb == "am") {
+                        $demi_j_deb = "mat";
                     } else {
-                        $demi_j_deb="aprm";
+                        $demi_j_deb = "aprm";
                     }
 
-                    if($sql_p_demi_jour_fin=="am") {
-                        $demi_j_fin="mat";
+                    if ($sql_p_demi_jour_fin == "am") {
+                        $demi_j_fin = "mat";
                     } else {
-                        $demi_j_fin="aprm";
+                        $demi_j_fin = "aprm";
                     }
 
                     // on construit la chaine qui servira de valeur à passer dans les boutons-radio
                     $chaine_bouton_radio = "$sql_p_login--$sql_p_nb_jours--$sql_p_type--$sql_p_date_deb--$sql_p_demi_jour_deb--$sql_p_date_fin--$sql_p_demi_jour_fin";
-                    $boutonradio1="<input type=\"radio\" name=\"tab_bt_radio[$sql_p_num]\" value=\"$chaine_bouton_radio--OK\">";
-                    $boutonradio2="<input type=\"radio\" name=\"tab_bt_radio[$sql_p_num]\" value=\"$chaine_bouton_radio--not_OK\">";
-                    $boutonradio3="<input type=\"radio\" name=\"tab_bt_radio[$sql_p_num]\" value=\"$chaine_bouton_radio--RIEN\" checked>";
-                    $text_refus="<input class=\"form-control\" type=\"text\" name=\"tab_text_refus[$sql_p_num]\" size=\"20\" max=\"100\">";
+                    $boutonradio1        = "<input type=\"radio\" name=\"tab_bt_radio[$sql_p_num]\" value=\"$chaine_bouton_radio--OK\">";
+                    $boutonradio2        = "<input type=\"radio\" name=\"tab_bt_radio[$sql_p_num]\" value=\"$chaine_bouton_radio--not_OK\">";
+                    $boutonradio3        = "<input type=\"radio\" name=\"tab_bt_radio[$sql_p_num]\" value=\"$chaine_bouton_radio--RIEN\" checked>";
+                    $text_refus          = "<input class=\"form-control\" type=\"text\" name=\"tab_text_refus[$sql_p_num]\" size=\"20\" max=\"100\">";
 
                     $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
                     $return .= '<td><b>' . $tab_all_users[$sql_p_login]['nom'] . '</b><br>' . $tab_all_users[$sql_p_login]['prenom'] . '</td><td>' . $tab_all_users[$sql_p_login]['quotite'] . '%</td>';
                     $return .= '<td>' . $tab_type_all_abs[$sql_p_type]['libelle'] . '</td>';
                     $return .= '<td>' . $sql_p_date_deb_fr . '<span class="demi">' . $demi_j_deb . '</span></td><td>' . $sql_p_date_fin_fr . '<span class="demi">' . $demi_j_fin . '</span></td><td>' . $sql_p_commentaire . '</td><td><b>' . $sql_p_nb_jours . '</b></td>';
-                    $tab_conges=$tab_all_users[$sql_p_login]['conges'];
+                    $tab_conges = $tab_all_users[$sql_p_login]['conges'];
                     $return .= '<td>' . $tab_conges[$tab_type_all_abs[$sql_p_type]['libelle']]['solde'] . '</td>';
                     // foreach($tab_type_conges as $id_conges => $libelle)
                     // {
@@ -328,24 +330,24 @@ class Fonctions
                     //     }
                     // echo '<td>'.$tab_type_all_abs[$sql_p_type]['libelle'].'</td>';
                     $return .= '<td>' . $boutonradio1 . '</td><td>' . $boutonradio2 . '</td><td>' . $boutonradio3 . '</td><td>' . $text_refus . '</td>';
-                    if($_SESSION['config']['affiche_date_traitement']) {
-                        if($sql_p_date_demande == NULL) {
+                    if ($_SESSION['config']['affiche_date_traitement']) {
+                        if ($sql_p_date_demande == null) {
                             $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_p_date_traitement . '</td>';
                         } else {
                             $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : pas traité</td>';
                         }
                     }
-                    $return .= '</tr>' ;
+                    $return .= '</tr>';
                     $i = !$i;
                 } // while
-                $return .= '</tbody>' ;
-                $return .= '</table>' ;
+                $return .= '</tbody>';
+                $return .= '</table>';
             } //if($count1!=0)
         } //if( count($tab_all_users)!=0 )
 
         $return .= '<br>';
 
-        if(($count1==0) && ($count2==0)) {
+        if (($count1 == 0) && ($count2 == 0)) {
             $return .= '<strong>' . _('aucune_demande') . '</strong>';
         } else {
             $return .= '<hr/>';
@@ -375,15 +377,15 @@ class Fonctions
         $tab_text_refus = getpost_variable('tab_text_refus');
 
         // titre
-        $return .= '<h2>'. _('resp_traite_demandes_titre') .'</h2>';
+        $return .= '<h2>' . _('resp_traite_demandes_titre') . '</h2>';
 
         // si le tableau des bouton radio des demandes est vide , on affiche les demandes en cours
-        if( $tab_bt_radio == '' ) {
+        if ($tab_bt_radio == '') {
             $return .= \hr\Fonctions::affiche_all_demandes_en_cours($tab_type_cong);
         } else {
             $return .= \hr\Fonctions::traite_all_demande_en_cours($tab_bt_radio, $tab_text_refus);
             echo $return;
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session.'&onglet='.$onglet, false);
+            redirect(ROOT_PATH . 'hr/hr_index.php?session=' . $session . '&onglet=' . $onglet, false);
             exit;
         }
         return $return;
@@ -392,16 +394,16 @@ class Fonctions
     public static function new_conges($user_login, $numero_int, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         $new_debut = convert_date($new_debut);
-        $new_fin = convert_date($new_fin);
+        $new_fin   = convert_date($new_fin);
 
         // verif validité des valeurs saisies
-        $valid=verif_saisie_new_demande($new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment);
+        $valid = verif_saisie_new_demande($new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment);
 
-        if($valid) {
+        if ($valid) {
             $return .= $user_login . '---' . $new_debut . '_' . $new_demi_jour_deb . '---' . $new_fin . '_' . $new_demi_jour_fin . '---' . $new_nb_jours . '---' . $new_comment . '---' . $new_type_id . '<br>';
 
             // recup dans un tableau de tableau les infos des types de conges et absences
@@ -410,22 +412,22 @@ class Fonctions
             /**********************************/
             /* insert dans conges_periode     */
             /**********************************/
-            $new_etat="ok";
-            $result=insert_dans_periode($user_login, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id, $new_etat, 0);
+            $new_etat = "ok";
+            $result   = insert_dans_periode($user_login, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id, $new_etat, 0);
 
             /************************************************/
             /* UPDATE table "conges_solde_user" (jours restants) */
             // on retranche les jours seulement pour des conges pris (pas pour les absences)
             // donc seulement si le type de l'absence qu'on annule est un "conges"
-            if($tab_tout_type_abs[$new_type_id]['type']=="conges" || $tab_tout_type_abs[$user_type_abs_id]['type']=="conges_exceptionnels") {
-                $user_nb_jours_pris_float=(float) $new_nb_jours ;
+            if ($tab_tout_type_abs[$new_type_id]['type'] == "conges" || $tab_tout_type_abs[$user_type_abs_id]['type'] == "conges_exceptionnels") {
+                $user_nb_jours_pris_float = (float) $new_nb_jours;
                 soustrait_solde_et_reliquat_user($user_login, $numero_int, $user_nb_jours_pris_float, $new_type_id, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin);
             }
 
             $comment_log = "saisie conges par le responsable pour $user_login ($new_nb_jours jour(s)) type_conges = $new_type_id ( de $new_debut $new_demi_jour_deb a $new_fin $new_demi_jour_fin) ($new_comment)";
             log_action(0, "", $user_login, $comment_log);
 
-            if($result) {
+            if ($result) {
                 $return .= _('form_modif_ok') . '<br><br>';
             } else {
                 $return .= _('form_modif_not_ok') . '<br><br>';
@@ -443,78 +445,79 @@ class Fonctions
 
     public static function traite_demandes($user_login, $tab_radio_traite_demande, $tab_text_refus)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id();
-        $return = '';
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session  = session_id();
+        $return   = '';
 
         // recup dans un tableau de tableau les infos des types de conges et absences
         $tab_tout_type_abs = recup_tableau_tout_types_abs();
 
-        while($elem_tableau = each($tab_radio_traite_demande)) {
-            $champs = explode("--", $elem_tableau['value']);
-            $user_login=$champs[0];
-            $user_nb_jours_pris=$champs[1];
-            $user_nb_jours_pris_float=(float) $user_nb_jours_pris ;
-            $value_type_abs_id=$champs[2];
-            $date_deb=$champs[3];
-            $demi_jour_deb=$champs[4];
-            $date_fin=$champs[5];
-            $demi_jour_fin=$champs[6];
-            $reponse=$champs[7];
+        while ($elem_tableau = each($tab_radio_traite_demande)) {
+            $champs                   = explode("--", $elem_tableau['value']);
+            $user_login               = $champs[0];
+            $user_nb_jours_pris       = $champs[1];
+            $user_nb_jours_pris_float = (float) $user_nb_jours_pris;
+            $value_type_abs_id        = $champs[2];
+            $date_deb                 = $champs[3];
+            $demi_jour_deb            = $champs[4];
+            $date_fin                 = $champs[5];
+            $demi_jour_fin            = $champs[6];
+            $reponse                  = $champs[7];
 
-            $numero=$elem_tableau['key'];
-            $numero_int=(int) $numero;
+            $numero     = $elem_tableau['key'];
+            $numero_int = (int) $numero;
 
-            if($reponse == "ACCEPTE") { // acceptation definitive d'un conges
+            if ($reponse == "ACCEPTE") {
+                // acceptation definitive d'un conges
                 /* UPDATE table "conges_periode" */
-                $sql1 = 'UPDATE conges_periode SET p_etat=\'ok\', p_date_traitement=NOW() WHERE p_num='.\includes\SQL::quote($numero_int).' AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
+                $sql1    = 'UPDATE conges_periode SET p_etat=\'ok\', p_date_traitement=NOW() WHERE p_num=' . \includes\SQL::quote($numero_int) . ' AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
                 $ReqLog1 = \includes\SQL::query($sql1);
 
                 if ($ReqLog1 && \includes\SQL::getVar('affected_rows')) {
                     // Log de l'action
-                    log_action($numero_int,"ok", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $date_deb");
+                    log_action($numero_int, "ok", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $date_deb");
 
                     /* UPDATE table "conges_solde_user" (jours restants) */
                     // on retranche les jours seulement pour des conges pris (pas pour les absences)
                     // donc seulement si le type de l'absence qu'on annule est un "conges"
-                    if(($tab_tout_type_abs[$value_type_abs_id]['type']=="conges")||($tab_tout_type_abs[$value_type_abs_id]['type']=="conges_exceptionnels")) {
+                    if (($tab_tout_type_abs[$value_type_abs_id]['type'] == "conges") || ($tab_tout_type_abs[$value_type_abs_id]['type'] == "conges_exceptionnels")) {
                         soustrait_solde_et_reliquat_user($user_login, $numero_int, $user_nb_jours_pris_float, $value_type_abs_id, $date_deb, $demi_jour_deb, $date_fin, $demi_jour_fin);
                     }
 
                     //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                    if($_SESSION['config']['mail_valid_conges_alerte_user']) {
+                    if ($_SESSION['config']['mail_valid_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "accept_conges");
                     }
                 }
-            } elseif($reponse == "VALID") // première validation dans le cas d'une double validation
+            } elseif ($reponse == "VALID") // première validation dans le cas d'une double validation
             {
                 /* UPDATE table "conges_periode" */
-                $sql1 = 'UPDATE conges_periode SET p_etat=\'valid\', p_date_traitement=NOW() WHERE p_num='.\includes\SQL::quote($numero_int).' AND p_etat=\'demande\';' ;
+                $sql1    = 'UPDATE conges_periode SET p_etat=\'valid\', p_date_traitement=NOW() WHERE p_num=' . \includes\SQL::quote($numero_int) . ' AND p_etat=\'demande\';';
                 $ReqLog1 = \includes\SQL::query($sql1);
 
                 if ($ReqLog1 && \includes\SQL::getVar('affected_rows')) {
                     // Log de l'action
-                    log_action($numero_int,"valid", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $date_deb");
+                    log_action($numero_int, "valid", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $date_deb");
 
                     //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                    if($_SESSION['config']['mail_valid_conges_alerte_user']) {
+                    if ($_SESSION['config']['mail_valid_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "valid_conges");
                     }
                 }
-            } elseif($reponse == "REFUSE") // refus d'un conges
+            } elseif ($reponse == "REFUSE") // refus d'un conges
             {
                 // recup di motif de refus
-                $motif_refus=addslashes($tab_text_refus[$numero_int]);
-                $sql3 = 'UPDATE conges_periode SET p_etat=\'refus\', p_motif_refus="'.\includes\SQL::quote($motif_refus).'", p_date_traitement=NOW() WHERE p_num="'.\includes\SQL::quote($numero_int).'" AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
+                $motif_refus = addslashes($tab_text_refus[$numero_int]);
+                $sql3        = 'UPDATE conges_periode SET p_etat=\'refus\', p_motif_refus="' . \includes\SQL::quote($motif_refus) . '", p_date_traitement=NOW() WHERE p_num="' . \includes\SQL::quote($numero_int) . '" AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
 
                 $ReqLog3 = \includes\SQL::query($sql3);
 
                 if ($ReqLog3 && \includes\SQL::getVar('affected_rows')) {
                     // Log de l'action
-                    log_action($numero_int,"refus", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $date_deb");
+                    log_action($numero_int, "refus", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $date_deb");
 
                     //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                    if($_SESSION['config']['mail_refus_conges_alerte_user']) {
+                    if ($_SESSION['config']['mail_refus_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "refus_conges");
                     }
                 }
@@ -528,42 +531,42 @@ class Fonctions
 
     public static function annule_conges($user_login, $tab_checkbox_annule, $tab_text_annul)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id() ;
-        $return = '';
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session  = session_id();
+        $return   = '';
 
         // recup dans un tableau de tableau les infos des types de conges et absences
         $tab_tout_type_abs = recup_tableau_tout_types_abs();
 
-        while($elem_tableau = each($tab_checkbox_annule)) {
-            $champs = explode("--", $elem_tableau['value']);
-            $user_login=$champs[0];
-            $user_nb_jours_pris=$champs[1];
-            $VerifDec=verif_saisie_decimal($user_nb_jours_pris) ;
-            $numero=$elem_tableau['key'];
-            $numero_int=(int) $numero;
-            $user_type_abs_id=$champs[2];
+        while ($elem_tableau = each($tab_checkbox_annule)) {
+            $champs             = explode("--", $elem_tableau['value']);
+            $user_login         = $champs[0];
+            $user_nb_jours_pris = $champs[1];
+            $VerifDec           = verif_saisie_decimal($user_nb_jours_pris);
+            $numero             = $elem_tableau['key'];
+            $numero_int         = (int) $numero;
+            $user_type_abs_id   = $champs[2];
 
-            $motif_annul=addslashes($tab_text_annul[$numero_int]);
+            $motif_annul = addslashes($tab_text_annul[$numero_int]);
 
             /* UPDATE table "conges_periode" */
-            $sql1 = 'UPDATE conges_periode SET p_etat="annul", p_motif_refus="'.\includes\SQL::quote($motif_annul).'", p_date_traitement=NOW() WHERE p_num="'. \includes\SQL::quote($numero_int).'" AND p_etat="ok";';
+            $sql1    = 'UPDATE conges_periode SET p_etat="annul", p_motif_refus="' . \includes\SQL::quote($motif_annul) . '", p_date_traitement=NOW() WHERE p_num="' . \includes\SQL::quote($numero_int) . '" AND p_etat="ok";';
             $ReqLog1 = \includes\SQL::query($sql1);
 
             if ($ReqLog1 && \includes\SQL::getVar('affected_rows')) {
                 // Log de l'action
-                log_action($numero_int,"annul", $user_login, "annulation conges $numero ($user_login) ($user_nb_jours_pris jours)");
+                log_action($numero_int, "annul", $user_login, "annulation conges $numero ($user_login) ($user_nb_jours_pris jours)");
 
                 /* UPDATE table "conges_solde_user" (jours restants) */
                 // on re-crédite les jours seulement pour des conges pris (pas pour les absences)
                 // donc seulement si le type de l'absence qu'on annule est un "conges"
-                if(in_array($tab_tout_type_abs[$user_type_abs_id]['type'],["conges","conges_exceptionnels"])) {
-                    $sql2 = 'UPDATE conges_solde_user SET su_solde = su_solde+"'. \includes\SQL::quote($user_nb_jours_pris).'" WHERE su_login="'. \includes\SQL::quote($user_login).'" AND su_abs_id="'. \includes\SQL::quote($user_type_abs_id).'";';
+                if (in_array($tab_tout_type_abs[$user_type_abs_id]['type'], ["conges", "conges_exceptionnels"])) {
+                    $sql2    = 'UPDATE conges_solde_user SET su_solde = su_solde+"' . \includes\SQL::quote($user_nb_jours_pris) . '" WHERE su_login="' . \includes\SQL::quote($user_login) . '" AND su_abs_id="' . \includes\SQL::quote($user_type_abs_id) . '";';
                     $ReqLog2 = \includes\SQL::query($sql2);
                 }
 
                 //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                if($_SESSION['config']['mail_annul_conges_alerte_user']) {
+                if ($_SESSION['config']['mail_annul_conges_alerte_user']) {
                     alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "annul_conges");
                 }
             }
@@ -578,13 +581,13 @@ class Fonctions
     //affiche l'état des conges du user (avec le formulaire pour le responsable)
     public static function affiche_etat_conges_user_for_resp($user_login, $year_affichage, $tri_date)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id() ;
-        $return = '';
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session  = session_id();
+        $return   = '';
 
         // affichage de l'année et des boutons de défilement
-        $year_affichage_prec = $year_affichage-1 ;
-        $year_affichage_suiv = $year_affichage+1 ;
+        $year_affichage_prec = $year_affichage - 1;
+        $year_affichage_suiv = $year_affichage + 1;
 
         $return .= '<b>';
         $return .= '<a href="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user&user_login=' . $user_login . '&year_affichage=' . $year_affichage_prec . '"><<</a>';
@@ -592,26 +595,26 @@ class Fonctions
         $return .= '<a href="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user&user_login=' . $user_login . '&year_affichage=' . $year_affichage_suiv . '">>></a>';
         $return .= '</b><br><br>';
 
-
         // Récupération des informations de speriodes de conges/absences
         $sql3 = "SELECT p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_etat, p_motif_refus, p_date_demande, p_date_traitement, p_num FROM conges_periode " .
-                "WHERE p_login = '$user_login' " .
-                "AND p_etat !='demande' " .
-                "AND p_etat !='valid' " .
-                "AND (p_date_deb LIKE '$year_affichage%' OR p_date_fin LIKE '$year_affichage%') ";
-        if($tri_date=="descendant")
-            $sql3=$sql3." ORDER BY p_date_deb DESC ";
-        else
-            $sql3=$sql3." ORDER BY p_date_deb ASC ";
+            "WHERE p_login = '$user_login' " .
+            "AND p_etat !='demande' " .
+            "AND p_etat !='valid' " .
+            "AND (p_date_deb LIKE '$year_affichage%' OR p_date_fin LIKE '$year_affichage%') ";
+        if ($tri_date == "descendant") {
+            $sql3 = $sql3 . " ORDER BY p_date_deb DESC ";
+        } else {
+            $sql3 = $sql3 . " ORDER BY p_date_deb ASC ";
+        }
 
         $ReqLog3 = \includes\SQL::query($sql3);
 
-        $count3=$ReqLog3->num_rows;
-        if($count3==0) {
+        $count3 = $ReqLog3->num_rows;
+        if ($count3 == 0) {
             $return .= '<b>' . _('resp_traite_user_aucun_conges') . '</b><br><br>';
         } else {
             // recup dans un tableau de tableau les infos des types de conges et absences
-            $tab_types_abs = recup_tableau_tout_types_abs() ;
+            $tab_types_abs = recup_tableau_tout_types_abs();
 
             // AFFICHAGE TABLEAU
             $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user" method="POST">';
@@ -627,62 +630,66 @@ class Fonctions
             $return .= '<th>' . _('divers_nb_jours_pris_maj_1') . '</th>';
             $return .= '<th>' . _('divers_comment_maj_1') . '<br><i>' . _('resp_traite_user_motif_possible') . '</i></th>';
             $return .= '<th>' . _('divers_type_maj_1') . '</th>';
-            $return .= ' <th>'. _('divers_etat_maj_1') .'</th>';
-            $return .= ' <th>'. _('resp_traite_user_annul') .'</th>';
-            $return .= ' <th>'. _('resp_traite_user_motif_annul') .'</th>';
-            if( $_SESSION['config']['affiche_date_traitement'] ) {
-                $return .= '<th>'. _('divers_date_traitement') .'</th>' ;
+            $return .= ' <th>' . _('divers_etat_maj_1') . '</th>';
+            $return .= ' <th>' . _('resp_traite_user_annul') . '</th>';
+            $return .= ' <th>' . _('resp_traite_user_motif_annul') . '</th>';
+            if ($_SESSION['config']['affiche_date_traitement']) {
+                $return .= '<th>' . _('divers_date_traitement') . '</th>';
             }
             $return .= '</tr>';
             $return .= '</thead>';
             $return .= '<tbody>';
 
-            $i = true;
-            $tab_checkbox=array();
-            while ($resultat3 = $ReqLog3->fetch_array() ) {
-                $sql_date_deb           = eng_date_to_fr($resultat3["p_date_deb"]) ;
-                $sql_date_fin           = eng_date_to_fr($resultat3["p_date_fin"]) ;
-                $sql_demi_jour_deb      = $resultat3["p_demi_jour_deb"] ;
-                $sql_demi_jour_fin      = $resultat3["p_demi_jour_fin"] ;
+            $i            = true;
+            $tab_checkbox = array();
+            while ($resultat3 = $ReqLog3->fetch_array()) {
+                $sql_date_deb      = eng_date_to_fr($resultat3["p_date_deb"]);
+                $sql_date_fin      = eng_date_to_fr($resultat3["p_date_fin"]);
+                $sql_demi_jour_deb = $resultat3["p_demi_jour_deb"];
+                $sql_demi_jour_fin = $resultat3["p_demi_jour_fin"];
 
-                $sql_login              = $resultat3["p_login"] ;
-                $sql_nb_jours           = affiche_decimal($resultat3["p_nb_jours"]) ;
-                $sql_commentaire        = $resultat3["p_commentaire"] ;
-                $sql_type               = $resultat3["p_type"] ;
-                $sql_etat               = $resultat3["p_etat"] ;
-                $sql_motif_refus        = $resultat3["p_motif_refus"] ;
-                $sql_p_date_demande     = $resultat3["p_date_demande"];
-                $sql_p_date_traitement  = $resultat3["p_date_traitement"];
-                $sql_num                = $resultat3["p_num"] ;
+                $sql_login             = $resultat3["p_login"];
+                $sql_nb_jours          = affiche_decimal($resultat3["p_nb_jours"]);
+                $sql_commentaire       = $resultat3["p_commentaire"];
+                $sql_type              = $resultat3["p_type"];
+                $sql_etat              = $resultat3["p_etat"];
+                $sql_motif_refus       = $resultat3["p_motif_refus"];
+                $sql_p_date_demande    = $resultat3["p_date_demande"];
+                $sql_p_date_traitement = $resultat3["p_date_traitement"];
+                $sql_num               = $resultat3["p_num"];
 
-                if($sql_demi_jour_deb=="am") {
-                    $demi_j_deb =  _('divers_am_short') ;
+                if ($sql_demi_jour_deb == "am") {
+                    $demi_j_deb = _('divers_am_short');
                 } else {
-                    $demi_j_deb =  _('divers_pm_short') ;
+                    $demi_j_deb = _('divers_pm_short');
                 }
 
-                if($sql_demi_jour_fin=="am") {
-                    $demi_j_fin =  _('divers_am_short') ;
+                if ($sql_demi_jour_fin == "am") {
+                    $demi_j_fin = _('divers_am_short');
                 } else {
-                    $demi_j_fin =  _('divers_pm_short') ;
+                    $demi_j_fin = _('divers_pm_short');
                 }
 
-                if(($sql_etat=="annul") || ($sql_etat=="refus") || ($sql_etat=="ajout")) {
-                    $casecocher1="";
-                    if($sql_etat=="refus") {
-                        if($sql_motif_refus=="")
-                            $sql_motif_refus =  _('divers_inconnu')  ;
-                        $text_annul="<i>". _('resp_traite_user_motif') ." : $sql_motif_refus</i>";
-                    } elseif($sql_etat=="annul") {
-                        if($sql_motif_refus=="")
-                            $sql_motif_refus =  _('divers_inconnu')  ;
-                        $text_annul="<i>". _('resp_traite_user_motif') ." : $sql_motif_refus</i>";
-                    } elseif($sql_etat=="ajout") {
-                        $text_annul="&nbsp;";
+                if (($sql_etat == "annul") || ($sql_etat == "refus") || ($sql_etat == "ajout")) {
+                    $casecocher1 = "";
+                    if ($sql_etat == "refus") {
+                        if ($sql_motif_refus == "") {
+                            $sql_motif_refus = _('divers_inconnu');
+                        }
+
+                        $text_annul = "<i>" . _('resp_traite_user_motif') . " : $sql_motif_refus</i>";
+                    } elseif ($sql_etat == "annul") {
+                        if ($sql_motif_refus == "") {
+                            $sql_motif_refus = _('divers_inconnu');
+                        }
+
+                        $text_annul = "<i>" . _('resp_traite_user_motif') . " : $sql_motif_refus</i>";
+                    } elseif ($sql_etat == "ajout") {
+                        $text_annul = "&nbsp;";
                     }
                 } else {
-                    $casecocher1=sprintf("<input type=\"checkbox\" name=\"tab_checkbox_annule[$sql_num]\" value=\"$sql_login--$sql_nb_jours--$sql_type--ANNULE\">");
-                    $text_annul="<input type=\"text\" name=\"tab_text_annul[$sql_num]\" size=\"20\" max=\"100\">";
+                    $casecocher1 = sprintf("<input type=\"checkbox\" name=\"tab_checkbox_annule[$sql_num]\" value=\"$sql_login--$sql_nb_jours--$sql_type--ANNULE\">");
+                    $text_annul  = "<input type=\"text\" name=\"tab_text_annul[$sql_num]\" size=\"20\" max=\"100\">";
                 }
 
                 $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
@@ -692,10 +699,10 @@ class Fonctions
                 $return .= '<td>' . $sql_commentaire . '</td>';
                 $return .= '<td>' . $tab_types_abs[$sql_type]['libelle'] . '</td>';
                 $return .= '<td>';
-                if($sql_etat=="refus") {
-                    $return .= _('divers_refuse') ;
-                } elseif($sql_etat=="annul") {
-                    $return .= _('divers_annule') ;
+                if ($sql_etat == "refus") {
+                    $return .= _('divers_refuse');
+                } elseif ($sql_etat == "annul") {
+                    $return .= _('divers_annule');
                 } else {
                     $return .= $sql_etat;
                 }
@@ -703,8 +710,8 @@ class Fonctions
                 $return .= '<td>' . $casecocher1 . '</td>';
                 $return .= '<td>' . $text_annul . '</td>';
 
-                if($_SESSION['config']['affiche_date_traitement']) {
-                    if(empty($sql_p_date_demande)) {
+                if ($_SESSION['config']['affiche_date_traitement']) {
+                    if (empty($sql_p_date_demande)) {
                         $return .= '<td class="histo-left">' . _('divers_traitement') . ' : ' . $sql_p_date_traitement . '</td>';
                     } else {
                         $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_p_date_traitement . '</td>';
@@ -726,18 +733,18 @@ class Fonctions
     //affiche l'état des demande en attente de 2ieme validation du user (avec le formulaire pour le responsable)
     public static function affiche_etat_demande_2_valid_user_for_resp($user_login)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id() ;
-        $return = '';
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session  = session_id();
+        $return   = '';
 
         // Récupération des informations
         $sql2 = "SELECT p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_date_demande, p_date_traitement, p_num " .
-                "FROM conges_periode " .
-                "WHERE p_login = '$user_login' AND p_etat ='valid' ORDER BY p_date_deb";
+            "FROM conges_periode " .
+            "WHERE p_login = '$user_login' AND p_etat ='valid' ORDER BY p_date_deb";
         $ReqLog2 = \includes\SQL::query($sql2);
 
-        $count2=$ReqLog2->num_rows;
-        if($count2==0) {
+        $count2 = $ReqLog2->num_rows;
+        if ($count2 == 0) {
             $return .= '<b>' . _('resp_traite_user_aucune_demande') . '</b><br><br>';
         } else {
             // recup dans un tableau des types de conges
@@ -748,50 +755,49 @@ class Fonctions
             $return .= '<table cellpadding="2" class="tablo">';
             $return .= '<thead>';
             $return .= '<tr>';
-            $return .= '<th>'. _('divers_debut_maj_1') .'</th>';
-            $return .= '<th>'. _('divers_fin_maj_1') .'</th>';
-            $return .= '<th>'. _('divers_nb_jours_pris_maj_1') .'</th>';
-            $return .= '<th>'. _('divers_comment_maj_1') .'</th>';
-            $return .= '<th>'. _('divers_type_maj_1') .'</th>';
-            $return .= '<th>'. _('divers_accepter_maj_1') .'</th>';
-            $return .= '<th>'. _('divers_refuser_maj_1') .'</th>';
-            $return .= '<th>'. _('resp_traite_user_motif_refus') .'</th>';
-            if($_SESSION['config']['affiche_date_traitement']) {
-                $return .= '<th>'. _('divers_date_traitement') .'</th>' ;
+            $return .= '<th>' . _('divers_debut_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_fin_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_nb_jours_pris_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_type_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_accepter_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_refuser_maj_1') . '</th>';
+            $return .= '<th>' . _('resp_traite_user_motif_refus') . '</th>';
+            if ($_SESSION['config']['affiche_date_traitement']) {
+                $return .= '<th>' . _('divers_date_traitement') . '</th>';
             }
             $return .= '</tr>';
             $return .= '</thead>';
             $return .= '<tbody>';
 
-            $i = true;
-            $tab_checkbox=array();
-            while ($resultat2 = $ReqLog2->fetch_array() ) {
-                $sql_date_deb = $resultat2["p_date_deb"];
-                $sql_date_deb_fr = eng_date_to_fr($resultat2["p_date_deb"]) ;
-                $sql_demi_jour_deb=$resultat2["p_demi_jour_deb"] ;
-                if($sql_demi_jour_deb=="am") {
-                    $demi_j_deb =  _('divers_am_short') ;
+            $i            = true;
+            $tab_checkbox = array();
+            while ($resultat2 = $ReqLog2->fetch_array()) {
+                $sql_date_deb      = $resultat2["p_date_deb"];
+                $sql_date_deb_fr   = eng_date_to_fr($resultat2["p_date_deb"]);
+                $sql_demi_jour_deb = $resultat2["p_demi_jour_deb"];
+                if ($sql_demi_jour_deb == "am") {
+                    $demi_j_deb = _('divers_am_short');
                 } else {
-                    $demi_j_deb =  _('divers_pm_short') ;
+                    $demi_j_deb = _('divers_pm_short');
                 }
-                $sql_date_fin = $resultat2["p_date_fin"];
-                $sql_date_fin_fr = eng_date_to_fr($resultat2["p_date_fin"]) ;
-                $sql_demi_jour_fin=$resultat2["p_demi_jour_fin"] ;
-                if($sql_demi_jour_fin=="am") {
-                    $demi_j_fin =  _('divers_am_short') ;
+                $sql_date_fin      = $resultat2["p_date_fin"];
+                $sql_date_fin_fr   = eng_date_to_fr($resultat2["p_date_fin"]);
+                $sql_demi_jour_fin = $resultat2["p_demi_jour_fin"];
+                if ($sql_demi_jour_fin == "am") {
+                    $demi_j_fin = _('divers_am_short');
                 } else {
-                    $demi_j_fin =  _('divers_pm_short') ;
+                    $demi_j_fin = _('divers_pm_short');
                 }
-                $sql_nb_jours=affiche_decimal($resultat2["p_nb_jours"]) ;
-                $sql_commentaire=$resultat2["p_commentaire"] ;
-                $sql_type=$resultat2["p_type"] ;
-                $sql_date_demande = $resultat2["p_date_demande"];
+                $sql_nb_jours        = affiche_decimal($resultat2["p_nb_jours"]);
+                $sql_commentaire     = $resultat2["p_commentaire"];
+                $sql_type            = $resultat2["p_type"];
+                $sql_date_demande    = $resultat2["p_date_demande"];
                 $sql_date_traitement = $resultat2["p_date_traitement"];
-                $sql_num=$resultat2["p_num"] ;
+                $sql_num             = $resultat2["p_num"];
 
                 // on construit la chaine qui servira de valeur à passer dans les boutons-radio
                 $chaine_bouton_radio = "$user_login--$sql_nb_jours--$sql_type--$sql_date_deb--$sql_demi_jour_deb--$sql_date_fin--$sql_demi_jour_fin";
-
 
                 $casecocher1 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--ACCEPTE\">";
                 $casecocher2 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--REFUSE\">";
@@ -806,7 +812,7 @@ class Fonctions
                 $return .= '<td>' . $casecocher1 . '</td>';
                 $return .= '<td>' . $casecocher2 . '</td>';
                 $return .= '<td>' . $text_refus . '</td>';
-                if($_SESSION['config']['affiche_date_traitement']) {
+                if ($_SESSION['config']['affiche_date_traitement']) {
                     $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_date_traitement . '</td>';
                 }
 
@@ -827,19 +833,19 @@ class Fonctions
     //affiche l'état des demande du user (avec le formulaire pour le responsable)
     public static function affiche_etat_demande_user_for_resp($user_login, $tab_user, $tab_grd_resp)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id() ;
-        $return = '';
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session  = session_id();
+        $return   = '';
 
         // Récupération des informations
         $sql2 = "SELECT p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_date_demande, p_date_traitement, p_num " .
-                "FROM conges_periode " .
-                "WHERE p_login = '$user_login' AND p_etat ='demande' ".
-                "ORDER BY p_date_deb";
+            "FROM conges_periode " .
+            "WHERE p_login = '$user_login' AND p_etat ='demande' " .
+            "ORDER BY p_date_deb";
         $ReqLog2 = \includes\SQL::query($sql2);
 
-        $count2=$ReqLog2->num_rows;
-        if($count2==0) {
+        $count2 = $ReqLog2->num_rows;
+        if ($count2 == 0) {
             $return .= '<b>' . _('resp_traite_user_aucune_demande') . '</b><br><br>';
         } else {
             // recup dans un tableau des types de conges
@@ -850,81 +856,81 @@ class Fonctions
             $return .= '<table cellpadding="2" class="tablo">';
             $return .= '<thead>';
             $return .= '<tr>';
-            $return .= '<th>'. _('divers_debut_maj_1') .'</th>';
-            $return .= '<th>'. _('divers_fin_maj_1') .'</th>';
-            $return .= '<th>'. _('divers_nb_jours_pris_maj_1') .'</th>';
-            $return .= '<th>'. _('divers_comment_maj_1') .'</th>';
-            $return .= '<th>'. _('divers_type_maj_1') .'</th>';
-            $return .= '<th>'. _('divers_accepter_maj_1') .'</th>';
-            $return .= '<th>'. _('divers_refuser_maj_1') .'</th>';
-            $return .= '<th>'. _('resp_traite_user_motif_refus') .'</th>';
-            if( $_SESSION['config']['affiche_date_traitement'] ) {
-                $return .= '<th>'. _('divers_date_traitement') .'</th>' ;
+            $return .= '<th>' . _('divers_debut_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_fin_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_nb_jours_pris_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_type_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_accepter_maj_1') . '</th>';
+            $return .= '<th>' . _('divers_refuser_maj_1') . '</th>';
+            $return .= '<th>' . _('resp_traite_user_motif_refus') . '</th>';
+            if ($_SESSION['config']['affiche_date_traitement']) {
+                $return .= '<th>' . _('divers_date_traitement') . '</th>';
             }
             $return .= '</tr>';
             $return .= '</thead>';
             $return .= '<tbody>';
 
-            $i = true;
-            $tab_checkbox=array();
+            $i            = true;
+            $tab_checkbox = array();
             while ($resultat2 = $ReqLog2->fetch_array()) {
-                $sql_date_deb       = $resultat2["p_date_deb"];
-                $sql_date_fin       = $resultat2["p_date_fin"];
-                $sql_date_deb_fr    = eng_date_to_fr($resultat2["p_date_deb"]) ;
-                $sql_date_fin_fr    = eng_date_to_fr($resultat2["p_date_fin"]) ;
-                $sql_demi_jour_deb  = $resultat2["p_demi_jour_deb"] ;
-                $sql_demi_jour_fin  = $resultat2["p_demi_jour_fin"] ;
+                $sql_date_deb      = $resultat2["p_date_deb"];
+                $sql_date_fin      = $resultat2["p_date_fin"];
+                $sql_date_deb_fr   = eng_date_to_fr($resultat2["p_date_deb"]);
+                $sql_date_fin_fr   = eng_date_to_fr($resultat2["p_date_fin"]);
+                $sql_demi_jour_deb = $resultat2["p_demi_jour_deb"];
+                $sql_demi_jour_fin = $resultat2["p_demi_jour_fin"];
 
-                $sql_nb_jours       = affiche_decimal($resultat2["p_nb_jours"]) ;
-                $sql_commentaire    = $resultat2["p_commentaire"] ;
-                $sql_type           = $resultat2["p_type"] ;
-                $sql_date_demande   = $resultat2["p_date_demande"];
-                $sql_date_traitement= $resultat2["p_date_traitement"];
-                $sql_num            = $resultat2["p_num"] ;
+                $sql_nb_jours        = affiche_decimal($resultat2["p_nb_jours"]);
+                $sql_commentaire     = $resultat2["p_commentaire"];
+                $sql_type            = $resultat2["p_type"];
+                $sql_date_demande    = $resultat2["p_date_demande"];
+                $sql_date_traitement = $resultat2["p_date_traitement"];
+                $sql_num             = $resultat2["p_num"];
 
-
-                if($sql_demi_jour_deb=="am") {
-                    $demi_j_deb =  _('divers_am_short') ;
+                if ($sql_demi_jour_deb == "am") {
+                    $demi_j_deb = _('divers_am_short');
                 } else {
-                    $demi_j_deb =  _('divers_pm_short') ;
+                    $demi_j_deb = _('divers_pm_short');
                 }
-                if($sql_demi_jour_fin=="am") {
-                    $demi_j_fin =  _('divers_am_short') ;
+                if ($sql_demi_jour_fin == "am") {
+                    $demi_j_fin = _('divers_am_short');
                 } else {
-                    $demi_j_fin =  _('divers_pm_short') ;
+                    $demi_j_fin = _('divers_pm_short');
                 }
 
                 // on construit la chaine qui servira de valeur à passer dans les boutons-radio
                 $chaine_bouton_radio = "$user_login--$sql_nb_jours--$sql_type--$sql_date_deb--$sql_demi_jour_deb--$sql_date_fin--$sql_demi_jour_fin";
 
                 // si le user fait l'objet d'une double validation on a pas le meme resultat sur le bouton !
-                if($tab_user['double_valid'] == "Y") {
+                if ($tab_user['double_valid'] == "Y") {
                     /*******************************/
                     /* verif si le resp est grand_responsable pour ce user*/
-                    if(in_array($_SESSION['userlogin'], $tab_grd_resp)) { // si resp_login est dans le tableau
-                        $boutonradio1="<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--VALID\">";
+                    if (in_array($_SESSION['userlogin'], $tab_grd_resp)) {
+                        // si resp_login est dans le tableau
+                        $boutonradio1 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--VALID\">";
                     } else {
-                        $boutonradio1="<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--ACCEPTE\">";
+                        $boutonradio1 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--ACCEPTE\">";
                     }
                 } else {
-                    $boutonradio1="<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--ACCEPTE\">";
+                    $boutonradio1 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--ACCEPTE\">";
                 }
 
                 $boutonradio2 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--REFUSE\">";
 
-                $text_refus  = "<input type=\"text\" name=\"tab_text_refus[$sql_num]\" size=\"20\" max=\"100\">";
+                $text_refus = "<input type=\"text\" name=\"tab_text_refus[$sql_num]\" size=\"20\" max=\"100\">";
 
                 $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
                 $return .= '<td>' . $sql_date_deb_fr . '_' . $demi_j_deb . '</td>';
-                $return .= '<td>' . $sql_date_fin_fr . '_'  . $demi_j_fin . '</td>';
+                $return .= '<td>' . $sql_date_fin_fr . '_' . $demi_j_fin . '</td>';
                 $return .= '<td>' . $sql_nb_jours . '</td>';
                 $return .= '<td>' . $sql_commentaire . '</td>';
                 $return .= '<td>' . $tab_type_all_abs[$sql_type]['libelle'] . '</td>';
                 $return .= '<td>' . $boutonradio1 . '</td>';
                 $return .= '<td>' . $boutonradio2 . '</td>';
                 $return .= '<td>' . $text_refus . '</td>';
-                if( $_SESSION['config']['affiche_date_traitement'] ) {
-                    if($sql_date_traitement==NULL) {
+                if ($_SESSION['config']['affiche_date_traitement']) {
+                    if ($sql_date_traitement == null) {
                         $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_date_demande . '<br>' . _('divers_traitement') . ' : pas traité</td>';
                     } else {
                         $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_date_traitement . '</td>';
@@ -945,14 +951,14 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage($user_login,  $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date, $onglet)
+    public static function affichage($user_login, $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date, $onglet)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id();
-        $return = '';
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session  = session_id();
+        $return   = '';
 
         // on initialise le tableau global des jours fériés s'il ne l'est pas déjà :
-        if(!isset($_SESSION["tab_j_feries"])) {
+        if (!isset($_SESSION["tab_j_feries"])) {
             init_tab_jours_feries();
         }
 
@@ -960,20 +966,19 @@ class Fonctions
         /* Récupération des informations sur le user : */
         /********************/
         $list_group_dbl_valid_du_resp = get_list_groupes_double_valid_du_resp($_SESSION['userlogin']);
-        $tab_user=array();
-        $tab_user = recup_infos_du_user($user_login, $list_group_dbl_valid_du_resp);
-        $list_all_users_du_hr=\hr\Fonctions::get_list_all_users_du_hr($_SESSION['userlogin']);
+        $tab_user                     = array();
+        $tab_user                     = recup_infos_du_user($user_login, $list_group_dbl_valid_du_resp);
+        $list_all_users_du_hr         = \hr\Fonctions::get_list_all_users_du_hr($_SESSION['userlogin']);
         // recup des grd resp du user
-        $tab_grd_resp=array();
-        if($_SESSION['config']['double_validation_conges']) {
+        $tab_grd_resp = array();
+        if ($_SESSION['config']['double_validation_conges']) {
             get_tab_grd_resp_du_user($user_login, $tab_grd_resp);
         }
 
         /********************/
         /* Titre */
         /********************/
-        $return .= '<h2>'. _('resp_traite_user_titre') . ' ' . $tab_user['prenom'] . ' ' . $tab_user['nom'] . '.</h2>';
-
+        $return .= '<h2>' . _('resp_traite_user_titre') . ' ' . $tab_user['prenom'] . ' ' . $tab_user['nom'] . '.</h2>';
 
         /********************/
         /* Bilan des Conges */
@@ -992,7 +997,7 @@ class Fonctions
         if ((false == $_SESSION['config']['dimanche_travail'])
             && (false == $_SESSION['config']['samedi_travail'])
         ) {
-            $daysOfWeekDisabled = [0,6];
+            $daysOfWeekDisabled = [0, 6];
         } else {
             if (false == $_SESSION['config']['dimanche_travail']) {
                 $daysOfWeekDisabled = [0];
@@ -1013,7 +1018,7 @@ class Fonctions
                 $datesDisabled[] = \App\Helpers\Formatter::dateIso2Fr($date);
             }
         }
-        $startDate =  '';
+        $startDate = '';
 
         $datePickerOpts = [
             'daysOfWeekDisabled' => $daysOfWeekDisabled,
@@ -1021,19 +1026,19 @@ class Fonctions
             'startDate'          => $startDate,
         ];
         $return .= '<script>generateDatePicker(' . json_encode($datePickerOpts) . ');</script>';
-            
+
         // si les mois et année ne sont pas renseignés, on prend ceux du jour
-        if($year_calendrier_saisie_debut==0) {
-            $year_calendrier_saisie_debut=date("Y");
+        if ($year_calendrier_saisie_debut == 0) {
+            $year_calendrier_saisie_debut = date("Y");
         }
-        if($mois_calendrier_saisie_debut==0) {
-            $mois_calendrier_saisie_debut=date("m");
+        if ($mois_calendrier_saisie_debut == 0) {
+            $mois_calendrier_saisie_debut = date("m");
         }
-        if($year_calendrier_saisie_fin==0) {
-            $year_calendrier_saisie_fin=date("Y");
+        if ($year_calendrier_saisie_fin == 0) {
+            $year_calendrier_saisie_fin = date("Y");
         }
-        if($mois_calendrier_saisie_fin==0) {
-            $mois_calendrier_saisie_fin=date("m");
+        if ($mois_calendrier_saisie_fin == 0) {
+            $mois_calendrier_saisie_fin = date("m");
         }
         $return .= '<h3>' . _('resp_traite_user_new_conges') . '</h3>';
 
@@ -1044,9 +1049,9 @@ class Fonctions
         /*********************/
         /* Etat des Demandes */
         /*********************/
-        if($_SESSION['config']['user_saisie_demande']) {
+        if ($_SESSION['config']['user_saisie_demande']) {
             //verif si le user est bien un user du resp (et pas seulement du grad resp)
-            if(strstr($list_all_users_du_hr, "'$user_login'")!=FALSE) {
+            if (strstr($list_all_users_du_hr, "'$user_login'") != false) {
                 $return .= '<h3>' . _('resp_traite_user_etat_demandes') . '</h3>';
 
                 //affiche l'état des demande du user (avec le formulaire pour le responsable)
@@ -1059,11 +1064,11 @@ class Fonctions
         /*********************/
         /* Etat des Demandes en attente de 2ieme validation */
         /*********************/
-        if($_SESSION['config']['double_validation_conges']) {
+        if ($_SESSION['config']['double_validation_conges']) {
             /*******************************/
             /* verif si le resp est grand_responsable pour ce user*/
 
-            if(in_array($_SESSION['userlogin'], $tab_grd_resp)) // si resp_login est dans le tableau
+            if (in_array($_SESSION['userlogin'], $tab_grd_resp)) // si resp_login est dans le tableau
             {
                 $return .= '<h3>' . _('resp_traite_user_etat_demandes_2_valid') . '</h3>';
 
@@ -1080,7 +1085,7 @@ class Fonctions
         $return .= '<h3>' . _('resp_traite_user_etat_conges') . '</h3>';
 
         //affiche l'état des conges du user (avec le formulaire pour le responsable)
-        $return .= \hr\Fonctions::affiche_etat_conges_user_for_resp($user_login,  $year_affichage, $tri_date);
+        $return .= \hr\Fonctions::affiche_etat_conges_user_for_resp($user_login, $year_affichage, $tri_date);
 
         //echo "<hr align=\"center\" size=\"2\" width=\"90%\"> \n";
 
@@ -1102,50 +1107,50 @@ class Fonctions
     public static function pageTraiteUserModule($onglet)
     {
         //var pour hr_traite_user.php
-        $user_login                 = htmlentities(getpost_variable('user_login'), ENT_QUOTES | ENT_HTML401);
-        $tab_checkbox_annule        = getpost_variable('tab_checkbox_annule') ;
-        $tab_radio_traite_demande   = getpost_variable('tab_radio_traite_demande') ;
-        $new_demande_conges         = getpost_variable('new_demande_conges', 0) ;
-        $return = '';
+        $user_login               = htmlentities(getpost_variable('user_login'), ENT_QUOTES | ENT_HTML401);
+        $tab_checkbox_annule      = getpost_variable('tab_checkbox_annule');
+        $tab_radio_traite_demande = getpost_variable('tab_radio_traite_demande');
+        $new_demande_conges       = getpost_variable('new_demande_conges', 0);
+        $return                   = '';
 
         // si une annulation de conges a été selectionée :
-        if( $tab_checkbox_annule != '' ) {
-            $tab_text_annul         = getpost_variable('tab_text_annul') ;
+        if ($tab_checkbox_annule != '') {
+            $tab_text_annul = getpost_variable('tab_text_annul');
             $return .= \hr\Fonctions::annule_conges($user_login, $tab_checkbox_annule, $tab_text_annul);
         }
         // si le traitement des demandes a été selectionée :
-        elseif( $tab_radio_traite_demande != '' ) {
-            $tab_text_refus         = getpost_variable('tab_text_refus') ;
+        elseif ($tab_radio_traite_demande != '') {
+            $tab_text_refus = getpost_variable('tab_text_refus');
             $return .= \hr\Fonctions::traite_demandes($user_login, $tab_radio_traite_demande, $tab_text_refus);
         }
         // si un nouveau conges ou absence a été saisi pour un user :
-        elseif( $new_demande_conges == 1 ) {
-            $new_debut          = getpost_variable('new_debut') ;
-            $new_demi_jour_deb  = getpost_variable('new_demi_jour_deb') ;
-            $new_fin            = getpost_variable('new_fin') ;
-            $new_demi_jour_fin  = getpost_variable('new_demi_jour_fin') ;
-            $new_comment        = getpost_variable('new_comment') ;
-            $new_type           = getpost_variable('new_type') ;
+        elseif ($new_demande_conges == 1) {
+            $new_debut         = getpost_variable('new_debut');
+            $new_demi_jour_deb = getpost_variable('new_demi_jour_deb');
+            $new_fin           = getpost_variable('new_fin');
+            $new_demi_jour_fin = getpost_variable('new_demi_jour_fin');
+            $new_comment       = getpost_variable('new_comment');
+            $new_type          = getpost_variable('new_type');
 
-            if( $_SESSION['config']['disable_saise_champ_nb_jours_pris'] ) {
-                $new_nb_jours = compter($user_login, '', $new_debut,  $new_fin, $new_demi_jour_deb, $new_demi_jour_fin, $comment);
-                if ($new_nb_jours <= 0 ) {
-                    $new_nb_jours      = getpost_variable('new_nb_jours');
+            if ($_SESSION['config']['disable_saise_champ_nb_jours_pris']) {
+                $new_nb_jours = compter($user_login, '', $new_debut, $new_fin, $new_demi_jour_deb, $new_demi_jour_fin, $comment);
+                if ($new_nb_jours <= 0) {
+                    $new_nb_jours = getpost_variable('new_nb_jours');
                 }
             } else {
-                $new_nb_jours   = getpost_variable('new_nb_jours') ;
+                $new_nb_jours = getpost_variable('new_nb_jours');
             }
 
             $return .= \hr\Fonctions::new_conges($user_login, "", $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type);
         } else {
-            $year_calendrier_saisie_debut   = getpost_variable('year_calendrier_saisie_debut', 0) ;
-            $mois_calendrier_saisie_debut   = getpost_variable('mois_calendrier_saisie_debut', 0) ;
-            $year_calendrier_saisie_fin     = getpost_variable('year_calendrier_saisie_fin', 0) ;
-            $mois_calendrier_saisie_fin     = getpost_variable('mois_calendrier_saisie_fin', 0) ;
-            $tri_date                       = getpost_variable('tri_date', "ascendant") ;
-            $year_affichage                 = (int) getpost_variable('year_affichage' , date("Y") );
+            $year_calendrier_saisie_debut = getpost_variable('year_calendrier_saisie_debut', 0);
+            $mois_calendrier_saisie_debut = getpost_variable('mois_calendrier_saisie_debut', 0);
+            $year_calendrier_saisie_fin   = getpost_variable('year_calendrier_saisie_fin', 0);
+            $mois_calendrier_saisie_fin   = getpost_variable('mois_calendrier_saisie_fin', 0);
+            $tri_date                     = getpost_variable('tri_date', "ascendant");
+            $year_affichage               = (int) getpost_variable('year_affichage', date("Y"));
 
-            $return .= \hr\Fonctions::affichage($user_login,  $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date, $onglet);
+            $return .= \hr\Fonctions::affichage($user_login, $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date, $onglet);
         }
         return $return;
     }
@@ -1153,18 +1158,20 @@ class Fonctions
     // recup de la liste de tous les groupes pour le mode RH
     public static function get_list_groupes_pour_rh($user_login)
     {
-        $list_group="";
+        $list_group = "";
 
-        $sql1="SELECT g_gid FROM conges_groupe ORDER BY g_gid";
+        $sql1    = "SELECT g_gid FROM conges_groupe ORDER BY g_gid";
         $ReqLog1 = \includes\SQL::query($sql1);
 
-        if($ReqLog1->num_rows != 0) {
+        if ($ReqLog1->num_rows != 0) {
             while ($resultat1 = $ReqLog1->fetch_array()) {
-                $current_group=$resultat1["g_gid"];
-                if($list_group=="")
-                    $list_group="$current_group";
-                else
-                    $list_group=$list_group.", $current_group";
+                $current_group = $resultat1["g_gid"];
+                if ($list_group == "") {
+                    $list_group = "$current_group";
+                } else {
+                    $list_group = $list_group . ", $current_group";
+                }
+
             }
         }
         return $list_group;
@@ -1173,49 +1180,49 @@ class Fonctions
     // on insert l'ajout de conges dans la table periode
     public static function insert_ajout_dans_periode($login, $nb_jours, $id_type_abs, $commentaire)
     {
-        $date_today=date("Y-m-d");
+        $date_today = date("Y-m-d");
 
-        $result=insert_dans_periode($login, $date_today, "am", $date_today, "am", $nb_jours, $commentaire, $id_type_abs, "ajout", 0);
+        $result = insert_dans_periode($login, $date_today, "am", $date_today, "am", $nb_jours, $commentaire, $id_type_abs, "ajout", 0);
     }
 
     public static function ajout_global_groupe($choix_groupe, $tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all)
     {
 
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
+        $session  = session_id();
 
         // recup de la liste des users d'un groupe donné
         $list_users = get_list_users_du_groupe($choix_groupe);
 
-        foreach($tab_new_nb_conges_all as $id_conges => $nb_jours) {
-            if($nb_jours!=0) {
+        foreach ($tab_new_nb_conges_all as $id_conges => $nb_jours) {
+            if ($nb_jours != 0) {
                 $comment = $tab_new_comment_all[$id_conges];
 
-                $sql1="SELECT u_login, u_quotite FROM conges_users WHERE u_login IN ($list_users) ORDER BY u_login ";
+                $sql1    = "SELECT u_login, u_quotite FROM conges_users WHERE u_login IN ($list_users) ORDER BY u_login ";
                 $ReqLog1 = \includes\SQL::query($sql1);
 
                 while ($resultat1 = $ReqLog1->fetch_array()) {
-                    $current_login  =$resultat1["u_login"];
-                    $current_quotite=$resultat1["u_quotite"];
+                    $current_login   = $resultat1["u_login"];
+                    $current_quotite = $resultat1["u_quotite"];
 
-                    if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
-                        $nb_conges=$nb_jours;
+                    if ((!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges] != true)) {
+                        $nb_conges = $nb_jours;
                     } else {
                         // pour arrondir au 1/2 le + proche on  fait x 2, on arrondit, puis on divise par 2
-                        $nb_conges = (ROUND(($nb_jours*($current_quotite/100))*2))/2  ;
+                        $nb_conges = (ROUND(($nb_jours * ($current_quotite / 100)) * 2)) / 2;
                     }
 
-                    $valid=verif_saisie_decimal($nb_conges);
-                    if($valid) {
+                    $valid = verif_saisie_decimal($nb_conges);
+                    if ($valid) {
                         // 1 : on update conges_solde_user
-                        $req_update = 'UPDATE conges_solde_user SET su_solde = su_solde+ '.$nb_conges.'
-                                WHERE  su_login = "'. \includes\SQL::quote($current_login).'" AND su_abs_id = '.intval($id_conges).';';
+                        $req_update = 'UPDATE conges_solde_user SET su_solde = su_solde+ ' . $nb_conges . '
+                                WHERE  su_login = "' . \includes\SQL::quote($current_login) . '" AND su_abs_id = ' . intval($id_conges) . ';';
                         $ReqLog_update = \includes\SQL::query($req_update);
 
                         // 2 : on insert l'ajout de conges dans la table periode
                         // recup du nom du groupe
-                        $groupename= get_group_name_from_id($choix_groupe);
-                        $commentaire =  _('resp_ajout_conges_comment_periode_groupe') ." $groupename";
+                        $groupename  = get_group_name_from_id($choix_groupe);
+                        $commentaire = _('resp_ajout_conges_comment_periode_groupe') . " $groupename";
 
                         // ajout conges
                         \hr\Fonctions::insert_ajout_dans_periode($current_login, $nb_conges, $id_conges, $commentaire);
@@ -1223,7 +1230,7 @@ class Fonctions
                 }
 
                 $group_name = get_group_name_from_id($choix_groupe);
-                if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
+                if ((!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges] != true)) {
                     $comment_log = "ajout conges pour groupe $group_name ($nb_jours jour(s)) ($comment) (calcul proportionnel : No)";
                 } else {
                     $comment_log = "ajout conges pour groupe $group_name ($nb_jours jour(s)) ($comment) (calcul proportionnel : Yes)";
@@ -1236,46 +1243,46 @@ class Fonctions
     public static function ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
         $list_users_du_resp = \hr\Fonctions::get_list_all_users_du_hr($_SESSION['userlogin']);
 
-        foreach($tab_new_nb_conges_all as $id_conges => $nb_jours) {
-            if($nb_jours!=0) {
+        foreach ($tab_new_nb_conges_all as $id_conges => $nb_jours) {
+            if ($nb_jours != 0) {
                 $comment = $tab_new_comment_all[$id_conges];
 
-                $sql1="SELECT u_login, u_quotite FROM conges_users WHERE u_login IN ($list_users_du_resp) ORDER BY u_login ";
+                $sql1    = "SELECT u_login, u_quotite FROM conges_users WHERE u_login IN ($list_users_du_resp) ORDER BY u_login ";
                 $ReqLog1 = \includes\SQL::query($sql1);
 
-                while($resultat1 = $ReqLog1->fetch_array()) {
-                    $current_login  =$resultat1["u_login"];
-                    $current_quotite=$resultat1["u_quotite"];
+                while ($resultat1 = $ReqLog1->fetch_array()) {
+                    $current_login   = $resultat1["u_login"];
+                    $current_quotite = $resultat1["u_quotite"];
 
-                    if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
-                        $nb_conges=$nb_jours;
+                    if ((!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges] != true)) {
+                        $nb_conges = $nb_jours;
                     } else {
                         // pour arrondir au 1/2 le + proche on  fait x 2, on arrondit, puis on divise par 2
-                        $nb_conges = (ROUND(($nb_jours*($current_quotite/100))*2))/2  ;
+                        $nb_conges = (ROUND(($nb_jours * ($current_quotite / 100)) * 2)) / 2;
                     }
-                    $valid=verif_saisie_decimal($nb_conges);
-                    if($valid) {
+                    $valid = verif_saisie_decimal($nb_conges);
+                    if ($valid) {
                         // 1 : update de la table conges_solde_user
-                        $req_update = 'UPDATE conges_solde_user SET su_solde = su_solde + '.$nb_conges.'
-                                WHERE  su_login = "'. \includes\SQL::quote($current_login).'"  AND su_abs_id = "'. \includes\SQL::quote($id_conges).'";';
+                        $req_update = 'UPDATE conges_solde_user SET su_solde = su_solde + ' . $nb_conges . '
+                                WHERE  su_login = "' . \includes\SQL::quote($current_login) . '"  AND su_abs_id = "' . \includes\SQL::quote($id_conges) . '";';
                         $ReqLog_update = \includes\SQL::query($req_update);
 
                         // 2 : on insert l'ajout de conges GLOBAL (pour tous les users) dans la table periode
-                        $commentaire =  _('resp_ajout_conges_comment_periode_all') ;
+                        $commentaire = _('resp_ajout_conges_comment_periode_all');
                         // ajout conges
                         \hr\Fonctions::insert_ajout_dans_periode($current_login, $nb_conges, $id_conges, $commentaire);
                     }
                 }
 
-                if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
+                if ((!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges] != true)) {
                     $comment_log = "ajout conges global ($nb_jours jour(s)) ($comment) (calcul proportionnel : No)";
                 } else {
                     $comment_log = "ajout conges global ($nb_jours jour(s)) ($comment) (calcul proportionnel : Yes)";
@@ -1286,38 +1293,37 @@ class Fonctions
         return $return;
     }
 
-
     public static function ajout_conges($tab_champ_saisie, $tab_commentaire_saisie)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
-        foreach($tab_champ_saisie as $user_name => $tab_conges)   // tab_champ_saisie[$current_login][$id_conges]=valeur du nb de jours ajouté saisi
+        foreach ($tab_champ_saisie as $user_name => $tab_conges) // tab_champ_saisie[$current_login][$id_conges]=valeur du nb de jours ajouté saisi
         {
-          foreach($tab_conges as $id_conges => $user_nb_jours_ajout) {
-            $valid=verif_saisie_decimal($user_nb_jours_ajout);   //verif la bonne saisie du nombre décimal
-            if($valid) {
-              if($user_nb_jours_ajout!=0) {
-                /* Modification de la table conges_users */
-                $sql1 = 'UPDATE conges_solde_user SET su_solde = su_solde+'.$user_nb_jours_ajout.' WHERE su_login="'. \includes\SQL::quote($user_name).'" AND su_abs_id = "'. \includes\SQL::quote($id_conges).'";';
-                /* On valide l'UPDATE dans la table ! */
-                $ReqLog1 = \includes\SQL::query($sql1) ;
+            foreach ($tab_conges as $id_conges => $user_nb_jours_ajout) {
+                $valid = verif_saisie_decimal($user_nb_jours_ajout); //verif la bonne saisie du nombre décimal
+                if ($valid) {
+                    if ($user_nb_jours_ajout != 0) {
+                        /* Modification de la table conges_users */
+                        $sql1 = 'UPDATE conges_solde_user SET su_solde = su_solde+' . $user_nb_jours_ajout . ' WHERE su_login="' . \includes\SQL::quote($user_name) . '" AND su_abs_id = "' . \includes\SQL::quote($id_conges) . '";';
+                        /* On valide l'UPDATE dans la table ! */
+                        $ReqLog1 = \includes\SQL::query($sql1);
 
-                // on insert l'ajout de conges dans la table periode
-                $commentaire =  _('resp_ajout_conges_comment_periode_user') ;
-                \hr\Fonctions::insert_ajout_dans_periode($user_name, $user_nb_jours_ajout, $id_conges, $commentaire);
-              }
+                        // on insert l'ajout de conges dans la table periode
+                        $commentaire = _('resp_ajout_conges_comment_periode_user');
+                        \hr\Fonctions::insert_ajout_dans_periode($user_name, $user_nb_jours_ajout, $id_conges, $commentaire);
+                    }
+                }
             }
-          }
         }
     }
 
     public static function affichage_saisie_globale_groupe($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /***********************************************************************/
         /* SAISIE GROUPE pour tous les utilisateurs */
@@ -1325,7 +1331,7 @@ class Fonctions
         // on établi la liste complète des groupes pour le mode RH
         $list_group = \hr\Fonctions::get_list_groupes_pour_rh($_SESSION['userlogin']);
 
-        if($list_group!="") //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
+        if ($list_group != "") //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
         {
             $return .= '<h2>' . _('resp_ajout_conges_ajout_groupe') . '</h2>';
             $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout_conges" method="POST">';
@@ -1334,25 +1340,25 @@ class Fonctions
             $return .= '<tr>';
             $return .= '<td class="big">' . _('resp_ajout_conges_choix_groupe') . ' : </td>';
             // création du select pour le choix du groupe
-            $text_choix_group="<select name=\"choix_groupe\" >";
-            $sql_group = "SELECT g_gid, g_groupename FROM conges_groupe WHERE g_gid IN ($list_group) ORDER BY g_groupename "  ;
-            $ReqLog_group = \includes\SQL::query($sql_group) ;
+            $text_choix_group = "<select name=\"choix_groupe\" >";
+            $sql_group        = "SELECT g_gid, g_groupename FROM conges_groupe WHERE g_gid IN ($list_group) ORDER BY g_groupename ";
+            $ReqLog_group     = \includes\SQL::query($sql_group);
 
             while ($resultat_group = $ReqLog_group->fetch_array()) {
-                $current_group_id=$resultat_group["g_gid"];
-                $current_group_name=$resultat_group["g_groupename"];
-                $text_choix_group=$text_choix_group."<option value=\"$current_group_id\" >$current_group_name</option>";
+                $current_group_id   = $resultat_group["g_gid"];
+                $current_group_name = $resultat_group["g_groupename"];
+                $text_choix_group   = $text_choix_group . "<option value=\"$current_group_id\" >$current_group_name</option>";
             }
-            $text_choix_group=$text_choix_group."</select>" ;
+            $text_choix_group = $text_choix_group . "</select>";
 
             $return .= '<td colspan="3">' . $text_choix_group . '</td>';
             $return .= '</tr>';
             $return .= '<tr>';
             $return .= '<th colspan="2">' . _('resp_ajout_conges_nb_jours_all_1') . ' ' . _('resp_ajout_conges_nb_jours_all_2') . '</th>';
-            $return .= '<th>' ._('resp_ajout_conges_calcul_prop') . '</th>';
+            $return .= '<th>' . _('resp_ajout_conges_calcul_prop') . '</th>';
             $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
             $return .= '</tr>';
-            foreach($tab_type_conges as $id_conges => $libelle) {
+            foreach ($tab_type_conges as $id_conges => $libelle) {
                 $return .= '<tr>';
                 $return .= '<td><strong>' . $libelle . '<strong></td>';
                 $return .= '<td><input class="form-control" type="text" name="tab_new_nb_conges_all[' . $id_conges . ']" size="6" maxlength="6" value="0"></td>';
@@ -1374,8 +1380,8 @@ class Fonctions
     public static function affichage_saisie_globale_pour_tous($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /************************************************************/
         /* SAISIE GLOBALE pour tous les utilisateurs du responsable */
@@ -1390,7 +1396,7 @@ class Fonctions
         $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
         $return .= '</tr>';
         $return .= '</thead>';
-        foreach($tab_type_conges as $id_conges => $libelle) {
+        foreach ($tab_type_conges as $id_conges => $libelle) {
             $return .= '<tr>';
             $return .= '<td><strong>' . $libelle . '<strong></td>';
             $return .= '<td><input class="form-control" type="text" name="tab_new_nb_conges_all[' . $id_conges . ']" size="6" maxlength="6" value="0"></td>';
@@ -1413,15 +1419,15 @@ class Fonctions
     public static function affichage_saisie_user_par_user($tab_type_conges, $tab_type_conges_exceptionnels, $tab_all_users_du_hr, $tab_all_users_du_grand_resp)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /************************************************************/
         /* SAISIE USER PAR USER pour tous les utilisateurs du responsable */
         $return .= '<h2>Ajout par utilisateur</h2>';
         $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout_conges" method="POST">';
 
-        if( (count($tab_all_users_du_hr)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
+        if ((count($tab_all_users_du_hr) != 0) || (count($tab_all_users_du_grand_resp) != 0)) {
             // AFFICHAGE TITRES TABLEAU
             $return .= '<div class="table-responsive"><table class="table table-hover table-condensed table-striped">';
             $return .= '<thead>';
@@ -1429,54 +1435,54 @@ class Fonctions
             $return .= '<th>' . _('divers_nom_maj_1') . '</th>';
             $return .= '<th>' . _('divers_prenom_maj_1') . '</th>';
             $return .= '<th>' . _('divers_quotite_maj_1') . '</th>';
-            foreach($tab_type_conges as $id_conges => $libelle) {
+            foreach ($tab_type_conges as $id_conges => $libelle) {
                 $return .= '<th>' . $libelle . '<br><i>(' . _('divers_solde') . ')</i></th>';
                 $return .= '<th>' . $libelle . '<br>' . _('resp_ajout_conges_nb_jours_ajout') . '</th>';
             }
             if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-                foreach($tab_type_conges_exceptionnels as $id_conges => $libelle) {
+                foreach ($tab_type_conges_exceptionnels as $id_conges => $libelle) {
                     $return .= '<th>' . $libelle . '<br><i>(' . _('divers_solde') . ')</i></th>';
                     $return .= '<th>' . $libelle . '<br>' . _('resp_ajout_conges_nb_jours_ajout') . '</th>';
                 }
             }
-            $return .= '<th>'. _('divers_comment_maj_1') . '<br></th>';
+            $return .= '<th>' . _('divers_comment_maj_1') . '<br></th>';
             $return .= '</tr>';
             $return .= '</thead>';
             $return .= '<tbody>';
 
             // AFFICHAGE LIGNES TABLEAU
-            $cpt_lignes=0 ;
-            $tab_champ_saisie_conges=array();
+            $cpt_lignes              = 0;
+            $tab_champ_saisie_conges = array();
 
             $i = true;
             // affichage des users dont on est responsable :
-            foreach($tab_all_users_du_hr as $current_login => $tab_current_user) {
+            foreach ($tab_all_users_du_hr as $current_login => $tab_current_user) {
                 $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
                 //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-                $tab_conges=$tab_current_user['conges'];
+                $tab_conges = $tab_current_user['conges'];
 
                 /** sur la ligne ,   **/
                 $return .= '<td>' . $tab_current_user['nom'] . '</td>';
                 $return .= '<td>' . $tab_current_user['prenom'] . '</td>';
                 $return .= '<td>' . $tab_current_user['quotite'] . '%</td>';
 
-                foreach($tab_type_conges as $id_conges => $libelle) {
+                foreach ($tab_type_conges as $id_conges => $libelle) {
                     /** le champ de saisie est <input type="text" name="tab_champ_saisie[valeur de u_login][id_du_type_de_conges]" value="[valeur du nb de jours ajouté saisi]"> */
-                    $champ_saisie_conges="<input class=\"form-control\" type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
+                    $champ_saisie_conges = "<input class=\"form-control\" type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
                     $return .= '<td>' . $tab_conges[$libelle]['nb_an'] . ' <i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
                     $return .= '<td align="center" class="histo">' . $champ_saisie_conges . '</td>';
                 }
                 if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-                    foreach($tab_type_conges_exceptionnels as $id_conges => $libelle) {
+                    foreach ($tab_type_conges_exceptionnels as $id_conges => $libelle) {
                         /** le champ de saisie est <input type="text" name="tab_champ_saisie[valeur de u_login][id_du_type_de_conges]" value="[valeur du nb de jours ajouté saisi]"> */
-                        $champ_saisie_conges="<input class=\"form-control\" type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
+                        $champ_saisie_conges = "<input class=\"form-control\" type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
                         $return .= '<td><i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
                         $return .= '<td align="center" class="histo">' . $champ_saisie_conges . '</td>';
                     }
                 }
                 $return .= '<td align="center" class="histo"><input class="form-control" type="text" name="tab_commentaire_saisie[' . $current_login . ']" size="30" maxlength="200" value=""></td>';
                 $return .= '</tr>';
-                $cpt_lignes++ ;
+                $cpt_lignes++;
                 $i = !$i;
             }
 
@@ -1495,47 +1501,45 @@ class Fonctions
     // renvoit un tableau de tableau contenant les informations de tous les users dont $login est HR responsable
     public static function recup_infos_all_users_du_hr($login)
     {
-        $tab=array();
-        $list_groupes_double_validation=get_list_groupes_double_valid();
+        $tab                            = array();
+        $list_groupes_double_validation = get_list_groupes_double_valid();
 
-        $sql1 = "SELECT u_login FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_nom";
-        $ReqLog = \includes\SQL::query($sql1) ;
+        $sql1   = "SELECT u_login FROM conges_users WHERE u_login!='conges' AND u_login!='admin' ORDER BY u_nom";
+        $ReqLog = \includes\SQL::query($sql1);
 
-        while ($resultat = $ReqLog->fetch_array())
-        {
-            $tab_user=array();
-            $sql_login=$resultat["u_login"];
+        while ($resultat = $ReqLog->fetch_array()) {
+            $tab_user        = array();
+            $sql_login       = $resultat["u_login"];
             $tab[$sql_login] = recup_infos_du_user($sql_login, $list_groupes_double_validation);
         }
-        return $tab ;
+        return $tab;
     }
 
     // recup de la liste de TOUS les users pour le responsable RH
     // renvoit une liste de login entre quotes et séparés par des virgules
     public static function get_list_all_users_du_hr($resp_login)
     {
-        $list_users="";
+        $list_users = "";
 
-        $sql1="SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin'  ORDER BY u_nom  ";
+        $sql1    = "SELECT DISTINCT(u_login) FROM conges_users WHERE u_login!='conges' AND u_login!='admin'  ORDER BY u_nom  ";
         $ReqLog1 = \includes\SQL::query($sql1);
 
-        while ($resultat1 = $ReqLog1->fetch_array())
-        {
-            $current_login=$resultat1["u_login"];
-                if($list_users=="") {
-                    $list_users="'$current_login'";
-                } else {
-                    $list_users=$list_users.", '$current_login'";
-                }
+        while ($resultat1 = $ReqLog1->fetch_array()) {
+            $current_login = $resultat1["u_login"];
+            if ($list_users == "") {
+                $list_users = "'$current_login'";
+            } else {
+                $list_users = $list_users . ", '$current_login'";
+            }
         }
         return $list_users;
     }
 
-    public static function saisie_ajout( $tab_type_conges)
+    public static function saisie_ajout($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // recup du tableau des types de conges (seulement les congesexceptionnels )
         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
@@ -1547,10 +1551,10 @@ class Fonctions
         // recup de la liste de TOUS les users pour le RH
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
-        $tab_all_users_du_hr=\hr\Fonctions::recup_infos_all_users_du_hr($_SESSION['userlogin']);
-        $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
+        $tab_all_users_du_hr         = \hr\Fonctions::recup_infos_all_users_du_hr($_SESSION['userlogin']);
+        $tab_all_users_du_grand_resp = recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
 
-        if( (count($tab_all_users_du_hr)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
+        if ((count($tab_all_users_du_hr) != 0) || (count($tab_all_users_du_grand_resp) != 0)) {
             /************************************************************/
             /* SAISIE GLOBALE pour tous les utilisateurs du responsable */
             $return .= \hr\Fonctions::affichage_saisie_globale_pour_tous($tab_type_conges);
@@ -1558,7 +1562,7 @@ class Fonctions
 
             /***********************************************************************/
             /* SAISIE GROUPE pour tous les utilisateurs d'un groupe du responsable */
-            if( $_SESSION['config']['gestion_groupes'] ) {
+            if ($_SESSION['config']['gestion_groupes']) {
                 $return .= \hr\Fonctions::affichage_saisie_globale_groupe($tab_type_conges);
             }
             $return .= '<br>';
@@ -1591,36 +1595,36 @@ class Fonctions
         $ajout_global = getpost_variable('ajout_global');
         $ajout_groupe = getpost_variable('ajout_groupe');
         $choix_groupe = getpost_variable('choix_groupe');
-        $return = '';
+        $return       = '';
 
         // titre
-        $return .= '<h1>'. _('resp_ajout_conges_titre') . '</h1>';
+        $return .= '<h1>' . _('resp_ajout_conges_titre') . '</h1>';
 
-        if( $ajout_conges == "TRUE" ) {
-            $tab_champ_saisie            = getpost_variable('tab_champ_saisie');
-            $tab_commentaire_saisie        = getpost_variable('tab_commentaire_saisie');
+        if ($ajout_conges == "TRUE") {
+            $tab_champ_saisie       = getpost_variable('tab_champ_saisie');
+            $tab_commentaire_saisie = getpost_variable('tab_commentaire_saisie');
 
             $return .= \hr\Fonctions::ajout_conges($tab_champ_saisie, $tab_commentaire_saisie);
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
+            redirect(ROOT_PATH . 'hr/hr_index.php?session=' . $session, false);
             exit;
-        } elseif( $ajout_global == "TRUE" ) {
+        } elseif ($ajout_global == "TRUE") {
 
-            $tab_new_nb_conges_all       = getpost_variable('tab_new_nb_conges_all');
-            $tab_calcul_proportionnel    = getpost_variable('tab_calcul_proportionnel');
-            $tab_new_comment_all         = getpost_variable('tab_new_comment_all');
+            $tab_new_nb_conges_all    = getpost_variable('tab_new_nb_conges_all');
+            $tab_calcul_proportionnel = getpost_variable('tab_calcul_proportionnel');
+            $tab_new_comment_all      = getpost_variable('tab_new_comment_all');
 
             $return .= \hr\Fonctions::ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all);
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
+            redirect(ROOT_PATH . 'hr/hr_index.php?session=' . $session, false);
             exit;
-        } elseif( $ajout_groupe == "TRUE" ) {
+        } elseif ($ajout_groupe == "TRUE") {
 
-            $tab_new_nb_conges_all       = getpost_variable('tab_new_nb_conges_all');
-            $tab_calcul_proportionnel    = getpost_variable('tab_calcul_proportionnel');
-            $tab_new_comment_all         = getpost_variable('tab_new_comment_all');
-            $choix_groupe                = getpost_variable('choix_groupe');
+            $tab_new_nb_conges_all    = getpost_variable('tab_new_nb_conges_all');
+            $tab_calcul_proportionnel = getpost_variable('tab_calcul_proportionnel');
+            $tab_new_comment_all      = getpost_variable('tab_new_comment_all');
+            $choix_groupe             = getpost_variable('choix_groupe');
 
             \hr\Fonctions::ajout_global_groupe($choix_groupe, $tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all);
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
+            redirect(ROOT_PATH . 'hr/hr_index.php?session=' . $session, false);
             exit;
         } else {
             $return .= \hr\Fonctions::saisie_ajout($tab_type_cong);
@@ -1635,22 +1639,22 @@ class Fonctions
     {
 
         //Initialisation de variables
-        $iCstJour = 3600*24;
-        $tbJourFerie=array();
+        $iCstJour    = 3600 * 24;
+        $tbJourFerie = array();
 
         // Détermination des dates toujours fixes
-        $tbJourFerie["Jour de l an"]     = $iAnnee . "-01-01";
-        $tbJourFerie["Armistice 39-45"]  = $iAnnee . "-05-08";
-        $tbJourFerie["Toussaint"]        = $iAnnee . "-11-01";
-        $tbJourFerie["Armistice 14-18"]  = $iAnnee . "-11-11";
-        $tbJourFerie["Assomption"]       = $iAnnee . "-08-15";
-        $tbJourFerie["Fete du travail"]  = $iAnnee . "-05-01";
-        $tbJourFerie["Fete nationale"]   = $iAnnee . "-07-14";
-        $tbJourFerie["Noel"]    = $iAnnee . "-12-25";
+        $tbJourFerie["Jour de l an"]    = $iAnnee . "-01-01";
+        $tbJourFerie["Armistice 39-45"] = $iAnnee . "-05-08";
+        $tbJourFerie["Toussaint"]       = $iAnnee . "-11-01";
+        $tbJourFerie["Armistice 14-18"] = $iAnnee . "-11-11";
+        $tbJourFerie["Assomption"]      = $iAnnee . "-08-15";
+        $tbJourFerie["Fete du travail"] = $iAnnee . "-05-01";
+        $tbJourFerie["Fete nationale"]  = $iAnnee . "-07-14";
+        $tbJourFerie["Noel"]            = $iAnnee . "-12-25";
 
         // Récupération des fêtes mobiles
-             $tbJourFerie["Lundi de Paques"]   = $iAnnee . date( "-m-d", easter_date($iAnnee) + 1*$iCstJour );
-             $tbJourFerie["Jeudi de l ascension"] = $iAnnee . date( "-m-d", easter_date($iAnnee) + 39*$iCstJour );
+        $tbJourFerie["Lundi de Paques"]      = $iAnnee . date("-m-d", easter_date($iAnnee) + 1 * $iCstJour);
+        $tbJourFerie["Jeudi de l ascension"] = $iAnnee . date("-m-d", easter_date($iAnnee) + 39 * $iCstJour);
 
         // Retour du tableau des jours fériés pour l'année demandée
         return $tbJourFerie;
@@ -1660,51 +1664,55 @@ class Fonctions
     public static function get_tableau_jour_feries($year, &$tab_year)
     {
 
-        $sql_select='SELECT jf_date FROM conges_jours_feries WHERE jf_date LIKE "'. \includes\SQL::quote($year).'-%" ;';
+        $sql_select = 'SELECT jf_date FROM conges_jours_feries WHERE jf_date LIKE "' . \includes\SQL::quote($year) . '-%" ;';
         $res_select = \includes\SQL::query($sql_select);
         $num_select = $res_select->num_rows;
 
-        if($num_select!=0) {
-            while($result_select = $res_select->fetch_array()) {
-                $tab_year[]=$result_select["jf_date"];
+        if ($num_select != 0) {
+            while ($result_select = $res_select->fetch_array()) {
+                $tab_year[] = $result_select["jf_date"];
             }
         }
     }
 
-    public static function verif_year_deja_saisie($tab_checkbox_j_chome) {
-        $date_1=key($tab_checkbox_j_chome);
-        $year=substr($date_1, 0, 4);
-        $sql_select='SELECT jf_date FROM conges_jours_feries WHERE jf_date LIKE "'. \includes\SQL::quote($year).'%" ;';
-        $relog = \includes\SQL::query($sql_select);
-        return($relog->num_rows != 0);
+    public static function verif_year_deja_saisie($tab_checkbox_j_chome)
+    {
+        $date_1     = key($tab_checkbox_j_chome);
+        $year       = substr($date_1, 0, 4);
+        $sql_select = 'SELECT jf_date FROM conges_jours_feries WHERE jf_date LIKE "' . \includes\SQL::quote($year) . '%" ;';
+        $relog      = \includes\SQL::query($sql_select);
+        return ($relog->num_rows != 0);
     }
 
-    public static function delete_year($tab_checkbox_j_chome) {
-        $date_1=key($tab_checkbox_j_chome);
-        $year=substr($date_1, 0, 4);
-        $sql_delete='DELETE FROM conges_jours_feries WHERE jf_date LIKE "'. \includes\SQL::quote($year).'%" ;';
-        $result = \includes\SQL::query($sql_delete);
+    public static function delete_year($tab_checkbox_j_chome)
+    {
+        $date_1     = key($tab_checkbox_j_chome);
+        $year       = substr($date_1, 0, 4);
+        $sql_delete = 'DELETE FROM conges_jours_feries WHERE jf_date LIKE "' . \includes\SQL::quote($year) . '%" ;';
+        $result     = \includes\SQL::query($sql_delete);
 
         return true;
     }
 
-    public static function insert_year($tab_checkbox_j_chome) {
-        foreach($tab_checkbox_j_chome as $key => $value)
-            $result = \includes\SQL::query('INSERT INTO conges_jours_feries SET jf_date="'. \includes\SQL::quote($key).'";');
+    public static function insert_year($tab_checkbox_j_chome)
+    {
+        foreach ($tab_checkbox_j_chome as $key => $value) {
+            $result = \includes\SQL::query('INSERT INTO conges_jours_feries SET jf_date="' . \includes\SQL::quote($key) . '";');
+        }
+
         return true;
     }
 
     public static function commit_saisie($tab_checkbox_j_chome)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // si l'année est déja renseignée dans la database, on efface ttes les dates de l'année
-        if(\hr\Fonctions::verif_year_deja_saisie($tab_checkbox_j_chome)) {
+        if (\hr\Fonctions::verif_year_deja_saisie($tab_checkbox_j_chome)) {
             $result = \hr\Fonctions::delete_year($tab_checkbox_j_chome);
         }
-
 
         // on insert les nouvelles dates saisies
         $result = \hr\Fonctions::insert_year($tab_checkbox_j_chome);
@@ -1712,15 +1720,15 @@ class Fonctions
         // on recharge les jours feries dans les variables de session
         init_tab_jours_feries();
 
-        if($result) {
+        if ($result) {
             $return .= '<div class="alert alert-success">' . _('form_modif_ok') . '</div>';
         } else {
             $return .= '<div class="alert alert-danger">' . _('form_modif_not_ok') . '</div>';
         }
 
-        $date_1=key($tab_checkbox_j_chome);
-        $tab_date = explode('-', $date_1);
-        $comment_log = "saisie des jours chomés pour ".$tab_date[0] ;
+        $date_1      = key($tab_checkbox_j_chome);
+        $tab_date    = explode('-', $date_1);
+        $comment_log = "saisie des jours chomés pour " . $tab_date[0];
         log_action(0, "", "", $comment_log);
         return $return;
     }
@@ -1728,8 +1736,8 @@ class Fonctions
     public static function confirm_saisie($tab_checkbox_j_chome)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         header_popup();
 
@@ -1739,8 +1747,8 @@ class Fonctions
         $return .= '<tr>';
         $return .= '<td align="center">';
 
-        foreach($tab_checkbox_j_chome as $key => $value) {
-            $date_affiche=eng_date_to_fr($key);
+        foreach ($tab_checkbox_j_chome as $key => $value) {
+            $date_affiche = eng_date_to_fr($key);
             $return .= $date_affiche . '<br>';
             $return .= '<input type="hidden" name="tab_checkbox_j_chome[' . $key . ']" value="' . $value . '">';
         }
@@ -1759,18 +1767,20 @@ class Fonctions
         bottom();
     }
 
-    public static function affiche_jour_hors_mois($mois,$i,$year,$tab_year) {
-        $j_timestamp=mktime (0,0,0,$mois,$i,$year);
-        $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
+    public static function affiche_jour_hors_mois($mois, $i, $year, $tab_year)
+    {
+        $j_timestamp     = mktime(0, 0, 0, $mois, $i, $year);
+        $td_second_class = get_td_class_of_the_day_in_the_week($j_timestamp);
         return "<td class=\"cal-saisie2 month-out $td_second_class\">&nbsp;</td>\n";
     }
 
-    public static function affiche_jour_checkbox($mois,$i,$year,$tab_year) {
-        $j_timestamp=mktime (0,0,0,$mois,$i,$year);
-        $j_date=date("Y-m-d", $j_timestamp);
-        $j_day=date("d", $j_timestamp);
-        $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
-        $checked = in_array ("$j_date", $tab_year);
+    public static function affiche_jour_checkbox($mois, $i, $year, $tab_year)
+    {
+        $j_timestamp     = mktime(0, 0, 0, $mois, $i, $year);
+        $j_date          = date("Y-m-d", $j_timestamp);
+        $j_day           = date("d", $j_timestamp);
+        $td_second_class = get_td_class_of_the_day_in_the_week($j_timestamp);
+        $checked         = in_array("$j_date", $tab_year);
 
         return "<td  class=\"cal-saisie $td_second_class" . (($checked) ? ' fermeture' : '') . "\">$j_day<input type=\"checkbox\" name=\"tab_checkbox_j_chome[$j_date]\" value=\"Y\"" . (($checked) ? ' checked' : '') . "></td>\n";
     }
@@ -1779,15 +1789,15 @@ class Fonctions
     // on lui passe en parametre le tableau des jour chomé de l'année (pour pré-cocher certaines cases)
     public static function affiche_calendrier_saisie_jours_chomes($year, $mois, $tab_year)
     {
-        $jour_today=date("j");
-        $jour_today_name=date("D");
-        $return = '';
+        $jour_today      = date("j");
+        $jour_today_name = date("D");
+        $return          = '';
 
-        $first_jour_mois_timestamp=mktime (0,0,0,$mois,1,$year);
-        $mois_name=date_fr("F", $first_jour_mois_timestamp);
-        $first_jour_mois_rang=date("w", $first_jour_mois_timestamp);      // jour de la semaine en chiffre (0=dim , 6=sam)
-        if($first_jour_mois_rang==0) {
-            $first_jour_mois_rang=7 ;    // jour de la semaine en chiffre (1=lun , 7=dim)
+        $first_jour_mois_timestamp = mktime(0, 0, 0, $mois, 1, $year);
+        $mois_name                 = date_fr("F", $first_jour_mois_timestamp);
+        $first_jour_mois_rang      = date("w", $first_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
+        if ($first_jour_mois_rang == 0) {
+            $first_jour_mois_rang = 7; // jour de la semaine en chiffre (1=lun , 7=dim)
         }
 
         $return .= '<table>';
@@ -1808,56 +1818,56 @@ class Fonctions
         /* affichage ligne 1 du mois*/
         $return .= '<tr>';
         // affichage des cellules vides jusqu'au 1 du mois ...
-        for($i=1; $i<$first_jour_mois_rang; $i++) {
-            $return .= \hr\Fonctions::affiche_jour_hors_mois($mois,$i,$year,$tab_year);
+        for ($i = 1; $i < $first_jour_mois_rang; $i++) {
+            $return .= \hr\Fonctions::affiche_jour_hors_mois($mois, $i, $year, $tab_year);
         }
         // affichage des cellules cochables du 1 du mois à la fin de la ligne ...
-        for($i=$first_jour_mois_rang; $i<8; $i++) {
-            $j=$i-$first_jour_mois_rang+1;
-            $return .= \hr\Fonctions::affiche_jour_checkbox($mois,$j,$year,$tab_year);
+        for ($i = $first_jour_mois_rang; $i < 8; $i++) {
+            $j = $i - $first_jour_mois_rang + 1;
+            $return .= \hr\Fonctions::affiche_jour_checkbox($mois, $j, $year, $tab_year);
         }
         $return .= '</tr>';
 
         /* affichage ligne 2 du mois*/
         $return .= '<tr>';
-        for($i=8-$first_jour_mois_rang+1; $i<15-$first_jour_mois_rang+1; $i++) {
-            $return .= \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
+        for ($i = 8 - $first_jour_mois_rang + 1; $i < 15 - $first_jour_mois_rang + 1; $i++) {
+            $return .= \hr\Fonctions::affiche_jour_checkbox($mois, $i, $year, $tab_year);
         }
         $return .= '</tr>';
 
         /* affichage ligne 3 du mois*/
         $return .= '<tr>';
-        for($i=15-$first_jour_mois_rang+1; $i<22-$first_jour_mois_rang+1; $i++) {
-            $return .= \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
+        for ($i = 15 - $first_jour_mois_rang + 1; $i < 22 - $first_jour_mois_rang + 1; $i++) {
+            $return .= \hr\Fonctions::affiche_jour_checkbox($mois, $i, $year, $tab_year);
         }
         $return .= '</tr>';
 
         /* affichage ligne 4 du mois*/
         $return .= '<tr>';
-        for($i=22-$first_jour_mois_rang+1; $i<29-$first_jour_mois_rang+1; $i++) {
-            $return .= \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
+        for ($i = 22 - $first_jour_mois_rang + 1; $i < 29 - $first_jour_mois_rang + 1; $i++) {
+            $return .= \hr\Fonctions::affiche_jour_checkbox($mois, $i, $year, $tab_year);
         }
         $return .= '</tr>';
 
         /* affichage ligne 5 du mois (peut etre la derniere ligne) */
         $return .= '<tr>';
-        for($i=29-$first_jour_mois_rang+1; $i<36-$first_jour_mois_rang+1 && checkdate($mois, $i, $year); $i++) {
-            $return .= \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
+        for ($i = 29 - $first_jour_mois_rang + 1; $i < 36 - $first_jour_mois_rang + 1 && checkdate($mois, $i, $year); $i++) {
+            $return .= \hr\Fonctions::affiche_jour_checkbox($mois, $i, $year, $tab_year);
         }
 
-        for($i; $i<36-$first_jour_mois_rang+1; $i++) {
-            $return .= \hr\Fonctions::affiche_jour_hors_mois($mois,$i,$year,$tab_year);
+        for ($i; $i < 36 - $first_jour_mois_rang + 1; $i++) {
+            $return .= \hr\Fonctions::affiche_jour_hors_mois($mois, $i, $year, $tab_year);
         }
         $return .= '</tr>';
 
         /* affichage ligne 6 du mois (derniere ligne)*/
         $return .= '<tr>';
-        for($i=36-$first_jour_mois_rang+1; checkdate($mois, $i, $year); $i++) {
-            $return .= \hr\Fonctions::affiche_jour_checkbox($mois,$i,$year,$tab_year);
+        for ($i = 36 - $first_jour_mois_rang + 1; checkdate($mois, $i, $year); $i++) {
+            $return .= \hr\Fonctions::affiche_jour_checkbox($mois, $i, $year, $tab_year);
         }
 
-        for($i; $i<43-$first_jour_mois_rang+1; $i++) {
-            $return .= \hr\Fonctions::affiche_jour_hors_mois($mois,$i,$year,$tab_year);
+        for ($i; $i < 43 - $first_jour_mois_rang + 1; $i++) {
+            $return .= \hr\Fonctions::affiche_jour_hors_mois($mois, $i, $year, $tab_year);
         }
         $return .= '</tr></table>';
 
@@ -1867,24 +1877,26 @@ class Fonctions
     public static function saisie($year_calendrier_saisie)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // si l'année n'est pas renseignée, on prend celle du jour
-        if($year_calendrier_saisie==0) {
+        if ($year_calendrier_saisie == 0) {
             $year_calendrier_saisie = date("Y");
         }
 
         // on construit le tableau des jours feries de l'année considérée
-        $tab_year=array();
+        $tab_year = array();
         \hr\Fonctions::get_tableau_jour_feries($year_calendrier_saisie, $tab_year);
 
         //calcul automatique des jours feries
-        if($_SESSION['config']['calcul_auto_jours_feries_france']) {
-            $tableau_jour_feries = \hr\Fonctions::fcListJourFeries($year_calendrier_saisie) ;
+        if ($_SESSION['config']['calcul_auto_jours_feries_france']) {
+            $tableau_jour_feries = \hr\Fonctions::fcListJourFeries($year_calendrier_saisie);
             foreach ($tableau_jour_feries as $i => $value) {
-                if(!in_array ("$value", $tab_year))
+                if (!in_array("$value", $tab_year)) {
                     $tab_year[] = $value;
+                }
+
             }
         }
         $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=jours_chomes&year_calendrier_saisie=' . $year_calendrier_saisie . '" method="POST">';
@@ -1928,14 +1940,14 @@ class Fonctions
         // SERVER
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         // GET / POST
-        $choix_action                 = getpost_variable('choix_action');
-        $year_calendrier_saisie        = getpost_variable('year_calendrier_saisie', 0);
-        $checkbox = getpost_variable('tab_checkbox_j_chome');
-        $tab_checkbox_j_chome = (!is_array($checkbox) || empty($checkbox)) ? [] : $checkbox;
+        $choix_action           = getpost_variable('choix_action');
+        $year_calendrier_saisie = getpost_variable('year_calendrier_saisie', 0);
+        $checkbox               = getpost_variable('tab_checkbox_j_chome');
+        $tab_checkbox_j_chome   = (!is_array($checkbox) || empty($checkbox)) ? [] : $checkbox;
         /*************************************/
 
         // si l'année n'est pas renseignée, on prend celle du jour
-        if($year_calendrier_saisie==0) {
+        if ($year_calendrier_saisie == 0) {
             $year_calendrier_saisie = date("Y");
         }
 
@@ -1946,8 +1958,8 @@ class Fonctions
         $return .= '<div class="pager">';
         $return .= '<div class="onglet calendar-nav">';
         // navigation
-        $prev_link = "$PHP_SELF?session=$session&onglet=jours_chomes&year_calendrier_saisie=". ($year_calendrier_saisie - 1);
-        $next_link = "$PHP_SELF?session=$session&onglet=jours_chomes&year_calendrier_saisie=". ($year_calendrier_saisie + 1);
+        $prev_link = "$PHP_SELF?session=$session&onglet=jours_chomes&year_calendrier_saisie=" . ($year_calendrier_saisie - 1);
+        $next_link = "$PHP_SELF?session=$session&onglet=jours_chomes&year_calendrier_saisie=" . ($year_calendrier_saisie + 1);
         $return .= '<ul>';
         $return .= '<li><a href="' . $prev_link . '" class="calendar-prev"><i class="fa fa-chevron-left"></i><span>année précédente</span></a></li>';
         $return .= '&nbsp;<li class="current-year">' . $year_calendrier_saisie . '</li>';
@@ -1955,7 +1967,7 @@ class Fonctions
         $return .= '</ul>';
         $return .= '</div>';
         $return .= '</div>';
-        if($choix_action=="commit") {
+        if ($choix_action == "commit") {
             $return .= \hr\Fonctions::commit_saisie($tab_checkbox_j_chome);
         }
         $return .= '<div class="wrapper">';
@@ -1968,18 +1980,18 @@ class Fonctions
     public static function set_nouvelle_date_limite_reliquat()
     {
         //si on autorise les reliquats
-        if($_SESSION['config']['autorise_reliquats_exercice']) {
+        if ($_SESSION['config']['autorise_reliquats_exercice']) {
             // s'il y a une date limite d'utilisationdes reliquats (au format jj-mm)
-            if($_SESSION['config']['jour_mois_limite_reliquats']!=0) {
+            if ($_SESSION['config']['jour_mois_limite_reliquats'] != 0) {
                 // nouvelle date limite au format aaa-mm-jj
-                $t=explode("-", $_SESSION['config']['jour_mois_limite_reliquats']);
-                $new_date_limite = date("Y")."-".$t[1]."-".$t[0];
+                $t               = explode("-", $_SESSION['config']['jour_mois_limite_reliquats']);
+                $new_date_limite = date("Y") . "-" . $t[1] . "-" . $t[0];
 
                 //si la date limite n'a pas encore été updatée
-                if($_SESSION['config']['date_limite_reliquats'] < $new_date_limite) {
+                if ($_SESSION['config']['date_limite_reliquats'] < $new_date_limite) {
                     /* Modification de la table conges_appli */
-                    $sql_update= 'UPDATE conges_appli SET appli_valeur = \''.$new_date_limite.'\' WHERE appli_variable=\'date_limite_reliquats\';';
-                    $ReqLog_update = \includes\SQL::query($sql_update) ;
+                    $sql_update    = 'UPDATE conges_appli SET appli_valeur = \'' . $new_date_limite . '\' WHERE appli_variable=\'date_limite_reliquats\';';
+                    $ReqLog_update = \includes\SQL::query($sql_update);
 
                 }
             }
@@ -1990,16 +2002,16 @@ class Fonctions
     public static function cloture_globale_groupe($group_id, $tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // recup de la liste de TOUS les users du groupe
-        $tab_all_users_du_groupe=recup_infos_all_users_du_groupe($group_id);
-        $comment_cloture =  _('resp_cloture_exercice_commentaire') ." ".date("m/Y");
+        $tab_all_users_du_groupe = recup_infos_all_users_du_groupe($group_id);
+        $comment_cloture         = _('resp_cloture_exercice_commentaire') . " " . date("m/Y");
 
-        if(count($tab_all_users_du_groupe)!=0) {
+        if (count($tab_all_users_du_groupe) != 0) {
             // traitement des users dont on est responsable :
-            foreach($tab_all_users_du_groupe as $current_login => $tab_current_user) {
+            foreach ($tab_all_users_du_groupe as $current_login => $tab_current_user) {
                 $return .= \hr\Fonctions::cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $comment_cloture);
             }
         }
@@ -2010,20 +2022,20 @@ class Fonctions
     public static function cloture_globale($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
-        $tab_all_users_du_hr=\hr\Fonctions::recup_infos_all_users_du_hr($_SESSION['userlogin']);
-        $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
+        $tab_all_users_du_hr         = \hr\Fonctions::recup_infos_all_users_du_hr($_SESSION['userlogin']);
+        $tab_all_users_du_grand_resp = recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
 
-        $comment_cloture =  _('resp_cloture_exercice_commentaire') ." ".date("m/Y");
+        $comment_cloture = _('resp_cloture_exercice_commentaire') . " " . date("m/Y");
 
-        if( (count($tab_all_users_du_hr)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
+        if ((count($tab_all_users_du_hr) != 0) || (count($tab_all_users_du_grand_resp) != 0)) {
             // traitement des users dont on est responsable :
-            foreach($tab_all_users_du_hr as $current_login => $tab_current_user) {
+            foreach ($tab_all_users_du_hr as $current_login => $tab_current_user) {
                 $return .= \hr\Fonctions::cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $comment_cloture);
             }
         }
@@ -2035,17 +2047,17 @@ class Fonctions
     public static function update_appli_num_exercice()
     {
         // verif
-        $appli_num_exercice = $_SESSION['config']['num_exercice'] ;
-        $sql_verif = "SELECT u_login FROM conges_users WHERE u_login != 'admin' AND u_login != 'conges' AND u_num_exercice != $appli_num_exercice "  ;
-        $ReqLog_verif = \includes\SQL::query($sql_verif) ;
+        $appli_num_exercice = $_SESSION['config']['num_exercice'];
+        $sql_verif          = "SELECT u_login FROM conges_users WHERE u_login != 'admin' AND u_login != 'conges' AND u_num_exercice != $appli_num_exercice ";
+        $ReqLog_verif       = \includes\SQL::query($sql_verif);
 
-        if($ReqLog_verif->num_rows == 0) {
+        if ($ReqLog_verif->num_rows == 0) {
             /* Modification de la table conges_appli */
-            $sql_update= "UPDATE conges_appli SET appli_valeur = appli_valeur+1 WHERE appli_variable='num_exercice' ";
-            $ReqLog_update = \includes\SQL::query($sql_update) ;
+            $sql_update    = "UPDATE conges_appli SET appli_valeur = appli_valeur+1 WHERE appli_variable='num_exercice' ";
+            $ReqLog_update = \includes\SQL::query($sql_update);
 
             // ecriture dans les logs
-            $new_appli_num_exercice = $appli_num_exercice+1 ;
+            $new_appli_num_exercice = $appli_num_exercice + 1;
             log_action(0, "", "", "fin/debut exercice (appli_num_exercice : $appli_num_exercice -> $new_appli_num_exercice)");
         }
     }
@@ -2054,70 +2066,70 @@ class Fonctions
     {
         $return = '';
         // si le num d'exercice du user est < à celui de l'appli (il n'a pas encore été basculé): on le bascule d'exercice
-        if($tab_current_user['num_exercice'] < $_SESSION['config']['num_exercice']) {
+        if ($tab_current_user['num_exercice'] < $_SESSION['config']['num_exercice']) {
             // calcule de la date limite d'utilisation des reliquats (si on utilise une date limite et qu'elle n'est pas encore calculée)
             \hr\Fonctions::set_nouvelle_date_limite_reliquat();
 
             //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-            $tab_conges_current_user=$tab_current_user['conges'];
-            foreach($tab_type_conges as $id_conges => $libelle) {
+            $tab_conges_current_user = $tab_current_user['conges'];
+            foreach ($tab_type_conges as $id_conges => $libelle) {
                 $user_nb_jours_ajout_an = $tab_conges_current_user[$libelle]['nb_an'];
-                $user_solde_actuel= $tab_conges_current_user[$libelle]['solde'];
-                $user_reliquat_actuel= $tab_conges_current_user[$libelle]['reliquat'];
+                $user_solde_actuel      = $tab_conges_current_user[$libelle]['solde'];
+                $user_reliquat_actuel   = $tab_conges_current_user[$libelle]['reliquat'];
 
                 /**********************************************/
                 /* Modification de la table conges_solde_user */
 
-                if($_SESSION['config']['autorise_reliquats_exercice']) {
+                if ($_SESSION['config']['autorise_reliquats_exercice']) {
                     // ATTENTION : si le solde du user est négatif, on ne compte pas de reliquat et le nouveau solde est nb_jours_an + le solde actuel (qui est négatif)
-                    if($user_solde_actuel>0) {
+                    if ($user_solde_actuel > 0) {
                         //calcul du reliquat pour l'exercice suivant
-                        if($_SESSION['config']['nb_maxi_jours_reliquats']!=0) {
-                            if($user_solde_actuel <= $_SESSION['config']['nb_maxi_jours_reliquats']) {
-                                $new_reliquat = $user_solde_actuel ;
+                        if ($_SESSION['config']['nb_maxi_jours_reliquats'] != 0) {
+                            if ($user_solde_actuel <= $_SESSION['config']['nb_maxi_jours_reliquats']) {
+                                $new_reliquat = $user_solde_actuel;
                             } else {
-                                $new_reliquat = $_SESSION['config']['nb_maxi_jours_reliquats'] ;
+                                $new_reliquat = $_SESSION['config']['nb_maxi_jours_reliquats'];
                             }
                         } else {
-                            $new_reliquat = $user_reliquat_actuel + $user_solde_actuel ;
+                            $new_reliquat = $user_reliquat_actuel + $user_solde_actuel;
                         }
 
                         $VerifDec = verif_saisie_decimal($new_reliquat);
                         //
                         // update D'ABORD du reliquat
-                        $sql_reliquat = 'UPDATE conges_solde_user SET su_reliquat = '.$new_reliquat.' WHERE su_login="'. \includes\SQL::quote($current_login).'"  AND su_abs_id = '.$id_conges;
-                        $ReqLog_reliquat = \includes\SQL::query($sql_reliquat) ;
+                        $sql_reliquat    = 'UPDATE conges_solde_user SET su_reliquat = ' . $new_reliquat . ' WHERE su_login="' . \includes\SQL::quote($current_login) . '"  AND su_abs_id = ' . $id_conges;
+                        $ReqLog_reliquat = \includes\SQL::query($sql_reliquat);
                     } else {
-                        $new_reliquat = $user_solde_actuel ; // qui est nul ou negatif
+                        $new_reliquat = $user_solde_actuel; // qui est nul ou negatif
                     }
 
-                    $new_solde = $user_nb_jours_ajout_an + $new_reliquat  ;
-                    $VerifDec = verif_saisie_decimal($new_solde);
+                    $new_solde = $user_nb_jours_ajout_an + $new_reliquat;
+                    $VerifDec  = verif_saisie_decimal($new_solde);
 
                     // update du solde
-                    $sql_solde = 'UPDATE conges_solde_user SET su_solde = '.$new_solde.' WHERE su_login="'. \includes\SQL::quote($current_login).'"  AND su_abs_id = '.intval($id_conges).';';
-                    $ReqLog_solde = \includes\SQL::query($sql_solde) ;
+                    $sql_solde    = 'UPDATE conges_solde_user SET su_solde = ' . $new_solde . ' WHERE su_login="' . \includes\SQL::quote($current_login) . '"  AND su_abs_id = ' . intval($id_conges) . ';';
+                    $ReqLog_solde = \includes\SQL::query($sql_solde);
                 } else {
                     // ATTENTION : meme si on accepte pas les reliquats, si le solde du user est négatif, il faut le reporter: le nouveau solde est nb_jours_an + le solde actuel (qui est négatif)
-                    if($user_solde_actuel < 0) {
-                        $new_solde = $user_nb_jours_ajout_an + $user_solde_actuel ; // qui est nul ou negatif
+                    if ($user_solde_actuel < 0) {
+                        $new_solde = $user_nb_jours_ajout_an + $user_solde_actuel; // qui est nul ou negatif
                     } else {
-                        $new_solde = $user_nb_jours_ajout_an ;
+                        $new_solde = $user_nb_jours_ajout_an;
                     }
 
-                    $VerifDec = verif_saisie_decimal($new_solde);
-                    $sql_solde = 'UPDATE conges_solde_user SET su_solde = '.$new_solde.' WHERE su_login="'. \includes\SQL::quote($current_login).'" AND su_abs_id = '.intval($id_conges).';';
-                    $ReqLog_solde = \includes\SQL::query($sql_solde) ;
+                    $VerifDec     = verif_saisie_decimal($new_solde);
+                    $sql_solde    = 'UPDATE conges_solde_user SET su_solde = ' . $new_solde . ' WHERE su_login="' . \includes\SQL::quote($current_login) . '" AND su_abs_id = ' . intval($id_conges) . ';';
+                    $ReqLog_solde = \includes\SQL::query($sql_solde);
                 }
 
                 /* Modification de la table conges_users */
                 // ATTENTION : ne pas faire "SET u_num_exercice = u_num_exercice+1" dans la requete SQL car on incrémenterait pour chaque type d'absence !
-                $new_num_exercice=$_SESSION['config']['num_exercice'] ;
-                $sql2 = 'UPDATE conges_users SET u_num_exercice = '.$new_num_exercice.' WHERE u_login="'. \includes\SQL::quote($current_login).'"  ';
-                $ReqLog2 = \includes\SQL::query($sql2) ;
+                $new_num_exercice = $_SESSION['config']['num_exercice'];
+                $sql2             = 'UPDATE conges_users SET u_num_exercice = ' . $new_num_exercice . ' WHERE u_login="' . \includes\SQL::quote($current_login) . '"  ';
+                $ReqLog2          = \includes\SQL::query($sql2);
 
                 // on insert l'ajout de conges dans la table periode (avec le commentaire)
-                $date_today=date("Y-m-d");
+                $date_today = date("Y-m-d");
                 insert_dans_periode($current_login, $date_today, "am", $date_today, "am", $user_nb_jours_ajout_an, $commentaire, $id_conges, "ajout", 0);
             }
 
@@ -2131,19 +2143,19 @@ class Fonctions
     public static function cloture_users($tab_type_conges, $tab_cloture_users, $tab_commentaire_saisie)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
-        $tab_all_users_du_hr=\hr\Fonctions::recup_infos_all_users_du_hr($_SESSION['userlogin']);
-        $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
-        if( (count($tab_all_users_du_hr)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
+        $tab_all_users_du_hr         = \hr\Fonctions::recup_infos_all_users_du_hr($_SESSION['userlogin']);
+        $tab_all_users_du_grand_resp = recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
+        if ((count($tab_all_users_du_hr) != 0) || (count($tab_all_users_du_grand_resp) != 0)) {
             // traitement des users dont on est responsable :
-            foreach($tab_all_users_du_hr as $current_login => $tab_current_user) {
+            foreach ($tab_all_users_du_hr as $current_login => $tab_current_user) {
                 // tab_cloture_users[$current_login]=TRUE si checkbox "cloturer" est cochée
-                if( (isset($tab_cloture_users[$current_login])) && ($tab_cloture_users[$current_login]=TRUE) ) {
+                if ((isset($tab_cloture_users[$current_login])) && ($tab_cloture_users[$current_login] = true)) {
                     $commentaire = $tab_commentaire_saisie[$current_login];
                     $return .= \hr\Fonctions::cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $commentaire);
                 }
@@ -2155,16 +2167,16 @@ class Fonctions
     public static function affichage_cloture_globale_groupe($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /***********************************************************************/
         /* SAISIE GROUPE pour tous les utilisateurs d'un groupe du responsable */
 
         // on établi la liste complète des groupes dont on est le resp (ou le grd resp)
-        $list_group=get_list_groupes_du_resp($_SESSION['userlogin']);
+        $list_group = get_list_groupes_du_resp($_SESSION['userlogin']);
 
-        if($list_group!="") //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
+        if ($list_group != "") //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
         {
             $return .= '<form action="' . $PHP_SELF . '" method="POST">';
             $return .= '<table>';
@@ -2176,16 +2188,16 @@ class Fonctions
             $return .= '<tr>';
 
             // création du select pour le choix du groupe
-            $text_choix_group="<select name=\"choix_groupe\" >";
-            $sql_group = "SELECT g_gid, g_groupename FROM conges_groupe WHERE g_gid IN ($list_group) ORDER BY g_groupename "  ;
-            $ReqLog_group = \includes\SQL::query($sql_group) ;
+            $text_choix_group = "<select name=\"choix_groupe\" >";
+            $sql_group        = "SELECT g_gid, g_groupename FROM conges_groupe WHERE g_gid IN ($list_group) ORDER BY g_groupename ";
+            $ReqLog_group     = \includes\SQL::query($sql_group);
 
             while ($resultat_group = $ReqLog_group->fetch_array()) {
-                $current_group_id=$resultat_group["g_gid"];
-                $current_group_name=$resultat_group["g_groupename"];
-                $text_choix_group=$text_choix_group."<option value=\"$current_group_id\" >$current_group_name</option>";
+                $current_group_id   = $resultat_group["g_gid"];
+                $current_group_name = $resultat_group["g_groupename"];
+                $text_choix_group   = $text_choix_group . "<option value=\"$current_group_id\" >$current_group_name</option>";
             }
-            $text_choix_group=$text_choix_group."</select>" ;
+            $text_choix_group = $text_choix_group . "</select>";
 
             $return .= '<td class="big">' . _('resp_ajout_conges_choix_groupe') . ' : ' . $text_choix_group . '</td>';
             $return .= '</tr>';
@@ -2213,8 +2225,8 @@ class Fonctions
     public static function affichage_cloture_globale_pour_tous($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /************************************************************/
         /* CLOTURE EXERCICE GLOBALE pour tous les utilisateurs du responsable */
@@ -2247,14 +2259,14 @@ class Fonctions
         $return = '';
         $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
         //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-        $tab_conges=$tab_current_user['conges'];
+        $tab_conges = $tab_current_user['conges'];
 
         /** sur la ligne ,   **/
         $return .= '<td>' . $tab_current_user['nom'] . '</td>';
         $return .= '<td>' . $tab_current_user['prenom'] . '</td>';
         $return .= '<td>' . $tab_current_user['quotite'] . '%</td>';
 
-        foreach($tab_type_conges as $id_conges => $libelle) {
+        foreach ($tab_type_conges as $id_conges => $libelle) {
             if (isset($tab_conges[$libelle])) {
                 $return .= '<td>' . $tab_conges[$libelle]['nb_an'] . ' <i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
             } else {
@@ -2263,13 +2275,13 @@ class Fonctions
         }
 
         // si le num d'exercice du user est < à celui de l'appli (il n'a pas encore été basculé): on peut le cocher
-        if($tab_current_user['num_exercice'] < $_SESSION['config']['num_exercice']) {
+        if ($tab_current_user['num_exercice'] < $_SESSION['config']['num_exercice']) {
             $return .= '<td align="center" class="histo"><input type="checkbox" name="tab_cloture_users[' . $current_login . ']" value="TRUE" checked></td>';
         } else {
             $return .= '<td align="center" class="histo"><img src="' . IMG_PATH . 'stop.png" width="16" height="16" border="0" ></td>';
         }
 
-        $comment_cloture =  _('resp_cloture_exercice_commentaire') ." ".date("m/Y");
+        $comment_cloture = _('resp_cloture_exercice_commentaire') . " " . date("m/Y");
         $return .= '<td align="center" class="histo"><input type="text" name="tab_commentaire_saisie[' . $current_login . ']" size="20" maxlength="200" value="' . $comment_cloture . '"></td>';
         $return .= '</tr>';
 
@@ -2279,13 +2291,13 @@ class Fonctions
     public static function affichage_cloture_user_par_user($tab_type_conges, $tab_all_users_du_hr, $tab_all_users_du_grand_resp)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /************************************************************/
         /* CLOTURE EXERCICE USER PAR USER pour tous les utilisateurs du responsable */
 
-        if( (count($tab_all_users_du_hr)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
+        if ((count($tab_all_users_du_hr) != 0) || (count($tab_all_users_du_grand_resp) != 0)) {
             $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=cloture_year" method="POST">';
             $return .= '<table>';
             $return .= '<tr>';
@@ -2303,7 +2315,7 @@ class Fonctions
             $return .= '<th>' . _('divers_nom_maj_1') . '</th>';
             $return .= '<th>' . _('divers_prenom_maj_1') . '</th>';
             $return .= '<th>' . _('divers_quotite_maj_1') . '</th>';
-            foreach($tab_type_conges as $id_conges => $libelle) {
+            foreach ($tab_type_conges as $id_conges => $libelle) {
                 $return .= '<th>' . $libelle . '<br><i>(' . _('divers_solde') . ')</i></th>';
             }
             $return .= '<th>' . _('divers_cloturer_maj_1') . '<br></th>';
@@ -2316,7 +2328,7 @@ class Fonctions
 
             // affichage des users dont on est responsable :
             $i = true;
-            foreach($tab_all_users_du_hr as $current_login => $tab_current_user) {
+            foreach ($tab_all_users_du_hr as $current_login => $tab_current_user) {
                 $return .= \hr\Fonctions::affiche_ligne_du_user($current_login, $tab_type_conges, $tab_current_user, $i);
                 $i = !$i;
             }
@@ -2342,18 +2354,18 @@ class Fonctions
         return $return;
     }
 
-    public static function saisie_cloture( $tab_type_conges)
+    public static function saisie_cloture($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
-        $tab_all_users_du_hr=\hr\Fonctions::recup_infos_all_users_du_hr($_SESSION['userlogin']);
-        $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
-        if( (count($tab_all_users_du_hr)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
+        $tab_all_users_du_hr         = \hr\Fonctions::recup_infos_all_users_du_hr($_SESSION['userlogin']);
+        $tab_all_users_du_grand_resp = recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
+        if ((count($tab_all_users_du_hr) != 0) || (count($tab_all_users_du_grand_resp) != 0)) {
             /************************************************************/
             /* SAISIE GLOBALE pour tous les utilisateurs du responsable */
             $return .= \hr\Fonctions::affichage_cloture_globale_pour_tous($tab_type_conges);
@@ -2361,7 +2373,7 @@ class Fonctions
 
             /***********************************************************************/
             /* SAISIE GROUPE pour tous les utilisateurs d'un groupe du responsable */
-            if( $_SESSION['config']['gestion_groupes']) {
+            if ($_SESSION['config']['gestion_groupes']) {
                 $return .= \hr\Fonctions::affichage_cloture_globale_groupe($tab_type_conges);
             }
             $return .= '<br>';
@@ -2394,34 +2406,34 @@ class Fonctions
         $cloture_users   = getpost_variable('cloture_users');
         $cloture_globale = getpost_variable('cloture_globale');
         $cloture_groupe  = getpost_variable('cloture_groupe');
-        $return = '';
+        $return          = '';
         /*************************************/
 
         /** initialisation des tableaux des types de conges/absences  **/
         // recup du tableau des types de conges (conges et congesexceptionnels)
         // on concatene les 2 tableaux
-        $tab_type_cong = ( recup_tableau_types_conges() + recup_tableau_types_conges_exceptionnels()  );
+        $tab_type_cong = (recup_tableau_types_conges() + recup_tableau_types_conges_exceptionnels());
 
         // titre
-        $return .= '<h2>'. _('resp_cloture_exercice_titre') . '</H2>';
+        $return .= '<h2>' . _('resp_cloture_exercice_titre') . '</H2>';
 
-        if($cloture_users=="TRUE") {
-            $tab_cloture_users       = getpost_variable('tab_cloture_users');
-            $tab_commentaire_saisie       = getpost_variable('tab_commentaire_saisie'); //a vérifier
+        if ($cloture_users == "TRUE") {
+            $tab_cloture_users      = getpost_variable('tab_cloture_users');
+            $tab_commentaire_saisie = getpost_variable('tab_commentaire_saisie'); //a vérifier
             $return .= \hr\Fonctions::cloture_users($tab_type_cong, $tab_cloture_users, $tab_commentaire_saisie);
 
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
+            redirect(ROOT_PATH . 'hr/hr_index.php?session=' . $session, false);
             exit;
-        } elseif($cloture_globale=="TRUE") {
+        } elseif ($cloture_globale == "TRUE") {
             \hr\Fonctions::cloture_globale($tab_type_cong);
 
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
+            redirect(ROOT_PATH . 'hr/hr_index.php?session=' . $session, false);
             exit;
-        } elseif($cloture_groupe=="TRUE") {
-            $choix_groupe            = getpost_variable('choix_groupe');
+        } elseif ($cloture_groupe == "TRUE") {
+            $choix_groupe = getpost_variable('choix_groupe');
             $return .= \hr\Fonctions::cloture_globale_groupe($choix_groupe, $tab_type_cong);
 
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
+            redirect(ROOT_PATH . 'hr/hr_index.php?session=' . $session, false);
             exit;
         } else {
             $return .= \hr\Fonctions::saisie_cloture($tab_type_cong);
@@ -2431,15 +2443,15 @@ class Fonctions
 
     public static function affiche_calendrier_fermeture_mois($year, $mois, $tab_year)
     {
-        $jour_today=date("j");
-        $jour_today_name=date("D");
-        $return = '';
+        $jour_today      = date("j");
+        $jour_today_name = date("D");
+        $return          = '';
 
-        $first_jour_mois_timestamp=mktime (0,0,0,$mois,1,$year);
-        $mois_name=date_fr("F", $first_jour_mois_timestamp);
-        $first_jour_mois_rang=date("w", $first_jour_mois_timestamp);      // jour de la semaine en chiffre (0=dim , 6=sam)
-        if($first_jour_mois_rang==0) {
-            $first_jour_mois_rang=7 ;    // jour de la semaine en chiffre (1=lun , 7=dim)
+        $first_jour_mois_timestamp = mktime(0, 0, 0, $mois, 1, $year);
+        $mois_name                 = date_fr("F", $first_jour_mois_timestamp);
+        $first_jour_mois_rang      = date("w", $first_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
+        if ($first_jour_mois_rang == 0) {
+            $first_jour_mois_rang = 7; // jour de la semaine en chiffre (1=lun , 7=dim)
         }
 
         $return .= '<table>';
@@ -2454,30 +2466,30 @@ class Fonctions
         $return .= '<th class="cal-saisie2">' . _('vendredi_1c') . '</th>';
         $return .= '<th class="cal-saisie2">' . _('samedi_1c') . '</th>';
         $return .= '<th class="cal-saisie2">' . _('dimanche_1c') . '</th>';
-        $return .= '</tr>' ;
+        $return .= '</tr>';
         $return .= '</thead>';
 
         /* affichage ligne 1 du mois*/
         $return .= '<tr>';
         // affichage des cellules vides jusqu'au 1 du mois ...
-        for($i=1; $i<$first_jour_mois_rang; $i++) {
-            if( (($i==6)&&($_SESSION['config']['samedi_travail']==FALSE)) || (($i==7)&&($_SESSION['config']['dimanche_travail']==FALSE)) ) {
-                $bgcolor=$_SESSION['config']['week_end_bgcolor'];
+        for ($i = 1; $i < $first_jour_mois_rang; $i++) {
+            if ((($i == 6) && ($_SESSION['config']['samedi_travail'] == false)) || (($i == 7) && ($_SESSION['config']['dimanche_travail'] == false))) {
+                $bgcolor = $_SESSION['config']['week_end_bgcolor'];
             } else {
-                $bgcolor=$_SESSION['config']['semaine_bgcolor'];
+                $bgcolor = $_SESSION['config']['semaine_bgcolor'];
             }
             $return .= '<td class="month-out cal-saisie2">&nbsp;</td>';
         }
         // affichage des cellules du 1 du mois à la fin de la ligne ...
-        for($i=$first_jour_mois_rang; $i<8; $i++) {
-            $j=$i-$first_jour_mois_rang+1 ;
-            $j_timestamp=mktime (0,0,0,$mois,$j,$year);
-            $j_date=date("Y-m-d", $j_timestamp);
-            $j_day=date("d", $j_timestamp);
-            $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
+        for ($i = $first_jour_mois_rang; $i < 8; $i++) {
+            $j               = $i - $first_jour_mois_rang + 1;
+            $j_timestamp     = mktime(0, 0, 0, $mois, $j, $year);
+            $j_date          = date("Y-m-d", $j_timestamp);
+            $j_day           = date("d", $j_timestamp);
+            $td_second_class = get_td_class_of_the_day_in_the_week($j_timestamp);
 
-            if(in_array ("$j_date", $tab_year)) {
-                $td_second_class="fermeture";
+            if (in_array("$j_date", $tab_year)) {
+                $td_second_class = "fermeture";
             }
 
             $return .= '<td  class="cal-saisie ' . $td_second_class . '">' . $j_day . '</td>';
@@ -2486,14 +2498,14 @@ class Fonctions
 
         /* affichage ligne 2 du mois*/
         $return .= '<tr>';
-        for($i=8-$first_jour_mois_rang+1; $i<15-$first_jour_mois_rang+1; $i++) {
-            $j_timestamp=mktime (0,0,0,$mois,$i,$year);
-            $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
-            $j_date=date("Y-m-d", $j_timestamp);
-            $j_day=date("d", $j_timestamp);
+        for ($i = 8 - $first_jour_mois_rang + 1; $i < 15 - $first_jour_mois_rang + 1; $i++) {
+            $j_timestamp     = mktime(0, 0, 0, $mois, $i, $year);
+            $td_second_class = get_td_class_of_the_day_in_the_week($j_timestamp);
+            $j_date          = date("Y-m-d", $j_timestamp);
+            $j_day           = date("d", $j_timestamp);
 
-            if(in_array ("$j_date", $tab_year)) {
-                $td_second_class="fermeture";
+            if (in_array("$j_date", $tab_year)) {
+                $td_second_class = "fermeture";
             }
 
             $return .= '<td class="cal-saisie ' . $td_second_class . '">' . $j_day . '</td>';
@@ -2502,30 +2514,30 @@ class Fonctions
 
         /* affichage ligne 3 du mois*/
         $return .= '<tr>';
-        for($i=15-$first_jour_mois_rang+1; $i<22-$first_jour_mois_rang+1; $i++) {
-            $j_timestamp=mktime (0,0,0,$mois,$i,$year);
-            $j_date=date("Y-m-d", $j_timestamp);
-            $j_day=date("d", $j_timestamp);
-            $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
+        for ($i = 15 - $first_jour_mois_rang + 1; $i < 22 - $first_jour_mois_rang + 1; $i++) {
+            $j_timestamp     = mktime(0, 0, 0, $mois, $i, $year);
+            $j_date          = date("Y-m-d", $j_timestamp);
+            $j_day           = date("d", $j_timestamp);
+            $td_second_class = get_td_class_of_the_day_in_the_week($j_timestamp);
 
-            if(in_array ("$j_date", $tab_year)) {
-                $td_second_class="fermeture";
+            if (in_array("$j_date", $tab_year)) {
+                $td_second_class = "fermeture";
             }
 
-            $return .= '<td class="cal-saisie ' . $td_second_class . '">' . $j_day .  '</td>';
+            $return .= '<td class="cal-saisie ' . $td_second_class . '">' . $j_day . '</td>';
         }
         $return .= '</tr>';
 
         /* affichage ligne 4 du mois*/
         $return .= '<tr>';
-        for($i=22-$first_jour_mois_rang+1; $i<29-$first_jour_mois_rang+1; $i++) {
-            $j_timestamp=mktime (0,0,0,$mois,$i,$year);
-            $j_date=date("Y-m-d", $j_timestamp);
-            $j_day=date("d", $j_timestamp);
-            $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
+        for ($i = 22 - $first_jour_mois_rang + 1; $i < 29 - $first_jour_mois_rang + 1; $i++) {
+            $j_timestamp     = mktime(0, 0, 0, $mois, $i, $year);
+            $j_date          = date("Y-m-d", $j_timestamp);
+            $j_day           = date("d", $j_timestamp);
+            $td_second_class = get_td_class_of_the_day_in_the_week($j_timestamp);
 
-            if(in_array ("$j_date", $tab_year)) {
-                $td_second_class="fermeture";
+            if (in_array("$j_date", $tab_year)) {
+                $td_second_class = "fermeture";
             }
 
             $return .= '<td class="cal-saisie ' . $td_second_class . '">' . $j_day . '</td>';
@@ -2534,23 +2546,23 @@ class Fonctions
 
         /* affichage ligne 5 du mois (peut etre la derniere ligne) */
         $return .= '<tr>';
-        for($i=29-$first_jour_mois_rang+1; $i<36-$first_jour_mois_rang+1 && checkdate($mois, $i, $year); $i++) {
-            $j_timestamp=mktime (0,0,0,$mois,$i,$year);
-            $j_date=date("Y-m-d", $j_timestamp);
-            $j_day=date("d", $j_timestamp);
-            $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
+        for ($i = 29 - $first_jour_mois_rang + 1; $i < 36 - $first_jour_mois_rang + 1 && checkdate($mois, $i, $year); $i++) {
+            $j_timestamp     = mktime(0, 0, 0, $mois, $i, $year);
+            $j_date          = date("Y-m-d", $j_timestamp);
+            $j_day           = date("d", $j_timestamp);
+            $td_second_class = get_td_class_of_the_day_in_the_week($j_timestamp);
 
-            if(in_array ("$j_date", $tab_year)) {
-                $td_second_class="fermeture";
+            if (in_array("$j_date", $tab_year)) {
+                $td_second_class = "fermeture";
             }
 
             $return .= '<td  class="cal-saisie ' . $td_second_class . '">' . $j_day . '</td>';
         }
-        for($i; $i<36-$first_jour_mois_rang+1; $i++) {
-            if( (($i==35-$first_jour_mois_rang)&&($_SESSION['config']['samedi_travail']==FALSE)) || (($i==36-$first_jour_mois_rang)&&($_SESSION['config']['dimanche_travail']==FALSE)) ) {
-                $bgcolor=$_SESSION['config']['week_end_bgcolor'];
+        for ($i; $i < 36 - $first_jour_mois_rang + 1; $i++) {
+            if ((($i == 35 - $first_jour_mois_rang) && ($_SESSION['config']['samedi_travail'] == false)) || (($i == 36 - $first_jour_mois_rang) && ($_SESSION['config']['dimanche_travail'] == false))) {
+                $bgcolor = $_SESSION['config']['week_end_bgcolor'];
             } else {
-                $bgcolor=$_SESSION['config']['semaine_bgcolor'];
+                $bgcolor = $_SESSION['config']['semaine_bgcolor'];
             }
             $return .= '<td class="cal-saisie2 month-out">&nbsp;</td>';
         }
@@ -2558,23 +2570,23 @@ class Fonctions
 
         /* affichage ligne 6 du mois (derniere ligne)*/
         $return .= '<tr>';
-        for($i=36-$first_jour_mois_rang+1; checkdate($mois, $i, $year); $i++) {
-            $j_timestamp=mktime (0,0,0,$mois,$i,$year);
-            $j_date=date("Y-m-d", $j_timestamp);
-            $j_day=date("d", $j_timestamp);
-            $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
+        for ($i = 36 - $first_jour_mois_rang + 1; checkdate($mois, $i, $year); $i++) {
+            $j_timestamp     = mktime(0, 0, 0, $mois, $i, $year);
+            $j_date          = date("Y-m-d", $j_timestamp);
+            $j_day           = date("d", $j_timestamp);
+            $td_second_class = get_td_class_of_the_day_in_the_week($j_timestamp);
 
-            if(in_array ("$j_date", $tab_year)) {
-                $td_second_class="fermeture";
+            if (in_array("$j_date", $tab_year)) {
+                $td_second_class = "fermeture";
             }
 
             $return .= '<td  class="cal-saisie ' . $td_second_class . '">' . $j_day . '</td>';
         }
-        for($i; $i<43-$first_jour_mois_rang+1; $i++) {
-            if( (($i==42-$first_jour_mois_rang)&&($_SESSION['config']['samedi_travail']==FALSE)) || (($i==43-$first_jour_mois_rang)&&($_SESSION['config']['dimanche_travail']==FALSE))) {
-                $bgcolor=$_SESSION['config']['week_end_bgcolor'];
+        for ($i; $i < 43 - $first_jour_mois_rang + 1; $i++) {
+            if ((($i == 42 - $first_jour_mois_rang) && ($_SESSION['config']['samedi_travail'] == false)) || (($i == 43 - $first_jour_mois_rang) && ($_SESSION['config']['dimanche_travail'] == false))) {
+                $bgcolor = $_SESSION['config']['week_end_bgcolor'];
             } else {
-                $bgcolor=$_SESSION['config']['semaine_bgcolor'];
+                $bgcolor = $_SESSION['config']['semaine_bgcolor'];
             }
             $return .= '<td class="month-out cal-saisie2">&nbsp;</td>';
         }
@@ -2583,11 +2595,12 @@ class Fonctions
     }
 
     //calendrier des fermeture
-    public static function affiche_calendrier_fermeture($year, $groupe_id = 0) {
+    public static function affiche_calendrier_fermeture($year, $groupe_id = 0)
+    {
 
         // on construit le tableau de l'année considérée
-        $tab_year=array();
-        \hr\Fonctions::get_tableau_jour_fermeture($year, $tab_year,  $groupe_id);
+        $tab_year = array();
+        \hr\Fonctions::get_tableau_jour_fermeture($year, $tab_year, $groupe_id);
         $return = '';
 
         $return .= '<div class="calendar calendar-year">';
@@ -2607,67 +2620,76 @@ class Fonctions
     //insertion des nouvelles dates de fermeture
     public static function insert_year_fermeture($fermeture_id, $tab_j_ferme, $groupe_id)
     {
-        $sql_insert="";
-        foreach($tab_j_ferme as $jf_date ) {
-            $sql_insert="INSERT INTO conges_jours_fermeture (jf_id, jf_gid, jf_date) VALUES ($fermeture_id, $groupe_id, '$jf_date') ;";
+        $sql_insert = "";
+        foreach ($tab_j_ferme as $jf_date) {
+            $sql_insert    = "INSERT INTO conges_jours_fermeture (jf_id, jf_gid, jf_date) VALUES ($fermeture_id, $groupe_id, '$jf_date') ;";
             $result_insert = \includes\SQL::query($sql_insert);
         }
-        return TRUE;
+        return true;
     }
 
     // supprime une fermeture
     public static function delete_year_fermeture($fermeture_id, $groupe_id)
     {
 
-        $sql_delete="DELETE FROM conges_jours_fermeture WHERE jf_id = '$fermeture_id' AND jf_gid= '$groupe_id' ;";
-        $result = \includes\SQL::query($sql_delete);
-        return TRUE;
+        $sql_delete = "DELETE FROM conges_jours_fermeture WHERE jf_id = '$fermeture_id' AND jf_gid= '$groupe_id' ;";
+        $result     = \includes\SQL::query($sql_delete);
+        return true;
     }
 
     // recup l'id de la derniere fermeture (le max)
     public static function get_last_fermeture_id()
     {
-        $req_1="SELECT MAX(jf_id) FROM conges_jours_fermeture ";
+        $req_1 = "SELECT MAX(jf_id) FROM conges_jours_fermeture ";
         $res_1 = \includes\SQL::query($req_1);
         $row_1 = $res_1->fetch_array();
-        if(!$row_1)
-            return 0;     // si la table est vide, on renvoit 0
-        else
+        if (!$row_1) {
+            return 0;
+        }
+        // si la table est vide, on renvoit 0
+        else {
             return $row_1[0];
+        }
+
     }
 
     // verifie si la periode donnee chevauche une periode de conges d'un des user du groupe ..
     // retourne TRUE si chevauchement et FALSE sinon !
-    public static function verif_periode_chevauche_periode_groupe($date_debut, $date_fin, $num_current_periode='', $tab_periode_calcul, $groupe_id)
+    public static function verif_periode_chevauche_periode_groupe($date_debut, $date_fin, $num_current_periode = '', $tab_periode_calcul, $groupe_id)
     {
         /*****************************/
         // on construit le tableau des users affectés par les fermetures saisies :
-        if($groupe_id==0)  // fermeture pour tous !
+        if ($groupe_id == 0) // fermeture pour tous !
+        {
             $list_users = get_list_all_users();
-        else
+        } else {
             $list_users = get_list_users_du_groupe($groupe_id);
+        }
 
         $tab_users = explode(",", $list_users);
 
-        foreach($tab_users as $current_login) {
+        foreach ($tab_users as $current_login) {
             $current_login = trim($current_login);
             // on enleve les quotes qui ont été ajoutées lors de la creation de la liste
             $current_login = trim($current_login, "\'");
-            $comment="";
-            if(verif_periode_chevauche_periode_user($date_debut, $date_fin, $current_login, $num_current_periode, $tab_periode_calcul, $comment))
-                return TRUE;
+            $comment       = "";
+            if (verif_periode_chevauche_periode_user($date_debut, $date_fin, $current_login, $num_current_periode, $tab_periode_calcul, $comment)) {
+                return true;
+            }
+
         }
     }
 
     public static function commit_annul_fermeture($fermeture_id, $groupe_id)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /*****************************/
         // on construit le tableau des users affectés par les fermetures saisies :
-        if($groupe_id==0) { // fermeture pour tous !
+        if ($groupe_id == 0) {
+            // fermeture pour tous !
             $list_users = get_list_all_users();
         } else {
             $list_users = get_list_users_du_groupe($groupe_id);
@@ -2680,49 +2702,48 @@ class Fonctions
         // on suprimme les dates de cette fermeture dans conges_jours_fermeture
         $result = \hr\Fonctions::delete_year_fermeture($fermeture_id, $groupe_id);
 
-
         // on va traiter user par user pour annuler sa periode de conges correspondant et lui re-crediter son solde
-        foreach($tab_users as $current_login) {
+        foreach ($tab_users as $current_login) {
             $current_login = trim($current_login);
             // on enleve les quotes qui ont été ajoutées lors de la creation de la liste
             $current_login = trim($current_login, "\'");
 
             // on recupère les infos de la periode ....
-            $sql_credit='SELECT p_num, p_nb_jours, p_type FROM conges_periode WHERE p_login="'. \includes\SQL::quote($current_login).'" AND p_fermeture_id="' . \includes\SQL::quote($fermeture_id) .'" AND p_etat=\'ok\'';
-            $result_credit = \includes\SQL::query($sql_credit);
-            $row_credit = $result_credit->fetch_array();
-            $sql_num_periode=$row_credit['p_num'];
-            $sql_nb_jours_a_crediter=$row_credit['p_nb_jours'];
-            $sql_type_abs=$row_credit['p_type'];
-
+            $sql_credit              = 'SELECT p_num, p_nb_jours, p_type FROM conges_periode WHERE p_login="' . \includes\SQL::quote($current_login) . '" AND p_fermeture_id="' . \includes\SQL::quote($fermeture_id) . '" AND p_etat=\'ok\'';
+            $result_credit           = \includes\SQL::query($sql_credit);
+            $row_credit              = $result_credit->fetch_array();
+            $sql_num_periode         = $row_credit['p_num'];
+            $sql_nb_jours_a_crediter = $row_credit['p_nb_jours'];
+            $sql_type_abs            = $row_credit['p_type'];
 
             // on met à jour la table conges_periode .
-            $etat = "annul" ;
+            $etat = "annul";
 
-            $sql1 = 'UPDATE conges_periode SET p_etat = "'.\includes\SQL::quote($etat).'" WHERE p_num="'.\includes\SQL::quote($sql_num_periode).'" AND p_etat=\'ok\';';
+            $sql1   = 'UPDATE conges_periode SET p_etat = "' . \includes\SQL::quote($etat) . '" WHERE p_num="' . \includes\SQL::quote($sql_num_periode) . '" AND p_etat=\'ok\';';
             $ReqLog = \includes\SQL::query($sql1);
 
             if ($ReqLog && \includes\SQL::getVar('affected_rows')) {
                 // mise à jour du solde de jours de conges pour l'utilisateur $current_login
                 if ($sql_nb_jours_a_crediter != 0) {
-                    $sql1 = 'UPDATE conges_solde_user SET su_solde = su_solde + '.\includes\SQL::quote($sql_nb_jours_a_crediter).' WHERE su_login="'. \includes\SQL::quote($current_login).'" AND su_abs_id = '.\includes\SQL::quote($sql_type_abs) ;
+                    $sql1   = 'UPDATE conges_solde_user SET su_solde = su_solde + ' . \includes\SQL::quote($sql_nb_jours_a_crediter) . ' WHERE su_login="' . \includes\SQL::quote($current_login) . '" AND su_abs_id = ' . \includes\SQL::quote($sql_type_abs);
                     $ReqLog = \includes\SQL::query($sql1);
                 }
             }
         }
 
         $return .= '<div class="wrapper">';
-        if($result) {
+        if ($result) {
             $return .= '<br>' . _('form_modif_ok') . '<br><br>';
         } else {
             $return .= '<br>' . _('form_modif_not_ok') . ' !<br><br>';
         }
 
         // on enregistre cette action dan les logs
-        if($groupe_id==0) { // fermeture pour tous !
-            $comment_log = "annulation fermeture $fermeture_id (pour tous) " ;
+        if ($groupe_id == 0) {
+            // fermeture pour tous !
+            $comment_log = "annulation fermeture $fermeture_id (pour tous) ";
         } else {
-            $comment_log = "annulation fermeture $fermeture_id (pour le groupe $groupe_id)" ;
+            $comment_log = "annulation fermeture $fermeture_id (pour le groupe $groupe_id)";
         }
         log_action(0, "", "", $comment_log);
 
@@ -2736,18 +2757,19 @@ class Fonctions
     public static function commit_new_fermeture($new_date_debut, $new_date_fin, $groupe_id, $id_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // on transforme les formats des dates
-        $tab_date_debut=explode("/",$new_date_debut);   // date au format d/m/Y
-        $date_debut=$tab_date_debut[2]."-".$tab_date_debut[1]."-".$tab_date_debut[0];
-        $tab_date_fin=explode("/",$new_date_fin);   // date au format d/m/Y
-        $date_fin=$tab_date_fin[2]."-".$tab_date_fin[1]."-".$tab_date_fin[0];
+        $tab_date_debut = explode("/", $new_date_debut); // date au format d/m/Y
+        $date_debut     = $tab_date_debut[2] . "-" . $tab_date_debut[1] . "-" . $tab_date_debut[0];
+        $tab_date_fin   = explode("/", $new_date_fin); // date au format d/m/Y
+        $date_fin       = $tab_date_fin[2] . "-" . $tab_date_fin[1] . "-" . $tab_date_fin[0];
 
         /*****************************/
         // on construit le tableau des users affectés par les fermetures saisies :
-        if($groupe_id==0) { // fermeture pour tous !
+        if ($groupe_id == 0) {
+            // fermeture pour tous !
             $list_users = get_list_all_users();
         } else {
             $list_users = get_list_users_du_groupe($groupe_id);
@@ -2756,7 +2778,7 @@ class Fonctions
         $tab_users = explode(",", $list_users);
         //******************************
         // !!!!
-            // type d'absence à modifier ....
+        // type d'absence à modifier ....
         //    $id_type_conges = 1 ; //"cp" : conges payes
 
         //calcul de l'ID de de la fermeture (en fait l'ID de la saisie de fermeture)
@@ -2764,20 +2786,20 @@ class Fonctions
 
         /***********************************************/
         /** enregistrement des jours de fermetures   **/
-        $tab_fermeture=array();
-        for($current_date=$date_debut; $current_date <= $date_fin; $current_date=jour_suivant($current_date)) {
+        $tab_fermeture = array();
+        for ($current_date = $date_debut; $current_date <= $date_fin; $current_date = jour_suivant($current_date)) {
             $tab_fermeture[] = $current_date;
         }
 
         // on insere les nouvelles dates saisies dans conges_jours_fermeture
         $result = \hr\Fonctions::insert_year_fermeture($new_fermeture_id, $tab_fermeture, $groupe_id);
 
-        $opt_debut='am';
-        $opt_fin='pm';
+        $opt_debut = 'am';
+        $opt_fin   = 'pm';
 
         /*********************************************************/
         /** insersion des jours de fermetures pour chaque user  **/
-        foreach($tab_users as $current_login) {
+        foreach ($tab_users as $current_login) {
             $current_login = trim($current_login);
             // on enleve les quotes qui ont été ajoutées lors de la creation de la liste
             $current_login = trim($current_login, "\'");
@@ -2786,14 +2808,14 @@ class Fonctions
                 // on compte le nb de jour à enlever au user (par periode et au total)
                 // on ne met à jour la table conges_periode
                 $nb_jours = 0;
-                $comment="" ;
+                $comment  = "";
 
                 $nb_jours = compter($current_login, "", $date_debut, $date_fin, $opt_debut, $opt_fin, $comment);
 
                 // on ne met à jour la table conges_periode .
-                $commentaire =  _('divers_fermeture') ;
-                $etat = "ok" ;
-                $num_periode = insert_dans_periode($current_login, $date_debut, $opt_debut, $date_fin, $opt_fin, $nb_jours, $commentaire, $id_type_conges, $etat, $new_fermeture_id) ;
+                $commentaire = _('divers_fermeture');
+                $etat        = "ok";
+                $num_periode = insert_dans_periode($current_login, $date_debut, $opt_debut, $date_fin, $opt_fin, $nb_jours, $commentaire, $id_type_conges, $etat, $new_fermeture_id);
 
                 // mise à jour du solde de jours de conges pour l'utilisateur $current_login
                 if ($nb_jours != 0) {
@@ -2807,13 +2829,13 @@ class Fonctions
 
         $return .= '<div class="wrapper">';
 
-        if($result) {
+        if ($result) {
             $return .= '<br>' . _('form_modif_ok') . '<br><br>';
         } else {
             $return .= '<br>' . _('form_modif_not_ok') . ' !<br><br>';
         }
 
-        $comment_log = "saisie des jours de fermeture de $date_debut a $date_fin" ;
+        $comment_log = "saisie des jours de fermeture de $date_debut a $date_fin";
         log_action(0, "", "", $comment_log);
         $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_ok') . '">';
@@ -2825,8 +2847,8 @@ class Fonctions
     public static function confirm_annul_fermeture($fermeture_id, $groupe_id, $fermeture_date_debut, $fermeture_date_fin)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         $return .= '<div class="wrapper">';
         $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
@@ -2847,19 +2869,19 @@ class Fonctions
     // retourne un tableau des periodes de fermeture (pour un groupe donné (gid=0 pour tout le monde))
     public static function get_tableau_periodes_fermeture(&$tab_periodes_fermeture)
     {
-        $req_1="SELECT DISTINCT conges_periode.p_date_deb, conges_periode.p_date_fin, conges_periode.p_fermeture_id, conges_jours_fermeture.jf_gid, conges_groupe.g_groupename FROM conges_periode, conges_jours_fermeture LEFT JOIN conges_groupe ON conges_jours_fermeture.jf_gid=conges_groupe.g_gid WHERE conges_periode.p_fermeture_id = conges_jours_fermeture.jf_id AND conges_periode.p_etat='ok' ORDER BY conges_periode.p_date_deb DESC  ";
+        $req_1 = "SELECT DISTINCT conges_periode.p_date_deb, conges_periode.p_date_fin, conges_periode.p_fermeture_id, conges_jours_fermeture.jf_gid, conges_groupe.g_groupename FROM conges_periode, conges_jours_fermeture LEFT JOIN conges_groupe ON conges_jours_fermeture.jf_gid=conges_groupe.g_gid WHERE conges_periode.p_fermeture_id = conges_jours_fermeture.jf_id AND conges_periode.p_etat='ok' ORDER BY conges_periode.p_date_deb DESC  ";
         $res_1 = \includes\SQL::query($req_1);
 
         $num_select = $res_1->num_rows;
-        if($num_select!=0) {
-            while($result_select = $res_1->fetch_array()) {
-                $tab_periode=array();
-                $tab_periode['date_deb']=$result_select["p_date_deb"];
-                $tab_periode['date_fin']=$result_select["p_date_fin"];
-                $tab_periode['fermeture_id']=$result_select["p_fermeture_id"];
-                $tab_periode['groupe_id']=$result_select["jf_gid"];
-                $tab_periode['groupe_name']=$result_select["g_groupename"];
-                $tab_periodes_fermeture[]=$tab_periode;
+        if ($num_select != 0) {
+            while ($result_select = $res_1->fetch_array()) {
+                $tab_periode                 = array();
+                $tab_periode['date_deb']     = $result_select["p_date_deb"];
+                $tab_periode['date_fin']     = $result_select["p_date_fin"];
+                $tab_periode['fermeture_id'] = $result_select["p_fermeture_id"];
+                $tab_periode['groupe_id']    = $result_select["jf_gid"];
+                $tab_periode['groupe_name']  = $result_select["g_groupename"];
+                $tab_periodes_fermeture[]    = $tab_periode;
             }
         }
     }
@@ -2867,20 +2889,20 @@ class Fonctions
     // Affichage d'un SELECT de formulaire pour choix d'un type d'absence
     public static function affiche_select_conges_id()
     {
-        $tab_conges=recup_tableau_types_conges();
-        $tab_conges_except=recup_tableau_types_conges_exceptionnels();
-        $return = '';
+        $tab_conges        = recup_tableau_types_conges();
+        $tab_conges_except = recup_tableau_types_conges_exceptionnels();
+        $return            = '';
 
-        foreach($tab_conges as $id => $libelle) {
-            if($libelle == 1) {
+        foreach ($tab_conges as $id => $libelle) {
+            if ($libelle == 1) {
                 $return .= '<option value="' . $id . '" selected>' . $libelle . '</option>';
             } else {
-                $return .= '<option value="' . $id  . '">' . $libelle . '</option>';
+                $return .= '<option value="' . $id . '">' . $libelle . '</option>';
             }
         }
-        if(count($tab_conges_except)!=0) {
-            foreach($tab_conges_except as $id => $libelle) {
-                if($libelle == 1) {
+        if (count($tab_conges_except) != 0) {
+            foreach ($tab_conges_except as $id => $libelle) {
+                if ($libelle == 1) {
                     $return .= '<option value="' . $id . '" selected>' . $libelle . '</option>';
                 } else {
                     $return .= '<option value="' . $id . '">' . $libelle . '</option>';
@@ -2891,20 +2913,22 @@ class Fonctions
     }
 
     //renvoi un tableau des jours de fermeture
-    public static function get_tableau_jour_fermeture($year, &$tab_year,  $groupe_id)
+    public static function get_tableau_jour_fermeture($year, &$tab_year, $groupe_id)
     {
         $sql_select = " SELECT jf_date FROM conges_jours_fermeture WHERE DATE_FORMAT(jf_date, '%Y-%m-%d') LIKE '$year%'  ";
         // on recup les fermeture du groupe + les fermetures de tous !
-        if($groupe_id==0)
-            $sql_select = $sql_select."AND jf_gid = 0";
-        else
-            $sql_select = $sql_select."AND  (jf_gid = $groupe_id OR jf_gid =0 ) ";
-        $res_select = \includes\SQL::query($sql_select);
-        $num_select =$res_select->num_rows;
+        if ($groupe_id == 0) {
+            $sql_select = $sql_select . "AND jf_gid = 0";
+        } else {
+            $sql_select = $sql_select . "AND  (jf_gid = $groupe_id OR jf_gid =0 ) ";
+        }
 
-        if($num_select!=0) {
-            while($result_select = $res_select->fetch_array()) {
-                $tab_year[]=$result_select["jf_date"];
+        $res_select = \includes\SQL::query($sql_select);
+        $num_select = $res_select->num_rows;
+
+        if ($num_select != 0) {
+            while ($result_select = $res_select->fetch_array()) {
+                $tab_year[] = $result_select["jf_date"];
             }
         }
     }
@@ -2912,20 +2936,20 @@ class Fonctions
     public static function saisie_dates_fermeture($year, $groupe_id, $new_date_debut, $new_date_fin, $code_erreur)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
-        $tab_date_debut=explode("/",$new_date_debut);   // date au format d/m/Y
-        $timestamp_date_debut = mktime(0,0,0, $tab_date_debut[1], $tab_date_debut[0], $tab_date_debut[2]) ;
-        $date_debut_yyyy_mm_dd = $tab_date_debut[2]."-".$tab_date_debut[1]."-".$tab_date_debut[0] ;
-        $tab_date_fin=explode("/",$new_date_fin);   // date au format d/m/Y
-        $timestamp_date_fin = mktime(0,0,0, $tab_date_fin[1], $tab_date_fin[0], $tab_date_fin[2]) ;
-        $date_fin_yyyy_mm_dd = $tab_date_fin[2]."-".$tab_date_fin[1]."-".$tab_date_fin[0] ;
-        $timestamp_today = mktime(0,0,0, date("m"), date("d"), date("Y")) ;
+        $tab_date_debut        = explode("/", $new_date_debut); // date au format d/m/Y
+        $timestamp_date_debut  = mktime(0, 0, 0, $tab_date_debut[1], $tab_date_debut[0], $tab_date_debut[2]);
+        $date_debut_yyyy_mm_dd = $tab_date_debut[2] . "-" . $tab_date_debut[1] . "-" . $tab_date_debut[0];
+        $tab_date_fin          = explode("/", $new_date_fin); // date au format d/m/Y
+        $timestamp_date_fin    = mktime(0, 0, 0, $tab_date_fin[1], $tab_date_fin[0], $tab_date_fin[2]);
+        $date_fin_yyyy_mm_dd   = $tab_date_fin[2] . "-" . $tab_date_fin[1] . "-" . $tab_date_fin[0];
+        $timestamp_today       = mktime(0, 0, 0, date("m"), date("d"), date("Y"));
 
         // on construit le tableau de l'année considérée
-        $tab_year=array();
-        \hr\Fonctions::get_tableau_jour_fermeture($year, $tab_year,  $groupe_id);
+        $tab_year = array();
+        \hr\Fonctions::get_tableau_jour_fermeture($year, $tab_year, $groupe_id);
 
         $return .= '<form id="form-fermeture" class="form-inline" role="form" action="' . $PHP_SELF . '?session=' . $session . '&year=' . $year . '" method="POST">';
         $return .= '<div class="form-group">';
@@ -2951,8 +2975,8 @@ class Fonctions
     public static function saisie_groupe_fermeture()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         $return .= '<div class="row">';
         $return .= '<div class="col-md-6">';
@@ -2968,12 +2992,12 @@ class Fonctions
         $return .= '</form>';
         $return .= '</div>';
 
-        if($_SESSION['config']['gestion_groupes'] && $_SESSION['config']['fermeture_par_groupe']) {
+        if ($_SESSION['config']['gestion_groupes'] && $_SESSION['config']['fermeture_par_groupe']) {
             /********************/
             /* Choix Groupe     */
             /********************/
             // Récuperation des informations :
-            $sql_gr = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename"  ;
+            $sql_gr = "SELECT g_gid, g_groupename, g_comment FROM conges_groupe ORDER BY g_groupename";
 
             // AFFICHAGE TABLEAU
             $return .= '<div class="col-md-6">';
@@ -2982,9 +3006,9 @@ class Fonctions
             $ReqLog_gr = \includes\SQL::query($sql_gr);
             $return .= '<select class="form-control" name="groupe_id">';
             while ($resultat_gr = $ReqLog_gr->fetch_array()) {
-                $sql_gid=$resultat_gr["g_gid"] ;
-                $sql_group=$resultat_gr["g_groupename"] ;
-                $sql_comment=$resultat_gr["g_comment"] ;
+                $sql_gid     = $resultat_gr["g_gid"];
+                $sql_group   = $resultat_gr["g_groupename"];
+                $sql_comment = $resultat_gr["g_comment"];
 
                 $return .= '<option value="' . $sql_gid . '">' . $sql_group;
             }
@@ -3001,21 +3025,21 @@ class Fonctions
 
         $tab_periodes_fermeture = array();
         \hr\Fonctions::get_tableau_periodes_fermeture($tab_periodes_fermeture);
-        if(count($tab_periodes_fermeture)!=0) {
+        if (count($tab_periodes_fermeture) != 0) {
             $return .= '<table class="table">';
             $return .= '<thead>';
             $return .= '<tr>';
             $return .= '<th colspan="2">Fermetures</th>';
             $return .= '</tr>';
             $return .= '</thead>';
-            foreach($tab_periodes_fermeture as $tab_periode) {
-                $date_affiche_1=eng_date_to_fr($tab_periode['date_deb']);
-                $date_affiche_2=eng_date_to_fr($tab_periode['date_fin']);
-                $fermeture_id =($tab_periode['fermeture_id']);
-                $groupe_id =($tab_periode['groupe_id']);
-                $groupe_name =($tab_periode['groupe_name']);
+            foreach ($tab_periodes_fermeture as $tab_periode) {
+                $date_affiche_1 = eng_date_to_fr($tab_periode['date_deb']);
+                $date_affiche_2 = eng_date_to_fr($tab_periode['date_fin']);
+                $fermeture_id   = ($tab_periode['fermeture_id']);
+                $groupe_id      = ($tab_periode['groupe_id']);
+                $groupe_name    = ($tab_periode['groupe_name']);
 
-                if($groupe_id==0) {
+                if ($groupe_id == 0) {
                     $groupe_name = 'Tous';
                 } else {
                     $groupe_name = $groupe_name;
@@ -3023,7 +3047,7 @@ class Fonctions
 
                 $return .= '<tr>';
                 $return .= '<td>';
-                $return .= _('divers_du') . ' <b>'. $date_affiche_1 . '</b> ' . _('divers_au') . ' <b>' . $date_affiche_2 . '</b>  (id ' . $fermeture_id . ')</b> ' . $groupe_name;
+                $return .= _('divers_du') . ' <b>' . $date_affiche_1 . '</b> ' . _('divers_au') . ' <b>' . $date_affiche_2 . '</b>  (id ' . $fermeture_id . ')</b> ' . $groupe_name;
                 $return .= '</td>';
                 $return .= '<td>';
                 $return .= '<a href="' . $PHP_SELF . '?session=' . $session . '&choix_action=annul_fermeture&fermeture_id=' . $fermeture_id . '&groupe_id=' . $groupe_id . '&fermeture_date_debut=' . $date_affiche_1 . '&fermeture_date_fin=' . $date_affiche_2 . '">' . _('admin_annuler_fermeture') . '</a>';
@@ -3034,7 +3058,7 @@ class Fonctions
         }
         $return .= '</div>';
         $return .= '<hr>';
-        $return .= '<a class="btn" href="'.ROOT_PATH.'/hr/hr_index.php?session=' . $session . '">' . _('form_cancel') . '</a>';
+        $return .= '<a class="btn" href="' . ROOT_PATH . '/hr/hr_index.php?session=' . $session . '">' . _('form_cancel') . '</a>';
         return $return;
     }
 
@@ -3064,43 +3088,43 @@ class Fonctions
         $groupe_id            = htmlentities(getpost_variable('groupe_id'), ENT_QUOTES | ENT_HTML401);
         $id_type_conges       = getpost_variable('id_type_conges');
         $new_date_debut       = getpost_variable('new_date_debut'); // valeur par dédaut = aujourd'hui
-        $new_date_fin         = getpost_variable('new_date_fin');   // valeur par dédaut = aujourd'hui
+        $new_date_fin         = getpost_variable('new_date_fin'); // valeur par dédaut = aujourd'hui
         $fermeture_id         = getpost_variable('fermeture_id', 0);
         $fermeture_date_debut = getpost_variable('fermeture_date_debut');
         $fermeture_date_fin   = getpost_variable('fermeture_date_fin');
         $code_erreur          = getpost_variable('code_erreur', 0);
 
         // si les dates de début ou de fin ne sont pas passé par get/post alors date du jour.
-        if($new_date_debut=="") {
-            if($year==0) {
-                $new_date_debut=date("d/m/Y") ;
+        if ($new_date_debut == "") {
+            if ($year == 0) {
+                $new_date_debut = date("d/m/Y");
             } else {
-                $new_date_debut=date("d/m/Y", mktime(0,0,0, date("m"), date("d"), $year) ) ;
+                $new_date_debut = date("d/m/Y", mktime(0, 0, 0, date("m"), date("d"), $year));
             }
         }
-        if($new_date_fin=="") {
-            if($year==0) {
-                $new_date_fin=date("d/m/Y") ;
+        if ($new_date_fin == "") {
+            if ($year == 0) {
+                $new_date_fin = date("d/m/Y");
             } else {
-                $new_date_fin=date("d/m/Y", mktime(0,0,0, date("m"), date("d"), $year) ) ;
+                $new_date_fin = date("d/m/Y", mktime(0, 0, 0, date("m"), date("d"), $year));
             }
         }
 
-        if($year ==0) {
-            $year= date("Y");
+        if ($year == 0) {
+            $year = date("Y");
         }
 
         /*************************************/
 
         /***********************************/
         /*  VERIF DES DATES RECUES   */
-        $tab_date_debut=explode("/",$new_date_debut);   // date au format d/m/Y
-        $timestamp_date_debut = mktime(0,0,0, $tab_date_debut[1], $tab_date_debut[0], $tab_date_debut[2]) ;
-        $date_debut_yyyy_mm_dd = $tab_date_debut[2]."-".$tab_date_debut[1]."-".$tab_date_debut[0] ;
-        $tab_date_fin=explode("/",$new_date_fin);   // date au format d/m/Y
-        $timestamp_date_fin = mktime(0,0,0, $tab_date_fin[1], $tab_date_fin[0], $tab_date_fin[2]) ;
-        $date_fin_yyyy_mm_dd = $tab_date_fin[2]."-".$tab_date_fin[1]."-".$tab_date_fin[0] ;
-        $timestamp_today = mktime(0,0,0, date("m"), date("d"), date("Y")) ;
+        $tab_date_debut        = explode("/", $new_date_debut); // date au format d/m/Y
+        $timestamp_date_debut  = mktime(0, 0, 0, $tab_date_debut[1], $tab_date_debut[0], $tab_date_debut[2]);
+        $date_debut_yyyy_mm_dd = $tab_date_debut[2] . "-" . $tab_date_debut[1] . "-" . $tab_date_debut[0];
+        $tab_date_fin          = explode("/", $new_date_fin); // date au format d/m/Y
+        $timestamp_date_fin    = mktime(0, 0, 0, $tab_date_fin[1], $tab_date_fin[0], $tab_date_fin[2]);
+        $date_fin_yyyy_mm_dd   = $tab_date_fin[2] . "-" . $tab_date_fin[1] . "-" . $tab_date_fin[0];
+        $timestamp_today       = mktime(0, 0, 0, date("m"), date("d"), date("Y"));
 
         /*********************************/
         /*   COMPOSITION DES ONGLETS...  */
@@ -3108,39 +3132,39 @@ class Fonctions
 
         $onglet = htmlentities(getpost_variable('onglet'), ENT_QUOTES | ENT_HTML401);
 
-        if(!$onglet) {
+        if (!$onglet) {
             $onglet = 'saisie';
         }
 
-        $onglets = array();
+        $onglets             = array();
         $onglets['saisie']   = _('admin_jours_fermeture_titre') . " " . "<span class=\"current-year\">$year</span>";
         $onglets['calendar'] = 'Calendrier des fermetures' . " " . "<span class=\"current-year\">$year</span>";
-        $onglets['year_nav'] = NULL;
+        $onglets['year_nav'] = null;
 
         //initialisation de l'action par défaut
-        if($choix_action=="") {
-            $choix_action="saisie_groupe";
+        if ($choix_action == "") {
+            $choix_action = "saisie_groupe";
         }
 
         /*********************************/
         /*   COMPOSITION DU HEADER...    */
         /*********************************/
 
-        $add_css = '<style>#onglet_menu .onglet{ width: '. (str_replace(',', '.', 100 / count($onglets) )).'% ;}</style>';
+        $add_css = '<style>#onglet_menu .onglet{ width: ' . (str_replace(',', '.', 100 / count($onglets))) . '% ;}</style>';
 
         /***********************************/
         // AFFICHAGE DE LA PAGE
-        header_menu('', 'Libertempo : '._('divers_fermeture'), $add_css);
+        header_menu('', 'Libertempo : ' . _('divers_fermeture'), $add_css);
 
         /*********************************/
         /*   AFFICHAGE DES ONGLETS...  */
         /*********************************/
         $return .= '<div id="onglet_menu">';
-        foreach($onglets as $key => $title) {
-            if($key == 'year_nav') {
+        foreach ($onglets as $key => $title) {
+            if ($key == 'year_nav') {
                 // navigation
-                $prev_link = "$PHP_SELF?session=$session&onglet=$onglet&year=". ($year - 1) . "&groupe_id=$groupe_id";
-                $next_link = "$PHP_SELF?session=$session&onglet=$onglet&year=". ($year + 1) . "&groupe_id=$groupe_id";
+                $prev_link = "$PHP_SELF?session=$session&onglet=$onglet&year=" . ($year - 1) . "&groupe_id=$groupe_id";
+                $next_link = "$PHP_SELF?session=$session&onglet=$onglet&year=" . ($year + 1) . "&groupe_id=$groupe_id";
                 $return .= '<div class="onglet calendar-nav">';
                 $return .= '<ul>';
                 $return .= '<li><a href="' . $prev_link . '" class="calendar-prev"><i class="fa fa-chevron-left"></i><span>année précédente</span></a></li>';
@@ -3155,92 +3179,93 @@ class Fonctions
         $return .= '</div>';
 
         // vérifie si les jours fériés sont saisie pour l'année en cours
-        if( (verif_jours_feries_saisis($date_debut_yyyy_mm_dd)==FALSE) && (verif_jours_feries_saisis($date_fin_yyyy_mm_dd)==FALSE) ) {
-                $code_erreur=1 ;  // code erreur : jour feriés non saisis
-                $onglet="calendar";
+        if ((verif_jours_feries_saisis($date_debut_yyyy_mm_dd) == false) && (verif_jours_feries_saisis($date_fin_yyyy_mm_dd) == false)) {
+            $code_erreur = 1; // code erreur : jour feriés non saisis
+            $onglet      = "calendar";
         }
 
         //initialisation de l'action demandée : saisie_dates, commit_new_fermeture pour enregistrer une fermeture, annul_fermeture pour confirmer une annulation, commit_annul_fermeture pour annuler une fermeture
 
         //en cas de confirmation d'une fermeture :
-        if($choix_action == "commit_new_fermeture") {
+        if ($choix_action == "commit_new_fermeture") {
             // on verifie que $new_date_debut est anterieure a $new_date_fin
-            if($timestamp_date_debut > $timestamp_date_fin) {
-                $code_erreur=2 ;  // code erreur : $new_date_debut est posterieure a $new_date_fin
-                $choix_action="saisie_dates";
+            if ($timestamp_date_debut > $timestamp_date_fin) {
+                $code_erreur  = 2; // code erreur : $new_date_debut est posterieure a $new_date_fin
+                $choix_action = "saisie_dates";
             }
             // on verifie que ce ne sont pas des dates passées
-            elseif($timestamp_date_debut < $timestamp_today) {
-                $code_erreur=3 ;  // code erreur : saisie de date passée
-                $choix_action="saisie_dates";
+            elseif ($timestamp_date_debut < $timestamp_today) {
+                $code_erreur  = 3; // code erreur : saisie de date passée
+                $choix_action = "saisie_dates";
             }
             // on ne verifie QUE si date_debut ou date_fin sont !=  d'aujourd'hui
             // (car aujourd'hui est la valeur par dédaut des dates, et on ne peut saisir aujourd'hui puisque c'est fermé !)
-            elseif( ($timestamp_date_debut==$timestamp_today) || ($timestamp_date_fin==$timestamp_today) ) {
-                $code_erreur=4 ;  // code erreur : saisie de aujourd'hui
-                $choix_action="saisie_dates";
+            elseif (($timestamp_date_debut == $timestamp_today) || ($timestamp_date_fin == $timestamp_today)) {
+                $code_erreur  = 4; // code erreur : saisie de aujourd'hui
+                $choix_action = "saisie_dates";
             } else {
                 // fabrication et initialisation du tableau des demi-jours de la date_debut à la date_fin
                 $tab_periode_calcul = make_tab_demi_jours_periode($date_debut_yyyy_mm_dd, $date_fin_yyyy_mm_dd, "am", "pm");
                 // on verifie si la periode saisie ne chevauche pas une periode existante
-                if(\hr\Fonctions::verif_periode_chevauche_periode_groupe($date_debut_yyyy_mm_dd, $date_fin_yyyy_mm_dd, '', $tab_periode_calcul, $groupe_id) ) {
-                    $code_erreur=5 ;  // code erreur : fermeture chevauche une periode deja saisie
-                    $choix_action="saisie_dates";
+                if (\hr\Fonctions::verif_periode_chevauche_periode_groupe($date_debut_yyyy_mm_dd, $date_fin_yyyy_mm_dd, '', $tab_periode_calcul, $groupe_id)) {
+                    $code_erreur  = 5; // code erreur : fermeture chevauche une periode deja saisie
+                    $choix_action = "saisie_dates";
                 }
             }
         }
 
-        if($onglet == 'calendar') {
+        if ($onglet == 'calendar') {
             // les jours fériés de l'annee de la periode saisie ne sont pas enregistrés
-            if($code_erreur==1) {
+            if ($code_erreur == 1) {
                 $return .= '<div class="alert alert-danger">' . _('admin_jours_fermeture_annee_non_saisie') . '</div>';
             }
 
-                   /************************************************/
+            /************************************************/
             // CALENDRIER DES FERMETURES
             $return .= \hr\Fonctions::affiche_calendrier_fermeture($year);
-        } elseif($choix_action=="saisie_dates") {
-            if($groupe_id=="") { // choix du groupe n'a pas été fait ($_SESSION['config']['fermeture_par_groupe']==FALSE)
-                $groupe_id=0;
+        } elseif ($choix_action == "saisie_dates") {
+            if ($groupe_id == "") {
+                // choix du groupe n'a pas été fait ($_SESSION['config']['fermeture_par_groupe']==FALSE)
+                $groupe_id = 0;
             }
 
             // $new_date_debut est anterieure a $new_date_fin
-            if($code_erreur==2) {
+            if ($code_erreur == 2) {
                 $return .= '<div class="alert alert-danger">' . _('admin_jours_fermeture_dates_incompatibles') . '</div>';
             }
 
             // ce ne sont des dates passées
-            if($code_erreur==3) {
+            if ($code_erreur == 3) {
                 $return .= '<div class="alert alert-danger">' . _('admin_jours_fermeture_date_passee_error') . '</div>';
             }
 
             // fermeture le jour même impossible
-            if($code_erreur==4) {
+            if ($code_erreur == 4) {
                 $return .= '<div class="alert alert-danger">' . _('admin_jours_fermeture_fermeture_aujourd_hui') . '</div>';
             }
 
             // la periode saisie chevauche une periode existante
-            if($code_erreur==5) {
+            if ($code_erreur == 5) {
                 $return .= '<div class="alert alert-danger">' . _('admin_jours_fermeture_chevauche_periode') . '</div>';
             }
 
             $return .= '<div class="wrapper">';
             $return .= '<a href="' . ROOT_PATH . 'hr/hr_index.php?session=' . $session . '" class="admin-back"><i class="fa fa-arrow-circle-o-left"></i>Retour mode rh</a>';
-            if($onglet == 'saisie') {
+            if ($onglet == 'saisie') {
                 $return .= \hr\Fonctions::saisie_dates_fermeture($year, $groupe_id, $new_date_debut, $new_date_fin, $code_erreur);
             }
-        } elseif($choix_action=="saisie_groupe") {
+        } elseif ($choix_action == "saisie_groupe") {
             $return .= '<div class="wrapper">';
             $return .= '<a href="' . ROOT_PATH . 'hr/hr_index.php?session=' . $session . '" class="admin-back"><i class="fa fa-arrow-circle-o-left"></i>Retour mode rh</a>';
             $return .= \hr\Fonctions::saisie_groupe_fermeture();
             $return .= '</div>';
-        } elseif($choix_action=="commit_new_fermeture") {
+        } elseif ($choix_action == "commit_new_fermeture") {
             $return .= $title;
             $return .= \hr\Fonctions::commit_new_fermeture($new_date_debut, $new_date_fin, $groupe_id, $id_type_conges);
-        } elseif($choix_action=="annul_fermeture") {
+        } elseif ($choix_action == "annul_fermeture") {
             $return .= $title;
             $return .= \hr\Fonctions::confirm_annul_fermeture($fermeture_id, $groupe_id, $fermeture_date_debut, $fermeture_date_fin);
-        } elseif($choix_action=="commit_annul_fermeture") {
+        } elseif ($choix_action == "commit_annul_fermeture") {
             $return .= $title;
             $return .= \hr\Fonctions::commit_annul_fermeture($fermeture_id, $groupe_id);
         }
@@ -3270,10 +3295,10 @@ class Fonctions
             } elseif ('DELETE' === $_POST['_METHOD'] && !empty($notice)) {
                 log_action(0, '', '', 'Suppression du planning ' . $_POST['planning_id']);
                 $message = '<form action="" method="post" accept-charset="UTF-8"
-enctype="application/x-www-form-urlencoded"><input type="hidden" name="planning_id" value="' . $_POST['planning_id'] . '" /><input type="hidden" name="status" value="' . \App\Models\Planning::STATUS_ACTIVE . '" /><input type="hidden" name="_METHOD" value="PATCH" /><div class="alert alert-info">' .  $notice . '. <button type="submit" class="btn btn-link alert-link">' . _('Annuler') . '</button></div></form>';
+enctype="application/x-www-form-urlencoded"><input type="hidden" name="planning_id" value="' . $_POST['planning_id'] . '" /><input type="hidden" name="status" value="' . \App\Models\Planning::STATUS_ACTIVE . '" /><input type="hidden" name="_METHOD" value="PATCH" /><div class="alert alert-info">' . $notice . '. <button type="submit" class="btn btn-link alert-link">' . _('Annuler') . '</button></div></form>';
             } else {
                 log_action(0, '', '', 'Récupération du planning ' . $_POST['planning_id']);
-                redirect(ROOT_PATH . 'hr/hr_index.php?session='. session_id() . '&onglet=liste_planning', false);
+                redirect(ROOT_PATH . 'hr/hr_index.php?session=' . session_id() . '&onglet=liste_planning', false);
             }
         }
 
@@ -3283,7 +3308,7 @@ enctype="application/x-www-form-urlencoded"><input type="hidden" name="planning_
         $return = '<h1>' . _('hr_affichage_liste_planning_titre') . '</h1>';
         $return .= $message;
         $session = session_id();
-        $table = new \App\Libraries\Structure\Table();
+        $table   = new \App\Libraries\Structure\Table();
         $table->addClasses([
             'table',
             'table-hover',
@@ -3301,7 +3326,7 @@ enctype="application/x-www-form-urlencoded"><input type="hidden" name="planning_
                 $childTable .= '<tr><td>' . $planning['name'] . '</td>';
                 $childTable .= '<td><form action="" method="post" accept-charset="UTF-8"
 enctype="application/x-www-form-urlencoded"><a  title="' . _('form_modif') . '" href="hr_index.php?onglet=modif_planning&id=' . $planning['planning_id'] .
-                '&session=' . $session . '"><i class="fa fa-pencil"></i></a>&nbsp;&nbsp;';
+                    '&session=' . $session . '"><i class="fa fa-pencil"></i></a>&nbsp;&nbsp;';
                 if (in_array($planning['planning_id'], $listIdUsed)) {
                     $childTable .= '<button title="' . _('planning_used') . '" type="button" class="btn btn-link disabled"><i class="fa fa-times-circle"></i></button>';
                 } else {
@@ -3336,7 +3361,7 @@ enctype="application/x-www-form-urlencoded"><a  title="' . _('form_modif') . '" 
         if (!empty($_POST)) {
             if (0 < (int) \App\ProtoControllers\HautResponsable\Planning::postPlanning($_POST, $errorsLst, $notice)) {
                 log_action(0, '', '', 'Édition du planning ' . $_POST['name']);
-                redirect(ROOT_PATH . 'hr/hr_index.php?session='. session_id() . '&onglet=liste_planning', false);
+                redirect(ROOT_PATH . 'hr/hr_index.php?session=' . session_id() . '&onglet=liste_planning', false);
             } else {
                 if (!empty($errorsLst)) {
                     $errors = '';
@@ -3367,13 +3392,13 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
-        $childTable = '<thead><tr><th class="col-md-4">' . _('Nom') .'</th><th></th></tr></thead><tbody>';
+        $childTable = '<thead><tr><th class="col-md-4">' . _('Nom') . '</th><th></th></tr></thead><tbody>';
         if (NIL_INT !== $id) {
-            $sql   = 'SELECT * FROM planning WHERE planning_id = ' . $id;
-            $query = \includes\SQL::query($sql);
-            $data = $query->fetch_assoc();
+            $sql       = 'SELECT * FROM planning WHERE planning_id = ' . $id;
+            $query     = \includes\SQL::query($sql);
+            $data      = $query->fetch_assoc();
             $valueName = $data['name'];
             $childTable .= '<tr><td>' . $valueName . '<input type="hidden" name="planning_id" value="' . $id . '" /><input type="hidden" name="_METHOD" value="PUT" /></td><td></td></tr>';
         }
@@ -3393,7 +3418,7 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
         $return .= '</div><div id="' . $idImpaire . '"><h4>' . _('hr_temps_partiel_sem_impaires') . '</h4>';
         $idPaire = uniqid();
         $return .= \hr\Fonctions::getFormPlanningTable(\App\Models\Planning\Creneau::TYPE_SEMAINE_IMPAIRE, $id, $_POST);
-        $return .= '</div><div id="' . $idPaire . '"><h4>' .  _('hr_temps_partiel_sem_paires') . '</h4>';
+        $return .= '</div><div id="' . $idPaire . '"><h4>' . _('hr_temps_partiel_sem_paires') . '</h4>';
 
         $return .= \hr\Fonctions::getFormPlanningTable(\App\Models\Planning\Creneau::TYPE_SEMAINE_PAIRE, $id, $_POST);
         $typeSemaine = [
@@ -3409,7 +3434,7 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
         $return .= '<h3>Employés associés</h3>';
         $return .= self::getFormPlanningEmployes($id);
         $return .= '<br><input type="submit" class="btn btn-success" value="' . _('form_submit') . '" />';
-        $return .='</form>';
+        $return .= '</form>';
 
         return $return;
     }
@@ -3448,14 +3473,14 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         $linkId       = uniqid();
         $selectJourId = uniqid();
         $debutId      = uniqid();
         $finId        = uniqid();
         $helperId     = uniqid();
-        $childTable = '<thead><tr><th width="20%">' . _('Jour') . '</th><th>' . _('Creneaux_travail') . '</th><tr></thead><tbody>';
+        $childTable   = '<thead><tr><th width="20%">' . _('Jour') . '</th><th>' . _('Creneaux_travail') . '</th><tr></thead><tbody>';
         $childTable .= '<tr><td><select class="form-control" id="' . $selectJourId . '"><option value="' . NIL_INT . '"></option>';
 
         foreach ($jours as $id => $jour) {
@@ -3466,7 +3491,7 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
         $childTable .= '<td><div class="form-inline col-xs-3"><input type="text" id="' . $debutId . '" class="form-control" style="width:45%" />&nbsp;<i class="fa fa-caret-right"></i>&nbsp;<input type="text" id="' . $finId . '" class="form-control" style="width:45%" size="8" /></div>';
         $childTable .= '&nbsp;&nbsp;<div class="form-inline col-xs-4"><label class="radio-inline"><input type="radio" name="periode" value="' . \App\Models\Planning\Creneau::TYPE_PERIODE_MATIN . '">' . _('form_am') . '</label>';
         $childTable .= '<label class="radio-inline"><input type="radio" name="periode" value="' . \App\Models\Planning\Creneau::TYPE_PERIODE_APRES_MIDI . '">' . _('form_pm') . '</label>';
-        $childTable .= '&nbsp;&nbsp; <button type="button" class="btn btn-default btn-sm" id="' .  $linkId . '"><i class="fa fa-plus link" ></i></button></div>';
+        $childTable .= '&nbsp;&nbsp; <button type="button" class="btn btn-default btn-sm" id="' . $linkId . '"><i class="fa fa-plus link" ></i></button></div>';
         $childTable .= '<span class="text-danger" id="' . $helperId . '"></span></td></tr>';
         $childTable .= '<script type="text/javascript">generateTimePicker("' . $debutId . '");generateTimePicker("' . $finId . '");</script>';
         foreach ($jours as $id => $jour) {
@@ -3506,15 +3531,15 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
      */
     private static function getFormPlanningEmployes($idPlanning)
     {
-        $idPlanning = (int) $idPlanning;
-        $return = '';
+        $idPlanning           = (int) $idPlanning;
+        $return               = '';
         $utilisateursAssocies = \App\ProtoControllers\HautResponsable\Planning::getListeUtilisateursAssocies($idPlanning);
 
         if (empty($utilisateursAssocies)) {
             $return .= '<div>' . _('hr_tout_utilisateur_associe') . '</div>';
         } else {
             $hasGroup = $_SESSION['config']['gestion_groupes'];
-            if($hasGroup) {
+            if ($hasGroup) {
                 $return .= '<div class="form-group col-md-4 col-sm-5">
                 <label class="control-label col-md-3 col-sm-3" for="groupe">Groupe&nbsp;:</label>
                 <div class="col-md-8 col-sm-8"><select class="form-control" name="groupeId" id="groupe">';
@@ -3527,26 +3552,26 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
                 }
                 $return .= '</select></div></div><br><br><br>';
                 $associations = array_map(function ($groupe) {
-                        return $groupe['utilisateurs'];
-                    },
+                    return $groupe['utilisateurs'];
+                },
                     $optionsGroupes
                 );
             }
             $return .= '<div>';
             foreach ($utilisateursAssocies as $utilisateur) {
                 $disabled = (\App\ProtoControllers\Utilisateur::hasSortiesEnCours($utilisateur['login']))
-                    ? 'disabled '
-                    : '';
+                ? 'disabled '
+                : '';
                 $checked = ($idPlanning === $utilisateur['planningId'])
-                    ? 'checked '
-                    : '';
+                ? 'checked '
+                : '';
                 $nom = \App\ProtoControllers\Utilisateur::getNomComplet($utilisateur['prenom'], $utilisateur['nom']);
                 $return .= '<div class="checkbox-utilisateur" data-user-login="' . $utilisateur['login'] . '">
-                    <label><input type="checkbox" name="utilisateurs[]" value="' . $utilisateur['login'] . '" ' . $disabled . $checked . ' />&nbsp;' . $nom  . '</label>
+                    <label><input type="checkbox" name="utilisateurs[]" value="' . $utilisateur['login'] . '" ' . $disabled . $checked . ' />&nbsp;' . $nom . '</label>
                 </div>';
             }
             $return .= '</div>';
-            if($hasGroup) {
+            if ($hasGroup) {
                 $return .= '<script type="text/javascript">
                 new selectAssociationPlanning("groupe", ' . json_encode($associations) . ', ' . NIL_INT . ');
                 </script>';

--- a/hr/hr_ajout_conges.php
+++ b/hr/hr_ajout_conges.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \hr\Fonctions::pageAjoutCongesModule($tab_type_cong, $session);

--- a/hr/hr_cloture_year.php
+++ b/hr/hr_cloture_year.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \hr\Fonctions::pageClotureYearModule($session);

--- a/hr/hr_index.php
+++ b/hr/hr_index.php
@@ -2,18 +2,17 @@
 
 define('ROOT_PATH', '../');
 require ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-include_once ROOT_PATH .'fonctions_conges.php' ;
-include_once INCLUDE_PATH .'fonction.php';
-include_once INCLUDE_PATH .'session.php';
-include_once ROOT_PATH .'fonctions_calcul.php';
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+include_once INCLUDE_PATH . 'session.php';
+include_once ROOT_PATH . 'fonctions_calcul.php';
 
 // verif des droits du user à afficher la page
 verif_droits_user($session, "is_hr");
-
 
 /*************************************/
 // recup des parametres reçus :
@@ -22,65 +21,63 @@ $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 // GET / POST
 $onglet = getpost_variable('onglet', "page_principale");
 
-
 /*********************************/
 /*   COMPOSITION DES ONGLETS...  */
 /*********************************/
 
 $onglets = array();
 
-
 $onglets['page_principale'] = _('resp_menu_button_retour_main');
 
-if( $_SESSION['config']['user_saisie_demande'] )
+if ($_SESSION['config']['user_saisie_demande']) {
     $onglets['traitement_demandes'] = _('resp_menu_button_traite_demande');
+}
 
 // if( $_SESSION['config']['resp_ajoute_conges'] )
-    $onglets['ajout_conges'] = _('resp_ajout_conges_titre');
-    $onglets['jours_chomes'] = _('admin_button_jours_chomes_1');
+$onglets['ajout_conges'] = _('resp_ajout_conges_titre');
+$onglets['jours_chomes'] = _('admin_button_jours_chomes_1');
 
-$onglets['cloture_year'] = _('resp_cloture_exercice_titre');
+$onglets['cloture_year']   = _('resp_cloture_exercice_titre');
 $onglets['liste_planning'] = _('hr_liste_planning');
 $onglets['ajout_planning'] = _('hr_ajout_planning');
 
-if ( !isset($onglets[ $onglet ]) && !in_array($onglet, ['traite_user', 'modif_planning']))
+if (!isset($onglets[$onglet]) && !in_array($onglet, ['traite_user', 'modif_planning'])) {
     $onglet = 'page_principale';
+}
 
 /*********************************/
 /*   COMPOSITION DU HEADER...    */
 /*********************************/
 
-$add_css = '<style>#onglet_menu .onglet{ width: '. (str_replace(',', '.', 100 / count($onglets) )).'% ;}</style>';
-header_menu('', 'Libertempo : '._('resp_menu_button_mode_hr'),$add_css);
+$add_css = '<style>#onglet_menu .onglet{ width: ' . (str_replace(',', '.', 100 / count($onglets))) . '% ;}</style>';
+header_menu('', 'Libertempo : ' . _('resp_menu_button_mode_hr'), $add_css);
 
 /*********************************/
 /*   AFFICHAGE DES ONGLETS...  */
 /*********************************/
 
 echo '<div id="onglet_menu">';
-foreach($onglets as $key => $title) {
-    echo '<div class="onglet '.($onglet == $key ? ' active': '').'" >
-        <a href="'.$PHP_SELF.'?session='.$session.'&onglet='.$key.'">'. $title .'</a>
+foreach ($onglets as $key => $title) {
+    echo '<div class="onglet ' . ($onglet == $key ? ' active' : '') . '" >
+        <a href="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $key . '">' . $title . '</a>
     </div>';
 }
 echo '</div>';
-
 
 /*********************************/
 /*   AFFICHAGE DE L'ONGLET ...    */
 /*********************************/
 
-
 /** initialisation des tableaux des types de conges/absences  **/
 // recup du tableau des types de conges (seulement les conges)
-$tab_type_cong=recup_tableau_types_conges();
+$tab_type_cong = recup_tableau_types_conges();
 
 // recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
 //    if ($_SESSION['config']['gestion_conges_exceptionnels'])
-$tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
+$tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
 
-echo '<div class="'.$onglet.' main-content">';
-    include_once ROOT_PATH . 'hr/hr_'.$onglet.'.php';
+echo '<div class="' . $onglet . ' main-content">';
+include_once ROOT_PATH . 'hr/hr_' . $onglet . '.php';
 echo '</div>';
 
 /*********************************/

--- a/hr/hr_jours_chomes.php
+++ b/hr/hr_jours_chomes.php
@@ -1,10 +1,11 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-if (file_exists(CONFIG_PATH .'config_ldap.php'))
-    include CONFIG_PATH .'config_ldap.php';
+if (file_exists(CONFIG_PATH . 'config_ldap.php')) {
+    include CONFIG_PATH . 'config_ldap.php';
+}
 
 echo \hr\Fonctions::pageJoursChomesModule($session);

--- a/hr/hr_jours_fermeture.php
+++ b/hr/hr_jours_fermeture.php
@@ -3,17 +3,16 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-if (file_exists(CONFIG_PATH .'config_ldap.php')) {
-    include_once CONFIG_PATH .'config_ldap.php';
+if (file_exists(CONFIG_PATH . 'config_ldap.php')) {
+    include_once CONFIG_PATH . 'config_ldap.php';
 }
 
-
-include_once ROOT_PATH .'fonctions_conges.php' ;
-include_once INCLUDE_PATH .'fonction.php';
-include_once INCLUDE_PATH .'session.php';
-include_once ROOT_PATH .'fonctions_calcul.php';
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+include_once INCLUDE_PATH . 'session.php';
+include_once ROOT_PATH . 'fonctions_calcul.php';
 
 echo \hr\Fonctions::pageJoursFermetureModule($session);
 bottom();

--- a/hr/hr_page_principale.php
+++ b/hr/hr_page_principale.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \hr\Fonctions::pagePrincipaleModule($tab_type_cong, $tab_type_conges_exceptionnels, $session);

--- a/hr/hr_traite_user.php
+++ b/hr/hr_traite_user.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \hr\Fonctions::pageTraiteUserModule($onglet);

--- a/hr/hr_traitement_demandes.php
+++ b/hr/hr_traitement_demandes.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \hr\Fonctions::pageTraitementDemandeModule($tab_type_cong, $onglet, $session);

--- a/imprim_calendrier.php
+++ b/imprim_calendrier.php
@@ -3,82 +3,79 @@
 define('ROOT_PATH', '');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-include_once ROOT_PATH .'fonctions_conges.php';
-include_once INCLUDE_PATH .'fonction.php';
-include_once INCLUDE_PATH .'session.php';
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+include_once INCLUDE_PATH . 'session.php';
 
-	/*** initialisation des variables ***/
-	$session=session_id();
-	/************************************/
+/*** initialisation des variables ***/
+$session = session_id();
+/************************************/
 
-	/*************************************/
-	// recup des parametres reçus :
-	// SERVER
-	$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-	// GET	/ POST
-	$action     = getpost_variable('action') ;
-	$new_mois = getpost_variable('new_mois', date("m")) ;
-	$new_year = getpost_variable('new_year', date("Y")) ;
-	/*************************************/
+/*************************************/
+// recup des parametres reçus :
+// SERVER
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+// GET    / POST
+$action   = getpost_variable('action');
+$new_mois = getpost_variable('new_mois', date("m"));
+$new_year = getpost_variable('new_year', date("Y"));
+/*************************************/
 
-
-	form_saisie($action, $new_mois, $new_year);
-
+form_saisie($action, $new_mois, $new_year);
 
 /*******************************************************************************/
 /**********  FONCTIONS  ********************************************************/
 
 function form_saisie($action, $new_mois, $new_year)
 {
-	$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-	$session=session_id();
+    $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+    $session  = session_id();
 
-	header_popup();
+    header_popup();
 
-    if($action=="imprim") {
+    if ($action == "imprim") {
         echo '<script type="text/javascript">OpenPopUp(\'calendrier.php?session=' . $session . '&printable=1&mois=' . $mois . '&year=' . $year . ',\'calendrier\',1000,600);</script>';
     }
 
+    echo "<center>\n";
+    echo "<h3>" . _('imprim_calendrier_titre') . "</h3>\n";
 
-	echo "<center>\n";
-	echo "<h3>". _('imprim_calendrier_titre') ."</h3>\n";
+    echo "<form action=\"$PHP_SELF?session=$session\" method=\"POST\">\n";
+    echo "<table>\n";
+    // choix du mois et annee
+    echo "<tr>\n";
+    echo "<td align=\"center\">\n";
+    echo "<b>" . _('divers_mois') . " : </b>\n";
+    $mois_default = date("m");
+    affiche_selection_new_mois($mois_default); // la variable est $new_mois
+    echo "</td>\n";
+    echo "<td align=\"center\">\n";
+    echo "<b>" . _('divers_annee') . " : </b>\n";
+    $year_default = date("Y");
+    affiche_selection_new_year($year_default - 5, $year_default + 5, $year_default); // la variable est $new_year
+    echo "</td>\n";
+    echo "</tr>\n";
+    // ligne vide
+    echo "<tr>\n";
+    echo "<td colspan=\"2\">&nbsp;\n";
+    echo "</td>\n";
+    echo "</tr>\n";
+    echo "<tr>\n";
+    echo "<td colspan=\"2\" align=\"center\">\n";
+    echo "	<input type=\"hidden\" name=\"action\" value=\"imprim\">\n";
+    echo "	<input type=\"submit\" value=\"" . _('form_submit') . "\">\n";
+    echo "</td>\n";
+    echo "</tr>\n";
+    echo "<tr>\n";
+    echo "<td colspan=\"2\" align=\"center\">\n";
+    echo "	<input type=\"button\" value=\"" . _('form_close_window') . "\" onClick=\"window.close();\">\n";
+    echo "</td>\n";
+    echo "</tr>\n";
+    echo "</table>\n";
+    echo "</form>\n";
 
-	echo "<form action=\"$PHP_SELF?session=$session\" method=\"POST\">\n";
-	echo "<table>\n";
-	// choix du mois et annee
-	echo "<tr>\n";
-		echo "<td align=\"center\">\n";
-		echo "<b>". _('divers_mois') ." : </b>\n";
-		$mois_default=date("m");
-		affiche_selection_new_mois($mois_default);  // la variable est $new_mois
-		echo "</td>\n";
-		echo "<td align=\"center\">\n";
-		echo "<b>". _('divers_annee') ." : </b>\n";
-		$year_default=date("Y");
-		affiche_selection_new_year($year_default-5, $year_default+5, $year_default );  // la variable est $new_year
-		echo "</td>\n";
-	echo "</tr>\n";
-	// ligne vide
-	echo "<tr>\n";
-		echo "<td colspan=\"2\">&nbsp;\n";
-		echo "</td>\n";
-	echo "</tr>\n";
-	echo "<tr>\n";
-	echo "<td colspan=\"2\" align=\"center\">\n";
-	echo "	<input type=\"hidden\" name=\"action\" value=\"imprim\">\n";
-	echo "	<input type=\"submit\" value=\"". _('form_submit') ."\">\n";
-	echo "</td>\n";
-	echo "</tr>\n";
-	echo "<tr>\n";
-	echo "<td colspan=\"2\" align=\"center\">\n";
-	echo "	<input type=\"button\" value=\"". _('form_close_window') ."\" onClick=\"window.close();\">\n";
-	echo "</td>\n";
-	echo "</tr>\n";
-	echo "</table>\n";
-	echo "</form>\n";
-
-	bottom();
+    bottom();
 
 }

--- a/includes/SQL.php
+++ b/includes/SQL.php
@@ -1,99 +1,110 @@
 <?php
 namespace includes;
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-
-
-
+defined('_PHP_CONGES') or die('Restricted access');
 
 // class SQL, interface with mysqli, it's a singleton, non-static method can be call staticly
 // Build for PHP 5.3
 class SQL
 {
-	// singleton
-	private static $instance;
+    // singleton
+    private static $instance;
 
-	// warper obj
-	private static $pdo_obj;
+    // warper obj
+    private static $pdo_obj;
 
-	//=====================
-	// singleton
-	//=====================
+    //=====================
+    // singleton
+    //=====================
 
-	// singleton pattern, code from php.net
-	// fucking parameters ... I don't find a way to use $args and call construtor with it ...
-	public static function singleton() {
-		if (!isset(self::$instance)) {
+    // singleton pattern, code from php.net
+    // fucking parameters ... I don't find a way to use $args and call construtor with it ...
+    public static function singleton()
+    {
+        if (!isset(self::$instance)) {
             $className = __CLASS__;
-			require CONFIG_PATH .'dbconnect.php';
+            require CONFIG_PATH . 'dbconnect.php';
 
-            self::$instance = new $className( $mysql_serveur , $mysql_user, $mysql_pass, $mysql_database);
-		}
-		return self::$instance;
-	}
-
-	public function initialized() {
-		return isset( self::$instance );
-	}
-
-	private function __construct() {
-		$args = func_get_args();
-		// this doesn't work ... need use ReflectionClass ... BEURK ! ReflectionClass is not documented ... unstable
-		// self::$pdo_obj = call_user_func_array('Database::__construct', $args);
-		$r = new \ReflectionClass('\includes\Database');
-		self::$pdo_obj = $r->newInstanceArgs($args);
-	}
-
-	// singleton pattern, code from php.net
-	public function __clone() { error_handler('Clone is not allowed.', E_USER_ERROR); }
-
-	// singleton pattern, code from php.net
-	public function __wakeup() { error_handler('Unserializing is not allowed.', E_USER_ERROR); }
-
-	// for call staticly dynamic fx (doesn't use instance vars and doesn't use singleton ;-) )
-	public static function __callStatic($name, $args) {
-		self::singleton();
-		if (method_exists(self::$instance, $name))
-			return call_user_func_array(array(self::$instance, $name), $args);
-		elseif (method_exists(self::$pdo_obj, $name))
-			return call_user_func_array(array(self::$pdo_obj, $name), $args);
-		else
-			throw new \Exception(sprintf('The required method "%s" does not exist for %s', $name, get_class(self::$instance)));
+            self::$instance = new $className($mysql_serveur, $mysql_user, $mysql_pass, $mysql_database);
+        }
+        return self::$instance;
     }
 
-	//=====================
-	// warper
-	//=====================
-
-	// isset on the warped obj
-    public function __isset($name) {
-		return isset(self::$pdo_obj->$name);
+    public function initialized()
+    {
+        return isset(self::$instance);
     }
 
-	// get on the warped obj
-    public function __get($name) {
-		return self::$pdo_obj->$name;
+    private function __construct()
+    {
+        $args = func_get_args();
+        // this doesn't work ... need use ReflectionClass ... BEURK ! ReflectionClass is not documented ... unstable
+        // self::$pdo_obj = call_user_func_array('Database::__construct', $args);
+        $r             = new \ReflectionClass('\includes\Database');
+        self::$pdo_obj = $r->newInstanceArgs($args);
     }
 
-	// isset on the warped obj
-    public function __set($name, $value) {
-		self::$pdo_obj->$name = $value;
+    // singleton pattern, code from php.net
+    public function __clone()
+    {error_handler('Clone is not allowed.', E_USER_ERROR);}
+
+    // singleton pattern, code from php.net
+    public function __wakeup()
+    {error_handler('Unserializing is not allowed.', E_USER_ERROR);}
+
+    // for call staticly dynamic fx (doesn't use instance vars and doesn't use singleton ;-) )
+    public static function __callStatic($name, $args)
+    {
+        self::singleton();
+        if (method_exists(self::$instance, $name)) {
+            return call_user_func_array(array(self::$instance, $name), $args);
+        } elseif (method_exists(self::$pdo_obj, $name)) {
+            return call_user_func_array(array(self::$pdo_obj, $name), $args);
+        } else {
+            throw new \Exception(sprintf('The required method "%s" does not exist for %s', $name, get_class(self::$instance)));
+        }
+
     }
 
-	// unset on the warped obj
-	public function __unset($name) {
-		unset(self::$pdo_obj->$name);
-	}
+    //=====================
+    // warper
+    //=====================
 
-	// call on the warped obj
-	public function __call($name, $args) {
-		return call_user_func_array(array(self::$pdo_obj, $name), $args);
-	}
+    // isset on the warped obj
+    public function __isset($name)
+    {
+        return isset(self::$pdo_obj->$name);
+    }
 
-	// call on the warped obj
-	public static function getVar($name) {
-		return self::$pdo_obj->$name;
-	}
+    // get on the warped obj
+    public function __get($name)
+    {
+        return self::$pdo_obj->$name;
+    }
+
+    // isset on the warped obj
+    public function __set($name, $value)
+    {
+        self::$pdo_obj->$name = $value;
+    }
+
+    // unset on the warped obj
+    public function __unset($name)
+    {
+        unset(self::$pdo_obj->$name);
+    }
+
+    // call on the warped obj
+    public function __call($name, $args)
+    {
+        return call_user_func_array(array(self::$pdo_obj, $name), $args);
+    }
+
+    // call on the warped obj
+    public static function getVar($name)
+    {
+        return self::$pdo_obj->$name;
+    }
 
     /**
      * Retourne l'objet DB
@@ -106,106 +117,110 @@ class SQL
     }
 }
 
-
 class Database extends \mysqli
 {
-	private static $hist = array();
+    private static $hist = array();
 
-    public function __construct ( $host='localhost', $username='root', $passwd ='',$dbname = 'db_conges')
+    public function __construct($host = 'localhost', $username = 'root', $passwd = '', $dbname = 'db_conges')
     {
-		parent::__construct (  $host , $username , $passwd , $dbname );
-		$this->query('SET NAMES \'utf8\';');
+        parent::__construct($host, $username, $passwd, $dbname);
+        $this->query('SET NAMES \'utf8\';');
     }
 
-	public function multi_query($query) {
-		throw new Exception('Function disabled !' );
-	}
-
-	public function real_query($query) {
-		throw new Exception('Function disabled !' );
-	}
-
-	public function getQuerys() {
-		return self::$hist;
-	}
-
-    public function query( $query , $resultmode = MYSQLI_STORE_RESULT )
+    public function multi_query($query)
     {
-		$nb = count(self::$hist);
+        throw new Exception('Function disabled !');
+    }
 
-		$backtraces = debug_backtrace();
-		$f = false;
-		foreach ( $backtraces as $k => $b ) {
-			if (isset($b['file']) && basename($b['file']) != 'sql.class.php') {
-				$f = $b;
-				break;
-			}
-		}
-		if ($f)
-			self::$hist[$nb]['back'] = $f;
-		self::$hist[$nb]['query'] = $query;
-		self::$hist[$nb]['t1'] = microtime(true);
-		$result = parent::query($query, $resultmode);
-		self::$hist[$nb]['t2'] = microtime(true);
-		self::$hist[$nb]['results'] = is_object($result) ? $result->num_rows : ($result ? 'TRUE': 'FALSE');
-		if ($this->errno != 0)
-		{
-			$dump_name = DUMP_PATH . 'sql_' . date('c') . '.dump';
-			$fh = fopen( $dump_name , 'a+');
-			if($fh ==! false) {
-				fputs ($fh, "\n".'##################################################');
-				fputs ($fh, "\n".'Date : '. date('Y-m-d H:i:s (T)') );
-				fputs ($fh, "\n".'**************************************************');
-				fputs ($fh, "\n".'--------------------------------------------------');
-				fputs ($fh, "\n".'=> Last erreur log');
-				fputs ($fh, "\n".var_export(error_get_last(), true));
-				fputs ($fh, "\n".'**************************************************');
-				fputs ($fh, "\n".'--------------------------------------------------');
-				fputs ($fh, "\n".'=> Debug Backtrace');
-				fputs ($fh, "\n".var_export($backtraces, true));
-				fputs ($fh, "\n".'**************************************************');
-				fputs ($fh, "\n".'--------------------------------------------------');
-				fputs ($fh, "\n".'=> Var dump $_REQUEST');
-				fputs ($fh, "\n".var_export($_REQUEST, true));
-				fputs ($fh, "\n".'--------------------------------------------------');
-				fputs ($fh, "\n".'=> Var dump $_SESSION');
-				fputs ($fh, "\n".var_export((isset($_SESSION) ? $_SESSION : array() ), true));
-				fputs ($fh, "\n".'--------------------------------------------------');
-				fputs ($fh, "\n".'=> Var dump $_SERVER');
-				fputs ($fh, "\n".var_export($_SERVER, true));
-				fputs ($fh, "\n".'**************************************************');
-				fclose ($fh);
-			}
+    public function real_query($query)
+    {
+        throw new Exception('Function disabled !');
+    }
 
-			if (defined('ERROR_MAIL_REPORT'))
-				@mail(ERROR_MAIL_REPORT,'Errors php-conges',file_get_contents($dump_name));
+    public function getQuerys()
+    {
+        return self::$hist;
+    }
 
-			@ob_clean();
-			// DONT USE GETTEXT ... KEEP THIS CODE WITHOUT REF ... THIS NEED TO BE A SAFE CODE !!!!
-			echo '<div style="margin: auto; width: 80%;">
+    public function query($query, $resultmode = MYSQLI_STORE_RESULT)
+    {
+        $nb = count(self::$hist);
+
+        $backtraces = debug_backtrace();
+        $f          = false;
+        foreach ($backtraces as $k => $b) {
+            if (isset($b['file']) && basename($b['file']) != 'sql.class.php') {
+                $f = $b;
+                break;
+            }
+        }
+        if ($f) {
+            self::$hist[$nb]['back'] = $f;
+        }
+
+        self::$hist[$nb]['query']   = $query;
+        self::$hist[$nb]['t1']      = microtime(true);
+        $result                     = parent::query($query, $resultmode);
+        self::$hist[$nb]['t2']      = microtime(true);
+        self::$hist[$nb]['results'] = is_object($result) ? $result->num_rows : ($result ? 'TRUE' : 'FALSE');
+        if ($this->errno != 0) {
+            $dump_name = DUMP_PATH . 'sql_' . date('c') . '.dump';
+            $fh        = fopen($dump_name, 'a+');
+            if ($fh == !false) {
+                fputs($fh, "\n" . '##################################################');
+                fputs($fh, "\n" . 'Date : ' . date('Y-m-d H:i:s (T)'));
+                fputs($fh, "\n" . '**************************************************');
+                fputs($fh, "\n" . '--------------------------------------------------');
+                fputs($fh, "\n" . '=> Last erreur log');
+                fputs($fh, "\n" . var_export(error_get_last(), true));
+                fputs($fh, "\n" . '**************************************************');
+                fputs($fh, "\n" . '--------------------------------------------------');
+                fputs($fh, "\n" . '=> Debug Backtrace');
+                fputs($fh, "\n" . var_export($backtraces, true));
+                fputs($fh, "\n" . '**************************************************');
+                fputs($fh, "\n" . '--------------------------------------------------');
+                fputs($fh, "\n" . '=> Var dump $_REQUEST');
+                fputs($fh, "\n" . var_export($_REQUEST, true));
+                fputs($fh, "\n" . '--------------------------------------------------');
+                fputs($fh, "\n" . '=> Var dump $_SESSION');
+                fputs($fh, "\n" . var_export((isset($_SESSION) ? $_SESSION : array()), true));
+                fputs($fh, "\n" . '--------------------------------------------------');
+                fputs($fh, "\n" . '=> Var dump $_SERVER');
+                fputs($fh, "\n" . var_export($_SERVER, true));
+                fputs($fh, "\n" . '**************************************************');
+                fclose($fh);
+            }
+
+            if (defined('ERROR_MAIL_REPORT')) {
+                @mail(ERROR_MAIL_REPORT, 'Errors php-conges', file_get_contents($dump_name));
+            }
+
+            @ob_clean();
+            // DONT USE GETTEXT ... KEEP THIS CODE WITHOUT REF ... THIS NEED TO BE A SAFE CODE !!!!
+            echo '<div style="margin: auto; width: 80%;">
 					<h1>Une erreur est survenue ...</h1>
 					<p>Pour aider la résolution de ce problème, veuillez fournir les informations suivantes :</p>
 					<div>
-						<div style="float:left;width: 230px;"><img src="'. IMG_PATH .'oops.png" style="width: 98%" /></div>
-						<textarea style="width: 70%" rows="14">'.
-						'login : '.@$_SESSION['userlogin']."\n".
-						'uri   : '.preg_replace('/session=phpconges[a-z0-9]{32}&?/','',@$_SERVER['REQUEST_URI'])."\n".
-						'dump  : '.$dump_name."\n"."\n".
-						'file  : '.$f['file']."\n".
-						'line  : '.$f['line']	."\n".
-						'fx    : $SQL->query'	."\n".
-						'error : '.$this->error	."\n".
-						'sql   : '.$query		."\n".
-						'</textarea>
+						<div style="float:left;width: 230px;"><img src="' . IMG_PATH . 'oops.png" style="width: 98%" /></div>
+						<textarea style="width: 70%" rows="14">' .
+            'login : ' . @$_SESSION['userlogin'] . "\n" .
+            'uri   : ' . preg_replace('/session=phpconges[a-z0-9]{32}&?/', '', @$_SERVER['REQUEST_URI']) . "\n" .
+            'dump  : ' . $dump_name . "\n" . "\n" .
+            'file  : ' . $f['file'] . "\n" .
+            'line  : ' . $f['line'] . "\n" .
+            'fx    : $SQL->query' . "\n" .
+            'error : ' . $this->error . "\n" .
+                'sql   : ' . $query . "\n" .
+                '</textarea>
 					</div>
 				</div>';
-			exit();
-		}
-		return $result;
+            exit();
+        }
+        return $result;
     }
 
-	public function quote( $escapestr )
-	{
-		return $this->escape_string( $escapestr );
-	}
+    public function quote($escapestr)
+    {
+        return $this->escape_string($escapestr);
+    }
 }

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -1,196 +1,210 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
-include_once INCLUDE_PATH .'fonction_config.php';
-include_once INCLUDE_PATH .'lang_profile.php';
+include_once INCLUDE_PATH . 'fonction_config.php';
+include_once INCLUDE_PATH . 'lang_profile.php';
 //better to include_once plugins at the end : see bottom function
 //include_once INCLUDE_PATH .'plugins.php';
 
-function schars( $htmlspec ) {
-    return htmlspecialchars( $htmlspec );
+function schars($htmlspec)
+{
+    return htmlspecialchars($htmlspec);
 }
 
-function redirect($url , $auto_exit = true) {
+function redirect($url, $auto_exit = true)
+{
     // $url = urlencode($url);
     if (headers_sent()) {
         echo '<html>';
-            echo '<head>';
-                echo '<meta HTTP-EQUIV="REFRESH" CONTENT="0; URL='.$url.'">';
-                echo '<script language=javascript>
+        echo '<head>';
+        echo '<meta HTTP-EQUIV="REFRESH" CONTENT="0; URL=' . $url . '">';
+        echo '<script language=javascript>
                         function redirection(page){
                             window.location=page;
                         }
-                        setTimeout(\'redirection("'.$url.'")\',100);
+                        setTimeout(\'redirection("' . $url . '")\',100);
                     </script>';
-            echo '</head>';
+        echo '</head>';
         echo '</html>';
+    } else {
+        header('Location: ' . $url);
     }
-    else {
-        header('Location: '.$url);
-    }
-    if ($auto_exit)
+    if ($auto_exit) {
         exit;
-}
+    }
 
+}
 
 //Get the name of current php page
-function curPage() {
- $local_scripts = array();
- $local_scripts[0] = substr($_SERVER["SCRIPT_NAME"],strrpos($_SERVER["SCRIPT_NAME"],"/")+1);
- $local_scripts[1] = $_SERVER["REQUEST_URI"];
- return $local_scripts;
+function curPage()
+{
+    $local_scripts    = array();
+    $local_scripts[0] = substr($_SERVER["SCRIPT_NAME"], strrpos($_SERVER["SCRIPT_NAME"], "/") + 1);
+    $local_scripts[1] = $_SERVER["REQUEST_URI"];
+    return $local_scripts;
 }
 
-
-function header_popup($title = '' , $additional_head = '' ) {
+function header_popup($title = '', $additional_head = '')
+{
     global $type_bottom;
     global $session;
 
     static $last_use = '';
     if ($last_use == '') {
         $last_use = debug_backtrace();
-    }else
-        throw new Exception('Warning : Ne peux ouvrir deux header !!! previous = '.$last_use['file']);
+    } else {
+        throw new Exception('Warning : Ne peux ouvrir deux header !!! previous = ' . $last_use['file']);
+    }
 
     $type_bottom = 'popup';
 
-    if (empty($title))
+    if (empty($title)) {
         $title = 'Libertempo';
+    }
 
     include_once TEMPLATE_PATH . 'popup_header.php';
 }
 
-function header_error($title = '' , $additional_head = '' ) {
+function header_error($title = '', $additional_head = '')
+{
     global $type_bottom;
     global $session;
 
     static $last_use = '';
     if ($last_use == '') {
         $last_use = debug_backtrace();
-    }else
-        throw new Exception('Warning : Ne peux ouvrir deux header !!! previous = '.$last_use['file']);
+    } else {
+        throw new Exception('Warning : Ne peux ouvrir deux header !!! previous = ' . $last_use['file']);
+    }
 
     $type_bottom = 'error';
 
-    if (empty($title))
+    if (empty($title)) {
         $title = 'Libertempo';
+    }
 
     include_once TEMPLATE_PATH . 'error_header.php';
 }
 
-function header_login($title = '' , $additional_head = '' ) {
+function header_login($title = '', $additional_head = '')
+{
     global $type_bottom;
     global $session;
 
     static $last_use = '';
     if ($last_use == '') {
         $last_use = debug_backtrace();
-    }else
-        throw new Exception('Warning : Ne peux ouvrir deux header !!! previous = '.$last_use['file']);
+    } else {
+        throw new Exception('Warning : Ne peux ouvrir deux header !!! previous = ' . $last_use['file']);
+    }
 
     $type_bottom = 'login';
 
-    if (empty($title))
+    if (empty($title)) {
         $title = 'Libertempo';
+    }
 
     include_once TEMPLATE_PATH . 'login_header.php';
 }
 
-function header_menu( $info ,$title = '' , $additional_head = '' ) {
+function header_menu($info, $title = '', $additional_head = '')
+{
     global $type_bottom;
     global $session;
 
     static $last_use = '';
     if ($last_use == '') {
         $last_use = debug_backtrace();
-    }else
-        throw new Exception('Warning : Ne peux ouvrir deux header !!! previous = '.$last_use['file']);
+    } else {
+        throw new Exception('Warning : Ne peux ouvrir deux header !!! previous = ' . $last_use['file']);
+    }
 
     $type_bottom = 'menu';
 
-    if (empty($title))
+    if (empty($title)) {
         $title = 'Libertempo';
+    }
 
     include_once TEMPLATE_PATH . 'menu_header.php';
 }
 
-function bouton($name, $icon ,$link, $active = false)
+function bouton($name, $icon, $link, $active = false)
 {
-    $name = str_replace('"','\\"',$name);
-    $icon = str_replace('"','\\"',$icon);
-    $link = str_replace('"','\\"',$link);
-    echo '<div class="button_div'.($active?' active':'').'">
-            <a href="'. $link .'">
-                <img src="'. IMG_PATH . $icon.'" title="'.$name.'" alt="'.$name.'">
-                <span>'.$name.'</span>
+    $name = str_replace('"', '\\"', $name);
+    $icon = str_replace('"', '\\"', $icon);
+    $link = str_replace('"', '\\"', $link);
+    echo '<div class="button_div' . ($active ? ' active' : '') . '">
+            <a href="' . $link . '">
+                <img src="' . IMG_PATH . $icon . '" title="' . $name . '" alt="' . $name . '">
+                <span>' . $name . '</span>
             </a>
         </div>';
 }
 
-function bouton_popup($name, $icon ,$link, $popup_name, $size_x, $size_y, $active = false)
+function bouton_popup($name, $icon, $link, $popup_name, $size_x, $size_y, $active = false)
 {
-    $name = str_replace('"','\\"',$name);
+    $name = str_replace('"', '\\"', $name);
 
-    echo '<div class="button_div'.($active?' active':'').'">
-            <a href="#" onClick="OpenPopUp(\''. $link .'\',\''.$popup_name.'\','.$size_x.','.$size_y.');">
-                <img src="'. IMG_PATH . $icon.'" title="'.$name.'" alt="'.$name.'">
-                <span>'.$name.'</span>
+    echo '<div class="button_div' . ($active ? ' active' : '') . '">
+            <a href="#" onClick="OpenPopUp(\'' . $link . '\',\'' . $popup_name . '\',' . $size_x . ',' . $size_y . ');">
+                <img src="' . IMG_PATH . $icon . '" title="' . $name . '" alt="' . $name . '">
+                <span>' . $name . '</span>
             </a>
         </div>';
 }
 
-function bottom() {
+function bottom()
+{
     global $type_bottom;
-
 
     static $last_use = '';
     if ($last_use == '') {
         $last_use = debug_backtrace();
-    }else
+    } else {
         throw new Exception('Warning : Ne peux ouvrir deux header !!!');
+    }
 
-    include_once INCLUDE_PATH .'plugins.php';
-    include_once TEMPLATE_PATH . $type_bottom .'_bottom.php';
+    include_once INCLUDE_PATH . 'plugins.php';
+    include_once TEMPLATE_PATH . $type_bottom . '_bottom.php';
 }
-
 
 //manage plugins
-function install_plugin($plugin){
-    include_once INCLUDE_PATH . "/plugins/".$plugin."/plugin_install.php";
+function install_plugin($plugin)
+{
+    include_once INCLUDE_PATH . "/plugins/" . $plugin . "/plugin_install.php";
 }
-function activate_plugin($plugin){
-    include_once INCLUDE_PATH . "/plugins/".$plugin."/plugin_active.php";
+function activate_plugin($plugin)
+{
+    include_once INCLUDE_PATH . "/plugins/" . $plugin . "/plugin_active.php";
 }
-function uninstall_plugin($plugin){
-    include_once INCLUDE_PATH . "/plugins/".$plugin."/plugin_uninstall.php";
+function uninstall_plugin($plugin)
+{
+    include_once INCLUDE_PATH . "/plugins/" . $plugin . "/plugin_uninstall.php";
 }
-function disable_plugin($plugin){
-    include_once INCLUDE_PATH . "/plugins/".$plugin."/plugin_inactive.php";
+function disable_plugin($plugin)
+{
+    include_once INCLUDE_PATH . "/plugins/" . $plugin . "/plugin_inactive.php";
 }
-
-
-
-
 
 //
 // indique (TRUE / FALSE) si une session est valide (par / au temps de connexion)
 //
 function session_is_valid($session)
 {
-   // ATTENTION:  on fixe l'id de session comme nom de session pour que , sur un meme pc, on puisse se loguer sous 2 users à la fois
-   if (session_id() == "")
-   {
-      session_name($session);
-      session_start();
-   }
+    // ATTENTION:  on fixe l'id de session comme nom de session pour que , sur un meme pc, on puisse se loguer sous 2 users à la fois
+    if (session_id() == "") {
+        session_name($session);
+        session_start();
+    }
 
-    if( (isset($_SESSION['timestamp_last'])) && (isset($_SESSION['config'])) )
-    {
+    if ((isset($_SESSION['timestamp_last'])) && (isset($_SESSION['config']))) {
         $difference = time() - $_SESSION['timestamp_last'];
 
-        if ( ($session==session_id()) && ($difference < $_SESSION['config']['duree_session']) )
+        if (($session == session_id()) && ($difference < $_SESSION['config']['duree_session'])) {
             return true;
+        }
+
     }
 
     return false;
@@ -201,34 +215,38 @@ function session_is_valid($session)
 //
 function session_create($username)
 {
-    if ($username != "")
-    {
-        if(isset($_SESSION)) unset($_SESSION);
-        $session = "phpconges".md5(uniqid(rand()));
+    if ($username != "") {
+        if (isset($_SESSION)) {
+            unset($_SESSION);
+        }
+
+        $session = "phpconges" . md5(uniqid(rand()));
         session_name($session);
         session_id($session);
 
         session_start();
-        $_SESSION['userlogin']=$username;
-        $maintenant=time();
-        $_SESSION['timestamp_start']=$maintenant;
-        $_SESSION['timestamp_last']=$maintenant;
-        if (function_exists('init_config_tab'))
-            $_SESSION['config']=init_config_tab();      // on initialise le tableau des variables de config
+        $_SESSION['userlogin']       = $username;
+        $maintenant                  = time();
+        $_SESSION['timestamp_start'] = $maintenant;
+        $_SESSION['timestamp_last']  = $maintenant;
+        if (function_exists('init_config_tab')) {
+            $_SESSION['config'] = init_config_tab();
+        }
+        // on initialise le tableau des variables de config
         //$session=session_id();
 
-        if (isset($_REQUEST['lang']))
+        if (isset($_REQUEST['lang'])) {
             $_SESSION['lang'] = $_REQUEST['lang'];
-    }
-    else
-    {
-        $session="";
+        }
+
+    } else {
+        $session = "";
     }
 
-    $comment_log = 'Connexion de '.$username;
+    $comment_log = 'Connexion de ' . $username;
     log_action(0, "", $username, $comment_log);
 
-    return   $session;
+    return $session;
 }
 
 //
@@ -236,10 +254,9 @@ function session_create($username)
 //
 function session_update($session)
 {
-   if ($session != "")
-   {
+    if ($session != "") {
         $_SESSION['timestamp_last'] = time();
-   }
+    }
 }
 
 //
@@ -247,49 +264,48 @@ function session_update($session)
 //
 function session_delete($session)
 {
-   if ($session != "")
-   {
-     unset($_SESSION['userlogin']);
-     unset($_SESSION['timestamp_start']);
-     unset($_SESSION['timestamp_last']);
-     unset($_SESSION['tab_j_feries']);
-     unset($_SESSION['config']);
-     unset($_SESSION['lang']);
-     session_destroy();
-   }
+    if ($session != "") {
+        unset($_SESSION['userlogin']);
+        unset($_SESSION['timestamp_start']);
+        unset($_SESSION['timestamp_last']);
+        unset($_SESSION['tab_j_feries']);
+        unset($_SESSION['config']);
+        unset($_SESSION['lang']);
+        session_destroy();
+    }
 }
-
-
 
 //
 // formulaire de saisie du user/password
 //
 function session_saisie_user_password($erreur, $session_username, $session_password)
 {
-   $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+    $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
     $config_php_conges_version      = $_SESSION['config']['php_conges_version'];
     $config_url_site_web_php_conges = $_SESSION['config']['url_site_web_php_conges'];
 //    $config_stylesheet_file         = $_SESSION['config']['stylesheet_file'];
 
-    $return_url                     = getpost_variable('return_url', false);
+    $return_url = getpost_variable('return_url', false);
 
     // verif si on est dans le repertoire install
-    if(substr(dirname ($_SERVER["SCRIPT_FILENAME"]), -6, 6) == "config")   // verif si on est dans le repertoire install
-        $config_dir=TRUE;
-    else
-        $config_dir=FALSE;
+    if (substr(dirname($_SERVER["SCRIPT_FILENAME"]), -6, 6) == "config") // verif si on est dans le repertoire install
+    {
+        $config_dir = true;
+    } else {
+        $config_dir = false;
+    }
 
     $add = '<script language="JavaScript" type="text/javascript">
 <!--
 // Les cookies sont obligatoires
 if (! navigator.cookieEnabled) {
-    document.write("<font color=\'#FF0000\'><br><br><center>'. _('cookies_obligatoires') .'</center></font><br><br>");
+    document.write("<font color=\'#FF0000\'><br><br><center>' . _('cookies_obligatoires') . '</center></font><br><br>");
 }
 //-->
 </script>
 <noscript>
-        <font color="#FF0000"><br><br><center>'. _('javascript_obligatoires') .'</center></font><br><br>
+        <font color="#FF0000"><br><br><center>' . _('javascript_obligatoires') . '</center></font><br><br>
 </noscript>';
 
     header_login('', $add);
@@ -299,45 +315,44 @@ if (! navigator.cookieEnabled) {
     exit;
 }
 
-
-
 //
 // autentifie un user dans le base mysql avec son login et son passwd conges :
 // - renvoie $username si authentification OK
 // - renvoie ""        si authentification FAIL
 //
-function autentification_passwd_conges($username,$password)
+function autentification_passwd_conges($username, $password)
 {
-    $password_md5=md5($password);
+    $password_md5 = md5($password);
 //  $req_conges="SELECT u_passwd   FROM conges_users   WHERE u_login='$username' AND u_passwd='$password_md5' " ;
     // on conserve le double mode d'autentificatio (nouveau cryptage (md5) ou ancien cryptage (mysql))
-    $req_conges='SELECT u_passwd   FROM conges_users   WHERE u_login="'. \includes\SQL::quote( $username ) .'" AND ( u_passwd=\''. md5($password) .'\' OR u_passwd=PASSWORD("'. \includes\SQL::quote( $password ).'") ) ' ;
-    $res_conges = \includes\SQL::query($req_conges) ;
+    $req_conges     = 'SELECT u_passwd   FROM conges_users   WHERE u_login="' . \includes\SQL::quote($username) . '" AND ( u_passwd=\'' . md5($password) . '\' OR u_passwd=PASSWORD("' . \includes\SQL::quote($password) . '") ) ';
+    $res_conges     = \includes\SQL::query($req_conges);
     $num_row_conges = $res_conges->num_rows;
-    if ($num_row_conges !=0)
+    if ($num_row_conges != 0) {
         return $username;
+    }
+
     return '';
 }
-
 
 // authentification du login/passwd sur un serveur LDAP
 // - renvoie $username si authentification OK
 // - renvoie ""        si authentification FAIL
 //
-function authentification_ldap_conges($username,$password)
+function authentification_ldap_conges($username, $password)
 {
-    require_once ( LIBRARY_PATH .'authLDAP.php');
+    require_once LIBRARY_PATH . 'authLDAP.php';
 
     $a = new authLDAP();
     //$a->DEBUG = 1;
     //$a->bind($username,$password);
-    $a->bind($username,stripslashes($password));
-    if ($a->is_authentificated())
+    $a->bind($username, stripslashes($password));
+    if ($a->is_authentificated()) {
         return $username;
+    }
 
     return '';
 }
-
 
 // Authentifie l'utilisateur auprès du serveur CAS, puis auprès de la base de donnée.
 // Si le login qui a permis d'authentifier l'utilisateur auprès du serveur
@@ -347,36 +362,33 @@ function authentification_ldap_conges($username,$password)
 // - renvoie ""        si authentification FAIL
 function authentification_passwd_conges_CAS()
 {
-    $config_CAS_host       =$_SESSION['config']['CAS_host'];
-    $config_CAS_portNumber =$_SESSION['config']['CAS_portNumber'];
-    $config_CAS_URI        =$_SESSION['config']['CAS_URI'];
-    $config_CAS_CACERT     =$_SESSION['config']['CAS_CACERT'];
+    $config_CAS_host       = $_SESSION['config']['CAS_host'];
+    $config_CAS_portNumber = $_SESSION['config']['CAS_portNumber'];
+    $config_CAS_URI        = $_SESSION['config']['CAS_URI'];
+    $config_CAS_CACERT     = $_SESSION['config']['CAS_CACERT'];
 
     global $connexionCAS;
     global $logoutCas;
 
-
     \phpCAS::setDebug();
 
     // initialisation phpCAS
-    if($connexionCAS!="active")
-    {
-        $CASCnx = \phpCAS::client(CAS_VERSION_2_0,$config_CAS_host,$config_CAS_portNumber,$config_CAS_URI);
+    if ($connexionCAS != "active") {
+        $CASCnx       = \phpCAS::client(CAS_VERSION_2_0, $config_CAS_host, $config_CAS_portNumber, $config_CAS_URI);
         $connexionCAS = "active";
 
     }
 
-    if($logoutCas==1)
-    {
+    if ($logoutCas == 1) {
         \phpCAS::logout();
     }
 
-
     // Vérification SSL
-    if(!empty($config_CAS_CACERT))
-        \phpCAS::setCasServerCACert ($config_CAS_CACERT);
-    else
+    if (!empty($config_CAS_CACERT)) {
+        \phpCAS::setCasServerCACert($config_CAS_CACERT);
+    } else {
         \phpCAS::setNoCasServerValidation();
+    }
 
     // authentificationCAS (redirection vers la page d'authentification de CAS)
     \phpCAS::forceAuthentication();
@@ -389,31 +401,29 @@ function authentification_passwd_conges_CAS()
     session_create($usernameCAS);
 
     //ON VERIFIE ICI QUE L'UTILISATEUR EST DEJA ENREGISTRE SOUS DBCONGES
-    $req_conges = 'SELECT u_login FROM conges_users WHERE u_login=\''. \includes\SQL::quote($usernameCAS).'\'';
-    $res_conges = \includes\SQL::query($req_conges) ;
+    $req_conges     = 'SELECT u_login FROM conges_users WHERE u_login=\'' . \includes\SQL::quote($usernameCAS) . '\'';
+    $res_conges     = \includes\SQL::query($req_conges);
     $num_row_conges = $res_conges->num_rows;
-    if($num_row_conges !=0) {
+    if ($num_row_conges != 0) {
         return $usernameCAS;
     } else {
         return '';
     }
 }
 
-
-function deconnexion_CAS($url="")
+function deconnexion_CAS($url = "")
 {
     // import des parametres du serveur CAS
 
-    $config_CAS_host       =$_SESSION['config']['CAS_host'];
-    $config_CAS_portNumber =$_SESSION['config']['CAS_portNumber'];
-    $config_CAS_URI        =$_SESSION['config']['CAS_URI'];
+    $config_CAS_host       = $_SESSION['config']['CAS_host'];
+    $config_CAS_portNumber = $_SESSION['config']['CAS_portNumber'];
+    $config_CAS_URI        = $_SESSION['config']['CAS_URI'];
 
     global $connexionCAS;
 
     // initialisation phpCAS
-    if($connexionCAS!="active")
-    {
-        $CASCnx = \phpCAS::client(CAS_VERSION_2_0,$config_CAS_host,$config_CAS_portNumber,$config_CAS_URI);
+    if ($connexionCAS != "active") {
+        $CASCnx       = \phpCAS::client(CAS_VERSION_2_0, $config_CAS_host, $config_CAS_portNumber, $config_CAS_URI);
         $connexionCAS = "active";
 
     }
@@ -421,45 +431,47 @@ function deconnexion_CAS($url="")
     \phpCAS::logoutWithUrl($url);
 }
 
-
 function hash_user($user)
 {
-	$ics_salt = $_SESSION['config']['export_ical_salt'];
-	$huser = hash('sha256', $user . $ics_salt);
-	return $huser;
+    $ics_salt = $_SESSION['config']['export_ical_salt'];
+    $huser    = hash('sha256', $user . $ics_salt);
+    return $huser;
 }
 
 function unhash_user($huser_test)
 {
-	$user = "";
-	$ics_salt = $_SESSION['config']['export_ical_salt'];
-	$req_user = 'SELECT u_login FROM conges_users';
-	$res_user = \includes\SQL::query($req_user) ;
+    $user     = "";
+    $ics_salt = $_SESSION['config']['export_ical_salt'];
+    $req_user = 'SELECT u_login FROM conges_users';
+    $res_user = \includes\SQL::query($req_user);
 
-	while ($resultat = $res_user->fetch_assoc())
-	{
-		$clear_user = $resultat['u_login'];
-		$huser = hash('sha256', $clear_user . $ics_salt);
-		if( $huser_test == $huser )
-			$user = $clear_user;
-	}
-	return $user;
+    while ($resultat = $res_user->fetch_assoc()) {
+        $clear_user = $resultat['u_login'];
+        $huser      = hash('sha256', $clear_user . $ics_salt);
+        if ($huser_test == $huser) {
+            $user = $clear_user;
+        }
+
+    }
+    return $user;
 }
 
 function authentification_AD_SSO()
 {
-	$cred = explode('@',$_SERVER['REMOTE_USER']);
-	if(count($cred)==1)
-		$userAD = $cred[0];
-	else
-		$userAD = $cred[1];
+    $cred = explode('@', $_SERVER['REMOTE_USER']);
+    if (count($cred) == 1) {
+        $userAD = $cred[0];
+    } else {
+        $userAD = $cred[1];
+    }
 
-	//ON VERIFIE ICI QUE L'UTILISATEUR EST DEJA ENREGISTRE SOUS DBCONGES
-	$req_conges = 'SELECT u_login FROM conges_users WHERE u_login=\''. SQL::quote($userAD).'\'';
-	$res_conges = SQL::query($req_conges) ;
-	$num_row_conges = $res_conges->num_rows;
-	if($num_row_conges !=0)
-		return $userAD;
+    //ON VERIFIE ICI QUE L'UTILISATEUR EST DEJA ENREGISTRE SOUS DBCONGES
+    $req_conges     = 'SELECT u_login FROM conges_users WHERE u_login=\'' . SQL::quote($userAD) . '\'';
+    $res_conges     = SQL::query($req_conges);
+    $num_row_conges = $res_conges->num_rows;
+    if ($num_row_conges != 0) {
+        return $userAD;
+    }
 
-	return '';
+    return '';
 }

--- a/includes/fonction_config.php
+++ b/includes/fonction_config.php
@@ -1,17 +1,16 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
 function affiche_bouton_retour($session)
 {
-	// Bouton de retour : différent suivant si on vient des pages d'install ou de l'appli
-	// $_SESSION['from_config'] est initialisée dans install/index
-	if( isset($_SESSION['from_config']) && $_SESSION['from_config'] )
-		echo '<center><a href="'. ROOT_PATH .'config/?session='.$session.'">'. _('form_retour') .'</a></center>';
-	else
-	{
-		echo '<form action="" method="POST">';
-		echo '<center><input type="button" value="'. _('form_close_window') .'" onClick="window.close();"></center>';
-		echo '</form>';
-	}
+    // Bouton de retour : différent suivant si on vient des pages d'install ou de l'appli
+    // $_SESSION['from_config'] est initialisée dans install/index
+    if (isset($_SESSION['from_config']) && $_SESSION['from_config']) {
+        echo '<center><a href="' . ROOT_PATH . 'config/?session=' . $session . '">' . _('form_retour') . '</a></center>';
+    } else {
+        echo '<form action="" method="POST">';
+        echo '<center><input type="button" value="' . _('form_close_window') . '" onClick="window.close();"></center>';
+        echo '</form>';
+    }
 }

--- a/includes/lang_profile.php
+++ b/includes/lang_profile.php
@@ -1,52 +1,46 @@
 <?php
 
-if(isset($_REQUEST['session']))
-	session_is_valid($_REQUEST['session']);
-
-if(isset($_REQUEST['lang']))
-	$lang = $_REQUEST['lang'];
-elseif(isset($_SESSION['lang']))
-	$lang = $_SESSION['lang'];
-else {
-    /* Retrieve lang informations from config database */
-    $lang_query = "SELECT conf_valeur FROM conges_config WHERE conf_nom='lang';";
-    $ReqLang = \includes\SQL::query($lang_query);
-    $lang = $ReqLang->fetch_row();
-    if ($lang != NULL)
-        $lang = $lang[0];
+if (isset($_REQUEST['session'])) {
+    session_is_valid($_REQUEST['session']);
 }
 
-putenv('LANG='.$lang); // On modifie la variable d'environnement
-$LoadLang = setlocale(LC_ALL, $lang, $lang.".utf8");
+if (isset($_REQUEST['lang'])) {
+    $lang = $_REQUEST['lang'];
+} elseif (isset($_SESSION['lang'])) {
+    $lang = $_SESSION['lang'];
+} else {
+    /* Retrieve lang informations from config database */
+    $lang_query = "SELECT conf_valeur FROM conges_config WHERE conf_nom='lang';";
+    $ReqLang    = \includes\SQL::query($lang_query);
+    $lang       = $ReqLang->fetch_row();
+    if ($lang != null) {
+        $lang = $lang[0];
+    }
 
-if(!$LoadLang)
-    {
-    $pattern = "/".$lang."/i";
+}
+
+putenv('LANG=' . $lang); // On modifie la variable d'environnement
+$LoadLang = setlocale(LC_ALL, $lang, $lang . ".utf8");
+
+if (!$LoadLang) {
+    $pattern = "/" . $lang . "/i";
     /* Retrieve lang informations from system */
     $originalLocales = explode(";", setlocale(LC_ALL, 0));
     foreach ($originalLocales as $localeSetting) {
-        if (preg_match($pattern, $localeSetting))
-            {$LoadLang = setlocale(LC_ALL, $localeSetting);}
-        }
+        if (preg_match($pattern, $localeSetting)) {$LoadLang = setlocale(LC_ALL, $localeSetting);}
     }
+}
 
 /* If we can not find the correct language, load fr... */
-if(!$LoadLang)
-    {
+if (!$LoadLang) {
     /* load default language */
     $LoadLang = setlocale(LC_ALL, 'fr_FR', 'fr_FR.utf8');
-    }
+}
 /* try another language... */
-if(!$LoadLang)
-    {$LoadLang = setlocale(LC_ALL, 'en_US', 'en_US.utf8');}
-if(!$LoadLang)
-    {$LoadLang = setlocale(LC_ALL, 'es_ES', 'es_ES.utf8');}
-
+if (!$LoadLang) {$LoadLang = setlocale(LC_ALL, 'en_US', 'en_US.utf8');}
+if (!$LoadLang) {$LoadLang = setlocale(LC_ALL, 'es_ES', 'es_ES.utf8');}
 
 $nomDesFichiersDeLangue = 'php-conges'; // Le nom de nos fichiers .mo
-bindtextdomain($nomDesFichiersDeLangue, LOCALE_PATH ); // On indique le chemin vers les fichiers .mo
-    bind_textdomain_codeset($nomDesFichiersDeLangue, 'UTF-8');  // Nos fichiers de langue sont en UTF-8 
+bindtextdomain($nomDesFichiersDeLangue, LOCALE_PATH); // On indique le chemin vers les fichiers .mo
+bind_textdomain_codeset($nomDesFichiersDeLangue, 'UTF-8'); // Nos fichiers de langue sont en UTF-8
 textdomain($nomDesFichiersDeLangue); // Le nom du domaine par défaut
-
-
-?>

--- a/includes/misc.class.php
+++ b/includes/misc.class.php
@@ -2,23 +2,18 @@
 
 /* misc class */
 
-
 class HTTPLocale
 {
-  var $language;
-  var $country;
+    public $language;
+    public $country;
 
-  function HTTPLocale()
-  {
-    $data = array_map("trim", explode(",", $_SERVER["HTTP_ACCEPT_LANGUAGE"]));
-    $data = array_map("trim", explode(";", $data[0]));
-    $data = array_map("trim", explode("-", $data[0])); //get first pair of language-country
-    
-    $this->language = strtolower($data[0]);
-	$this->country  = isset($data[1]) ? strtolower($data[1]) : $this->language;
-  }
+    public function HTTPLocale()
+    {
+        $data = array_map("trim", explode(",", $_SERVER["HTTP_ACCEPT_LANGUAGE"]));
+        $data = array_map("trim", explode(";", $data[0]));
+        $data = array_map("trim", explode("-", $data[0])); //get first pair of language-country
+
+        $this->language = strtolower($data[0]);
+        $this->country  = isset($data[1]) ? strtolower($data[1]) : $this->language;
+    }
 }
-
-
-
-?>

--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -1,43 +1,40 @@
 <?php
 
-
 include_once ROOT_PATH . 'define.php';
 
-function find_plugins_activated(){
-        $list_plugins = array();
-    if(isset($_SESSION['config']['installed_version']) && $_SESSION['config']['installed_version'] != "")
-    {
+function find_plugins_activated()
+{
+    $list_plugins = array();
+    if (isset($_SESSION['config']['installed_version']) && $_SESSION['config']['installed_version'] != "") {
 
-            $plugins_inst_activ_query = "SELECT p_name FROM conges_plugins WHERE p_is_active = 1 AND p_is_install = 1;";
-            $ReqLog_list_plugins = \includes\SQL::query($plugins_inst_activ_query);
-            if($ReqLog_list_plugins->num_rows !=0){
-                while($plugin=$ReqLog_list_plugins->fetch_array())
-                {
-                    array_push($list_plugins, $plugin["p_name"]);
-                }
+        $plugins_inst_activ_query = "SELECT p_name FROM conges_plugins WHERE p_is_active = 1 AND p_is_install = 1;";
+        $ReqLog_list_plugins      = \includes\SQL::query($plugins_inst_activ_query);
+        if ($ReqLog_list_plugins->num_rows != 0) {
+            while ($plugin = $ReqLog_list_plugins->fetch_array()) {
+                array_push($list_plugins, $plugin["p_name"]);
             }
+        }
     }
-        return $list_plugins;
+    return $list_plugins;
 }
 
-function include_plugins($plugins_activated){
+function include_plugins($plugins_activated)
+{
     $my_plugins = scandir(PLUGINS_DIR);
     $to_include = array();
-    foreach($my_plugins as $dir)
-    {
-    if(is_dir(PLUGINS_DIR."/$dir") && !preg_match("/^\./",$dir))
-        {
-        if(in_array($dir, $plugins_activated))
-            {
-            if(file_exists(PLUGINS_DIR."/$dir/allfilestoinclude.php")) include(PLUGINS_DIR."/$dir/allfilestoinclude.php");
+    foreach ($my_plugins as $dir) {
+        if (is_dir(PLUGINS_DIR . "/$dir") && !preg_match("/^\./", $dir)) {
+            if (in_array($dir, $plugins_activated)) {
+                if (file_exists(PLUGINS_DIR . "/$dir/allfilestoinclude.php")) {
+                    include PLUGINS_DIR . "/$dir/allfilestoinclude.php";
+                }
+
             }
         }
     }
 }
 
-
 $plugins_activated = find_plugins_activated();
 
 //massive include for plugins...
 include_plugins($plugins_activated);
-

--- a/includes/session.php
+++ b/includes/session.php
@@ -1,34 +1,33 @@
 <?php
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
 //
 // MAIN
 //
 
 /*** initialisation des variables ***/
-$session_username="";
-$session_password="";
+$session_username = "";
+$session_password = "";
 /************************************/
 
 //
 // recup du num  de session (mais on ne sais pas s'il est passé en GET ou POST
-$session=(isset($_REQUEST['session']) ? $_REQUEST['session'] : '' );
+$session = (isset($_REQUEST['session']) ? $_REQUEST['session'] : '');
 
 if ($session != "") //  UNE SESSION EXISTE
 {
-	if(session_is_valid($session) )
-		session_update($session);
-	else {
-		session_delete($session);
-		$session="";
-		$session_username="";
-		$session_password="";
-		$_SESSION['config']=init_config_tab();  // on recrée le tableau de config pour l'url du lien
-		
-		redirect(ROOT_PATH . 'index.php?error=session-invalid');
-	}
+    if (session_is_valid($session)) {
+        session_update($session);
+    } else {
+        session_delete($session);
+        $session            = "";
+        $session_username   = "";
+        $session_password   = "";
+        $_SESSION['config'] = init_config_tab(); // on recrée le tableau de config pour l'url du lien
+
+        redirect(ROOT_PATH . 'index.php?error=session-invalid');
+    }
+} else //  PAS DE SESSION   ($session == "")
+{
+    redirect(ROOT_PATH . 'index.php');
 }
-else    //  PAS DE SESSION   ($session == "")
-	redirect(ROOT_PATH . 'index.php');
-
-

--- a/index.php
+++ b/index.php
@@ -3,224 +3,190 @@ define('ROOT_PATH', '');
 require_once 'define.php';
 
 // test si dbconnect.php est présent !
-if (!is_readable( CONFIG_PATH .'dbconnect.php'))
-{
-	header("Location:". ROOT_PATH .'install/');
+if (!is_readable(CONFIG_PATH . 'dbconnect.php')) {
+    header("Location:" . ROOT_PATH . 'install/');
 }
 
-include_once INCLUDE_PATH .'fonction.php';
-include_once ROOT_PATH .'fonctions_conges.php'; // for init_config_tab()
-$_SESSION['config']=init_config_tab();      // on initialise le tableau des variables de config
-
+include_once INCLUDE_PATH . 'fonction.php';
+include_once ROOT_PATH . 'fonctions_conges.php'; // for init_config_tab()
+$_SESSION['config'] = init_config_tab(); // on initialise le tableau des variables de config
 
 /***** DEBUT DU PROG *****/
 
 /*** initialisation des variables ***/
 /************************************/
 
-if($err = getpost_variable('error', false))
-{
-	switch ($err) {
-		case 'session-invalid':
-			header_error();
-			echo "<p>" . _('session_pas_session_ouverte') . "<p>\n";
-			echo "<p>" . _('divers_veuillez') ." <a href='" .$_SESSION['config']['URL_ACCUEIL_CONGES'] . "/index.php' target='_top'><strong>" . _('divers_vous_authentifier') . "</strong></a></p>\n";
-			bottom();
-			exit();
-			break;
-	}
+if ($err = getpost_variable('error', false)) {
+    switch ($err) {
+        case 'session-invalid':
+            header_error();
+            echo "<p>" . _('session_pas_session_ouverte') . "<p>\n";
+            echo "<p>" . _('divers_veuillez') . " <a href='" . $_SESSION['config']['URL_ACCUEIL_CONGES'] . "/index.php' target='_top'><strong>" . _('divers_vous_authentifier') . "</strong></a></p>\n";
+            bottom();
+            exit();
+            break;
+    }
 }
 
-if($_SESSION['config']['auth'] == FALSE)    // si pas d'autentification (cf config de php_conges)
+if ($_SESSION['config']['auth'] == false) // si pas d'autentification (cf config de php_conges)
 {
-	$login = getpost_variable('login');
-	if(empty($login))
-	{
-	    // redirect( ROOT_PATH .'erreur.php?error_num=1');
+    $login = getpost_variable('login');
+    if (empty($login)) {
+        // redirect( ROOT_PATH .'erreur.php?error_num=1');
 
-		header_error();
-		printf("<h1>ERREUR !</h1>\n");
-		// authentification Error
-		echo '<p>' . _('erreur_user') . "</p>\n";
-		echo '<p>' . _('erreur_login_password') . "</p>\n" ;
-		bottom();
+        header_error();
+        printf("<h1>ERREUR !</h1>\n");
+        // authentification Error
+        echo '<p>' . _('erreur_user') . "</p>\n";
+        echo '<p>' . _('erreur_login_password') . "</p>\n";
+        bottom();
 
-		exit();
-	}
-	else
-	{
-		if(session_id()!="")
-			session_destroy();
+        exit();
+    } else {
+        if (session_id() != "") {
+            session_destroy();
+        }
 
-		// on initialise la nouvelle session
-		ini_set ( "session.gc_maxlifetime", $_SESSION['config']['duree_session'] );
-		session_create($login);
-	}
-}
-else
-{
-	$session_username = isset($_POST['session_username']) ? $_POST['session_username'] : '';
-	$session_password = isset($_POST['session_password']) ? $_POST['session_password'] : '';
+        // on initialise la nouvelle session
+        ini_set("session.gc_maxlifetime", $_SESSION['config']['duree_session']);
+        session_create($login);
+    }
+} else {
+    $session_username = isset($_POST['session_username']) ? $_POST['session_username'] : '';
+    $session_password = isset($_POST['session_password']) ? $_POST['session_password'] : '';
 
-	if(session_id()!="")
-		session_destroy();
+    if (session_id() != "") {
+        session_destroy();
+    }
 
-	// Si CAS alors on utilise le login CAS pour la session
-	if ( $_SESSION['config']['how_to_connect_user'] == "cas" && $_GET['cas'] != "no" )
-	{
-		//redirection vers l'url d'authentification CAS
-		$usernameCAS = authentification_passwd_conges_CAS();
-		if($usernameCAS == "") {
-			header_error();
+    // Si CAS alors on utilise le login CAS pour la session
+    if ($_SESSION['config']['how_to_connect_user'] == "cas" && $_GET['cas'] != "no") {
+        //redirection vers l'url d'authentification CAS
+        $usernameCAS = authentification_passwd_conges_CAS();
+        if ($usernameCAS == "") {
+            header_error();
 
-			echo  _('session_pas_de_compte_dans_dbconges') ."<br>\n";
-			echo  _('session_contactez_admin') ."\n";
+            echo _('session_pas_de_compte_dans_dbconges') . "<br>\n";
+            echo _('session_contactez_admin') . "\n";
 
-			$URL_ACCUEIL_CONGES=$_SESSION['config']['URL_ACCUEIL_CONGES'];
-			deconnexion_CAS($URL_ACCUEIL_CONGES);
-			bottom();
-			exit;
-		}
-	}
-	// Si SSO, on utilise les identifiants de session pour se connecter
-	else if ( $_SESSION['config']['how_to_connect_user'] == "SSO" )
-	{
-		$usernameSSO = authentification_AD_SSO();
-		if($usernameSSO != "")
-		{
-			session_create( $usernameSSO );
-		}
-		else//dans ce cas l'utilisateur n'a pas encore été enregistré dans la base de données db_conges
-		{
-			header_error();
+            $URL_ACCUEIL_CONGES = $_SESSION['config']['URL_ACCUEIL_CONGES'];
+            deconnexion_CAS($URL_ACCUEIL_CONGES);
+            bottom();
+            exit;
+        }
+    }
+    // Si SSO, on utilise les identifiants de session pour se connecter
+    else if ($_SESSION['config']['how_to_connect_user'] == "SSO") {
+        $usernameSSO = authentification_AD_SSO();
+        if ($usernameSSO != "") {
+            session_create($usernameSSO);
+        } else //dans ce cas l'utilisateur n'a pas encore été enregistré dans la base de données db_conges
+        {
+            header_error();
 
-			echo  _('session_pas_de_compte_dans_dbconges') ."<br>\n";
-			echo  _('session_contactez_admin') ."\n";
+            echo _('session_pas_de_compte_dans_dbconges') . "<br>\n";
+            echo _('session_contactez_admin') . "\n";
 
-			bottom();
-			exit;
-		}
-	}
-	else
-	{
-		if (($session_username == "") || ($session_password == "")) // si login et passwd non saisis
-		{
-			//  SAISIE LOGIN / PASSWORD :
-			session_saisie_user_password("", "", ""); // appel du formulaire d'authentification (login/password)
+            bottom();
+            exit;
+        }
+    } else {
+        if (($session_username == "") || ($session_password == "")) // si login et passwd non saisis
+        {
+            //  SAISIE LOGIN / PASSWORD :
+            session_saisie_user_password("", "", ""); // appel du formulaire d'authentification (login/password)
 
-			exit;
-		}
-		else
-		{
-			//  AUTHENTIFICATION :
-			// le user doit etre authentifié dans la table conges (login + passwd) ou dans le ldap.
-			// si on a trouve personne qui correspond au couple user/password
+            exit;
+        } else {
+            //  AUTHENTIFICATION :
+            // le user doit etre authentifié dans la table conges (login + passwd) ou dans le ldap.
+            // si on a trouve personne qui correspond au couple user/password
 
-			if ( $_SESSION['config']['how_to_connect_user'] == "ldap" && $session_username != "admin" )
-			{
-				$username_ldap = authentification_ldap_conges($session_username,$session_password);
-				if ( $username_ldap != $session_username)
-				{
-					$session="";
-					$session_username="";
-					$session_password="";
-					$erreur="login_passwd_incorrect";
-					// appel du formulaire d'intentification (login/password)
-					session_saisie_user_password($erreur, $session_username, $session_password);
+            if ($_SESSION['config']['how_to_connect_user'] == "ldap" && $session_username != "admin") {
+                $username_ldap = authentification_ldap_conges($session_username, $session_password);
+                if ($username_ldap != $session_username) {
+                    $session          = "";
+                    $session_username = "";
+                    $session_password = "";
+                    $erreur           = "login_passwd_incorrect";
+                    // appel du formulaire d'intentification (login/password)
+                    session_saisie_user_password($erreur, $session_username, $session_password);
 
-					exit;
-				}
-				else
-				{
-					if (valid_ldap_user($session_username)) // LDAP ok, on vérifie ici que le compte existe dans la base de données des congés.
-					{
-						// on initialise la nouvelle session
-						session_create($session_username);
-					}
-					else//dans ce cas l'utilisateur n'a pas encore été enregistré dans la base de données db_conges
-					{
-						header_error();
+                    exit;
+                } else {
+                    if (valid_ldap_user($session_username)) // LDAP ok, on vérifie ici que le compte existe dans la base de données des congés.
+                    {
+                        // on initialise la nouvelle session
+                        session_create($session_username);
+                    } else //dans ce cas l'utilisateur n'a pas encore été enregistré dans la base de données db_conges
+                    {
+                        header_error();
 
-						echo  _('session_pas_de_compte_dans_dbconges') ."<br>\n";
-						echo  _('session_contactez_admin') ."\n";
+                        echo _('session_pas_de_compte_dans_dbconges') . "<br>\n";
+                        echo _('session_contactez_admin') . "\n";
 
-						bottom();
-						exit;
-					}
-				}
-			} // fin du if test avec ldap
-			elseif ( $_SESSION['config']['how_to_connect_user'] == "dbconges" || $session_username == "admin" )
-			{
-				$username_conges = autentification_passwd_conges($session_username,$session_password);
-				if ( $username_conges != $session_username)
-				{
-					$session="";
-					$session_username="";
-					$session_password="";
-					$erreur="login_passwd_incorrect";
-					// appel du formulaire d'intentification (login/password)
-					session_saisie_user_password($erreur, $session_username, $session_password);
+                        bottom();
+                        exit;
+                    }
+                }
+            } // fin du if test avec ldap
+            elseif ($_SESSION['config']['how_to_connect_user'] == "dbconges" || $session_username == "admin") {
+                $username_conges = autentification_passwd_conges($session_username, $session_password);
+                if ($username_conges != $session_username) {
+                    $session          = "";
+                    $session_username = "";
+                    $session_password = "";
+                    $erreur           = "login_passwd_incorrect";
+                    // appel du formulaire d'intentification (login/password)
+                    session_saisie_user_password($erreur, $session_username, $session_password);
 
-					exit;
-				}
-				else
-				{
-					// on initialise la nouvelle session
-					session_create($session_username);
-				}
-			}
-		}
-	}
+                    exit;
+                } else {
+                    // on initialise la nouvelle session
+                    session_create($session_username);
+                }
+            }
+        }
+    }
 }
 
 /*****************************************************************/
 
-if(isset($_SESSION['userlogin']))
-{
-	$request= "SELECT u_nom, u_passwd, u_prenom, u_is_resp, u_is_hr, u_is_admin  FROM conges_users where u_login = '". \includes\SQL::quote($_SESSION['userlogin'])."' " ;
-	$rs = \includes\SQL::query($request );
-	if($rs->num_rows != 1)
-	{
-	    redirect( ROOT_PATH .'index.php' );
-	}
-	else
-	{
-		$session=session_id();
-		$row = $rs->fetch_array();
-		$NOM=$row["u_nom"];
-		$PRENOM=$row["u_prenom"];
+if (isset($_SESSION['userlogin'])) {
+    $request = "SELECT u_nom, u_passwd, u_prenom, u_is_resp, u_is_hr, u_is_admin  FROM conges_users where u_login = '" . \includes\SQL::quote($_SESSION['userlogin']) . "' ";
+    $rs      = \includes\SQL::query($request);
+    if ($rs->num_rows != 1) {
+        redirect(ROOT_PATH . 'index.php');
+    } else {
+        $session  = session_id();
+        $row      = $rs->fetch_array();
+        $NOM      = $row["u_nom"];
+        $PRENOM   = $row["u_prenom"];
         $is_admin = $row["u_is_admin"];
-        $is_hr = $row["u_is_hr"];
-		$is_resp = $row["u_is_resp"];
+        $is_hr    = $row["u_is_hr"];
+        $is_resp  = $row["u_is_resp"];
 
-		// si le login est celui d'un responsable ET on est pas en mode "responsable virtuel"
-		// OU on est en mode "responsable virtuel" avec login= celui du resp virtuel
-		$return_url = getpost_variable('return_url');
-		if (!empty($return_url))
-		{
-			if (strpos($return_url,'?'))
-				redirect( ROOT_PATH . $return_url .'&session=' . $session );
-			else
-				redirect( ROOT_PATH .$return_url . '?session=' . $session );
-		}
-		elseif ('Y' === $is_admin)
-		{
-			redirect( ROOT_PATH .'admin/admin_index.php?session=' . $session );
-		}
-        elseif ( $is_hr == "Y" )
-		{
-			redirect( ROOT_PATH .'hr/hr_index.php?session=' . $session );
-		}
-		elseif ( $is_resp=="Y" )
-		{
-			// redirection vers responsable/resp_index.php
-			redirect( ROOT_PATH .'responsable/resp_index.php?session=' . $session );
-		}
-		else
-		{
-			// redirection vers utilisateur/user_index.php
-			redirect( ROOT_PATH . 'utilisateur/user_index.php?session=' . $session );
-		}
+        // si le login est celui d'un responsable ET on est pas en mode "responsable virtuel"
+        // OU on est en mode "responsable virtuel" avec login= celui du resp virtuel
+        $return_url = getpost_variable('return_url');
+        if (!empty($return_url)) {
+            if (strpos($return_url, '?')) {
+                redirect(ROOT_PATH . $return_url . '&session=' . $session);
+            } else {
+                redirect(ROOT_PATH . $return_url . '?session=' . $session);
+            }
 
-	}
+        } elseif ('Y' === $is_admin) {
+            redirect(ROOT_PATH . 'admin/admin_index.php?session=' . $session);
+        } elseif ($is_hr == "Y") {
+            redirect(ROOT_PATH . 'hr/hr_index.php?session=' . $session);
+        } elseif ($is_resp == "Y") {
+            // redirection vers responsable/resp_index.php
+            redirect(ROOT_PATH . 'responsable/resp_index.php?session=' . $session);
+        } else {
+            // redirection vers utilisateur/user_index.php
+            redirect(ROOT_PATH . 'utilisateur/user_index.php?session=' . $session);
+        }
+
+    }
 }

--- a/install/Fonctions.php
+++ b/install/Fonctions.php
@@ -1,72 +1,75 @@
 <?php
 namespace install;
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
 /**
  * Regroupement de fonctions d'installation
  */
-class Fonctions {
+class Fonctions
+{
     // teste le fichier config.php
     //renvoit TRUE si ok, et FALSE sinon
-    public static function test_config_file() {
-        return is_readable( CONFIG_PATH .'config.php' );
+    public static function test_config_file()
+    {
+        return is_readable(CONFIG_PATH . 'config.php');
     }
-
 
     // teste le fichier dbconnect.php
     //renvoit TRUE si ok, et FALSE sinon
-    public static function test_dbconnect_file() {
-        return is_readable( CONFIG_PATH .'dbconnect.php' ) ;
+    public static function test_dbconnect_file()
+    {
+        return is_readable(CONFIG_PATH . 'dbconnect.php');
     }
-
 
     // teste l'ancien fichier de conf config_old.php // mis par le user pour upgrade v1.0 to v1.1
     //renvoit TRUE si ok, et FALSE sinon
-    public static function test_old_config_file() {
+    public static function test_old_config_file()
+    {
         return is_readable('config_old.php');
     }
 
-
     // teste l'existance et la conexion à la database
     //renvoit TRUE si ok, et FALSE sinon
-    public static function test_database() {
+    public static function test_database()
+    {
         try {
             \includes\SQL::singleton();
-        }
-        catch (Exception $e){
+        } catch (Exception $e) {
             return false;
         }
-        return \includes\SQL::getVar('connect_errno') == 0 ;
+        return \includes\SQL::getVar('connect_errno') == 0;
     }
 
-
-
     // renvoit le num de la version installée ou 0 s'il est inaccessible (non renseigné ou table non présente)
-    public static function get_installed_version() {
+    public static function get_installed_version()
+    {
         try {
             $reglog = \includes\SQL::query('show tables like \'conges_config\';');
-            if( $reglog->num_rows == 0)
+            if ($reglog->num_rows == 0) {
                 return 0;
-            $sql="SELECT conf_valeur FROM conges_config WHERE conf_nom='installed_version' ";
-            if($reglog = \includes\SQL::query($sql))
-                if($result=$reglog->fetch_array())
+            }
+
+            $sql = "SELECT conf_valeur FROM conges_config WHERE conf_nom='installed_version' ";
+            if ($reglog = \includes\SQL::query($sql)) {
+                if ($result = $reglog->fetch_array()) {
                     return $result['conf_valeur'];
-        }
-        catch(Exception $e) {
+                }
+            }
+
+        } catch (Exception $e) {
             return 0;
         }
         return 0;
     }
 
-
-
     // teste la creation de table (verif si le user a les droits suffisants ou pas)
     // renvoit TRUE ou FALSE
-    public static function test_create_table() {
+    public static function test_create_table()
+    {
         /*********************************************/
         // creation de la table `conges_test`
-        $sql_create="CREATE TABLE IF NOT EXISTS `conges_test` (
+        $sql_create = "CREATE TABLE IF NOT EXISTS `conges_test` (
             `test1` varchar(100) BINARY NOT NULL default '',
             `test2` varchar(100) BINARY NOT NULL default '',
             PRIMARY KEY  (`test1`)
@@ -74,36 +77,34 @@ class Fonctions {
         return \includes\SQL::query($sql_create);
     }
 
-
     // teste "alter table" (verif si le user a les droits suffisants ou pas)
     // renvoit TRUE ou FALSE
-    public static function test_alter_table() {
+    public static function test_alter_table()
+    {
         /*********************************************/
         // alter de la table `conges_test`
-        $sql_alter="ALTER TABLE `conges_test` CHANGE `test2` `test2` varchar(150) ;" ;
-        return \includes\SQL::query($sql_alter) ;
+        $sql_alter = "ALTER TABLE `conges_test` CHANGE `test2` `test2` varchar(150) ;";
+        return \includes\SQL::query($sql_alter);
     }
-
 
     // teste la suppression de table (verif si le user a les droits suffisants ou pas)
     // renvoit TRUE ou FALSE
-    public static function test_drop_table() {
+    public static function test_drop_table()
+    {
         /*********************************************/
         // suppression de la table `conges_test`
-        $sql_drop="DROP TABLE `conges_test` ;" ;
+        $sql_drop = "DROP TABLE `conges_test` ;";
         return \includes\SQL::query($sql_drop);
     }
 
-    public static function write_db_config($server,$user,$passwd,$db){
-        if (is_writable( CONFIG_PATH .'dbconnect_new.php' ))
-        {
-            $newdbconnect = file_get_contents(CONFIG_PATH .'dbconnect_new.php');
-            $newdbconnect .= "\n".'$mysql_serveur="'.$server.'" ;'."\n".'$mysql_user="'.$user.'" ;'."\n".'$mysql_pass="'.$passwd.'" ;'."\n".'$mysql_database="'.$db."\" ;\n";
-            file_put_contents(CONFIG_PATH .'dbconnect.php', $newdbconnect);
+    public static function write_db_config($server, $user, $passwd, $db)
+    {
+        if (is_writable(CONFIG_PATH . 'dbconnect_new.php')) {
+            $newdbconnect = file_get_contents(CONFIG_PATH . 'dbconnect_new.php');
+            $newdbconnect .= "\n" . '$mysql_serveur="' . $server . '" ;' . "\n" . '$mysql_user="' . $user . '" ;' . "\n" . '$mysql_pass="' . $passwd . '" ;' . "\n" . '$mysql_database="' . $db . "\" ;\n";
+            file_put_contents(CONFIG_PATH . 'dbconnect.php', $newdbconnect);
             return true;
-        }
-        else
-        {
+        } else {
             return false;
         }
     }
@@ -119,34 +120,34 @@ class Fonctions {
 
         // affichage du titre
         echo "<center>\n";
-        echo "<br><H1><img src=\"". IMG_PATH ."tux_config_32x32.png\" width=\"32\" height=\"32\" border=\"0\" title=\"". _('install_install_phpconges') ."\" alt=\"". _('install_install_phpconges') ."\"> ". _('install_index_titre') ."</H1>\n";
+        echo "<br><H1><img src=\"" . IMG_PATH . "tux_config_32x32.png\" width=\"32\" height=\"32\" border=\"0\" title=\"" . _('install_install_phpconges') . "\" alt=\"" . _('install_install_phpconges') . "\"> " . _('install_index_titre') . "</H1>\n";
         echo "<br><br>\n";
 
         echo "<table border=\"0\">\n";
         echo "<tr align=\"center\">\n";
-        echo "<td colspan=\"3\"><h2>". _('install_no_prev_version_found') .".<br>". _('install_indiquez') ." ...</h2><br><br></td>\n";
+        echo "<td colspan=\"3\"><h2>" . _('install_no_prev_version_found') . ".<br>" . _('install_indiquez') . " ...</h2><br><br></td>\n";
         echo "</tr>\n";
         echo "<tr align=\"center\">\n";
         echo "<td valign=top>\n";
         echo "\n";
-        echo "<h3>... ". _('install_nouvelle_install') ."</h3>\n";
+        echo "<h3>... " . _('install_nouvelle_install') . "</h3>\n";
         echo "<br>\n";
 
         // Formulaire : lance install.php
         echo "<form action=\"install.php\" method=\"POST\">\n";
         echo "<input type=\"hidden\" name=\"lang\" value=\"$lang\">\n";
-        echo "<input type=\"submit\" value=\"". _('form_start') ."\">\n";
+        echo "<input type=\"submit\" value=\"" . _('form_start') . "\">\n";
         echo "</form>\n";
         echo "</td>\n";
-        echo "<td><img src=\"". IMG_PATH ."shim.gif\" width=\"100\" height=\"10\" border=\"0\" vspace=\"0\" hspace=\"0\"></td>\n";
+        echo "<td><img src=\"" . IMG_PATH . "shim.gif\" width=\"100\" height=\"10\" border=\"0\" vspace=\"0\" hspace=\"0\"></td>\n";
         echo "<td valign=top>\n";
-        echo "<h3>... ". _('install_mise_a_jour') ."</h3><b>". _('install_indiquez_pre_version') ." :</b><br><br>\n";
+        echo "<h3>... " . _('install_mise_a_jour') . "</h3><b>" . _('install_indiquez_pre_version') . " :</b><br><br>\n";
 
         // Formulaire : lance mise_a_jour.php
         echo "<form action=\"mise_a_jour.php\" method=\"POST\">\n";
         // affichage de la liste des versions ...
         echo "<select name=\"version\">\n";
-        echo "<option value=\"0\">". _('install_installed_version') ."</option>\n";
+        echo "<option value=\"0\">" . _('install_installed_version') . "</option>\n";
         echo "<option value=\"1.8.1\">v1.8.1</option>\n";
         echo "<option value=\"1.8\">v1.8</option>\n";
         echo "<option value=\"1.7.0\">v1.7.0</option>\n";
@@ -155,7 +156,7 @@ class Fonctions {
         echo "</select>\n";
         echo "<br>\n";
         echo "<input type=\"hidden\" name=\"lang\" value=\"$lang\">\n";
-        echo "<input type=\"submit\" value=\"". _('form_start') ."\">\n";
+        echo "<input type=\"submit\" value=\"" . _('form_start') . "\">\n";
         echo "</form>\n";
         echo "</td>\n";
         echo "</tr>\n";
@@ -170,64 +171,57 @@ class Fonctions {
 
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
-        include CONFIG_PATH .'dbconnect.php' ;
-        include ROOT_PATH .'version.php' ;
+        include CONFIG_PATH . 'dbconnect.php';
+        include ROOT_PATH . 'version.php';
 
         //verif si create / alter table possible !!!
-        if(!\install\Fonctions::test_create_table())
-        {
-            echo "<font color=\"red\"><b>CREATE TABLE</b> ". _('install_impossible_sur_db') ." <b>$mysql_database</b> (". _('install_verif_droits_mysql') ." <b>$mysql_user</b>)...</font><br> \n";
-            echo "<br>". _('install_puis') ." ...<br>\n";
+        if (!\install\Fonctions::test_create_table()) {
+            echo "<font color=\"red\"><b>CREATE TABLE</b> " . _('install_impossible_sur_db') . " <b>$mysql_database</b> (" . _('install_verif_droits_mysql') . " <b>$mysql_user</b>)...</font><br> \n";
+            echo "<br>" . _('install_puis') . " ...<br>\n";
             echo "<form action=\"$PHP_SELF\" method=\"POST\">\n";
-            echo "<input type=\"submit\" value=\"". _('form_redo') ."\">\n";
+            echo "<input type=\"submit\" value=\"" . _('form_redo') . "\">\n";
             echo "</form>\n";
-        }
-        elseif(!\install\Fonctions::test_drop_table())
-        {
-            echo "<font color=\"red\"><b>DROP TABLE</b> ". _('install_impossible_sur_db') ." <b>$mysql_database</b> (". _('install_verif_droits_mysql') ." <b>$mysql_user</b>)...</font><br> \n";
-            echo "<br>". _('install_puis') ." ...<br>\n";
+        } elseif (!\install\Fonctions::test_drop_table()) {
+            echo "<font color=\"red\"><b>DROP TABLE</b> " . _('install_impossible_sur_db') . " <b>$mysql_database</b> (" . _('install_verif_droits_mysql') . " <b>$mysql_user</b>)...</font><br> \n";
+            echo "<br>" . _('install_puis') . " ...<br>\n";
             echo "<form action=\"$PHP_SELF\" method=\"POST\">\n";
-            echo "<input type=\"submit\" value=\"". _('form_redo') ."\">\n";
+            echo "<input type=\"submit\" value=\"" . _('form_redo') . "\">\n";
             echo "</form>\n";
-        }
-        else
-        {
+        } else {
             //on execute le script [nouvelle vesion].sql qui crée et initialise les tables
-            $file_sql="sql/php_conges_v$config_php_conges_version.sql";
-            if(file_exists($file_sql))
+            $file_sql = "sql/php_conges_v$config_php_conges_version.sql";
+            if (file_exists($file_sql)) {
                 $result = execute_sql_file($file_sql);
-
+            }
 
             /*************************************/
             // FIN : mise à jour de la "installed_version" et de la langue dans la table conges_config
-            $sql_update_version="UPDATE conges_config SET conf_valeur = '$config_php_conges_version' WHERE conf_nom='installed_version' ";
-            $result_update_version = \includes\SQL::query($sql_update_version) ;
+            $sql_update_version    = "UPDATE conges_config SET conf_valeur = '$config_php_conges_version' WHERE conf_nom='installed_version' ";
+            $result_update_version = \includes\SQL::query($sql_update_version);
 
-            $sql_update_lang="UPDATE conges_config SET conf_valeur = '$lang' WHERE conf_nom='lang' ";
-            $result_update_lang = \includes\SQL::query($sql_update_lang) ;
+            $sql_update_lang    = "UPDATE conges_config SET conf_valeur = '$lang' WHERE conf_nom='lang' ";
+            $result_update_lang = \includes\SQL::query($sql_update_lang);
 
-            $tab_url=explode("/", filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL));
+            $tab_url = explode("/", filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL));
 
             array_pop($tab_url);
             array_pop($tab_url);
 
-            $url_accueil= implode("/", $tab_url) ;  // on prend l'url complet sans le /install/install.php à la fin
+            $url_accueil = implode("/", $tab_url); // on prend l'url complet sans le /install/install.php à la fin
 
-            $sql_update_lang="UPDATE conges_config SET conf_valeur = '$url_accueil' WHERE conf_nom='URL_ACCUEIL_CONGES' ";
-            $result_update_lang = \includes\SQL::query($sql_update_lang) ;
-
+            $sql_update_lang    = "UPDATE conges_config SET conf_valeur = '$url_accueil' WHERE conf_nom='URL_ACCUEIL_CONGES' ";
+            $result_update_lang = \includes\SQL::query($sql_update_lang);
 
             $comment_log = "Install de php_conges (version = $config_php_conges_version) ";
             log_action(0, "", "", $comment_log);
 
             /*************************************/
             // on propose la page de config ....
-            echo "<br><br><h2>". _('install_ok') ." !</h2><br>\n";
+            echo "<br><br><h2>" . _('install_ok') . " !</h2><br>\n";
 
             echo "<META HTTP-EQUIV=REFRESH CONTENT=\"2; URL=../config/\">";
         }
     }
-
 
     // lance les differente maj depuis la $installed_version jusqu'à la version actuelle
     // la $installed_version est préalablement déterminée par get_installed_version() ou renseignée par l'utilisateur
@@ -235,130 +229,113 @@ class Fonctions {
     {
 
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        include CONFIG_PATH .'dbconnect.php' ;
-
+        include CONFIG_PATH . 'dbconnect.php';
 
         //*** ETAPE 0
-        if($etape==0)
-        {
+        if ($etape == 0) {
             //avant tout , on conseille une sauvegarde de la database !! (cf vieux index.php)
-            echo "<h3>". _('install_maj_passer_de') ." <font color=\"black\">$installed_version</font> ". _('install_maj_a_version') ." <font color=\"black\">$config_php_conges_version</font> .</h3>\n";
-            echo "<h3><font color=\"red\">". _('install_maj_sauvegardez') ." !!!</font></h3>\n";
+            echo "<h3>" . _('install_maj_passer_de') . " <font color=\"black\">$installed_version</font> " . _('install_maj_a_version') . " <font color=\"black\">$config_php_conges_version</font> .</h3>\n";
+            echo "<h3><font color=\"red\">" . _('install_maj_sauvegardez') . " !!!</font></h3>\n";
             echo "<h2>....</h2>\n";
             echo "<br>\n";
             echo "<form action=\"$PHP_SELF?lang=$lang\" method=\"POST\">\n";
             echo "<input type=\"hidden\" name=\"etape\" value=\"1\">\n";
             echo "<input type=\"hidden\" name=\"version\" value=\"$installed_version\">\n";
-            echo "<input type=\"submit\" value=\"". _('form_continuer') ."\">\n";
+            echo "<input type=\"submit\" value=\"" . _('form_continuer') . "\">\n";
             echo "</form>\n";
             echo "<br><br>\n";
 
         }
         //*** ETAPE 1
-        elseif($etape==1)
-        {
+        elseif ($etape == 1) {
             //verif si create / alter table possible !!!
-            if(!\install\Fonctions::test_create_table())
-            {
-                echo "<font color=\"red\"><b>CREATE TABLE</b> ". _('install_impossible_sur_db') ." <b>$mysql_database</b> (". _('install_verif_droits_mysql') ." <b>$mysql_user</b>)...</font><br> \n";
+            if (!\install\Fonctions::test_create_table()) {
+                echo "<font color=\"red\"><b>CREATE TABLE</b> " . _('install_impossible_sur_db') . " <b>$mysql_database</b> (" . _('install_verif_droits_mysql') . " <b>$mysql_user</b>)...</font><br> \n";
                 echo "<br>puis ...<br>\n";
                 echo "<form action=\"$PHP_SELF?lang=$lang\" method=\"POST\">\n";
                 echo "<input type=\"hidden\" name=\"etape\"value=\"1\" >\n";
                 echo "<input type=\"hidden\" name=\"version\" value=\"$installed_version\">\n";
-                echo "<input type=\"submit\" value=\"". _('form_redo') ."\">\n";
+                echo "<input type=\"submit\" value=\"" . _('form_redo') . "\">\n";
                 echo "</form>\n";
-            }
-            elseif(!\install\Fonctions::test_alter_table())
-            {
-                echo "<font color=\"red\"><b>ALTER TABLE</b> ". _('install_impossible_sur_db') ." <b>$mysql_database</b> (". _('install_verif_droits_mysql') ." <b>$mysql_user</b>)...</font><br> \n";
+            } elseif (!\install\Fonctions::test_alter_table()) {
+                echo "<font color=\"red\"><b>ALTER TABLE</b> " . _('install_impossible_sur_db') . " <b>$mysql_database</b> (" . _('install_verif_droits_mysql') . " <b>$mysql_user</b>)...</font><br> \n";
                 echo "<br>puis ...<br>\n";
                 echo "<form action=\"$PHP_SELF?lang=$lang\" method=\"POST\">\n";
                 echo "<input type=\"hidden\" name=\"etape\"value=\"1\" >\n";
                 echo "<input type=\"hidden\" name=\"version\" value=\"$installed_version\">\n";
-                echo "<input type=\"submit\" value=\"". _('form_redo') ."\">\n";
+                echo "<input type=\"submit\" value=\"" . _('form_redo') . "\">\n";
                 echo "</form>\n";
-            }
-            elseif(!\install\Fonctions::test_drop_table())
-            {
-                echo "<font color=\"red\"><b>DROP TABLE</b> ". _('install_impossible_sur_db') ." <b>$mysql_database</b> (". _('install_verif_droits_mysql') ." <b>$mysql_user</b>)...</font><br> \n";
+            } elseif (!\install\Fonctions::test_drop_table()) {
+                echo "<font color=\"red\"><b>DROP TABLE</b> " . _('install_impossible_sur_db') . " <b>$mysql_database</b> (" . _('install_verif_droits_mysql') . " <b>$mysql_user</b>)...</font><br> \n";
                 echo "<br>puis ...<br>\n";
                 echo "<form action=\"$PHP_SELF?lang=$lang\">\n";
                 echo "<input type=\"hidden\" name=\"etape\"value=\"1\" >\n";
                 echo "<input type=\"hidden\" name=\"version\" value=\"$installed_version\">\n";
-                echo "<input type=\"submit\" value=\"". _('form_redo') ."\">\n";
+                echo "<input type=\"submit\" value=\"" . _('form_redo') . "\">\n";
                 echo "</form>\n";
-            }
-            else
-            {
-                    echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$PHP_SELF?etape=2&version=$installed_version&lang=$lang\">";
+            } else {
+                echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$PHP_SELF?etape=2&version=$installed_version&lang=$lang\">";
             }
         }
         //*** ETAPE 2
-        elseif($etape==2)
-        {
-                $start_version=$installed_version ;
+        elseif ($etape == 2) {
+            $start_version = $installed_version;
 
             //on lance l'execution (include) des scripts d'upgrade l'un après l'autre jusqu a la version voulue ($config_php_conges_version) ..
-            if(($start_version=="1.5.0")||($start_version=="1.5.1")) {
-                $file_upgrade='upgrade_from_v1.5.0.php';
-                $new_installed_version="1.6.0";
+            if (($start_version == "1.5.0") || ($start_version == "1.5.1")) {
+                $file_upgrade          = 'upgrade_from_v1.5.0.php';
+                $new_installed_version = "1.6.0";
                 // execute le script php d'upgrade de la version1.5.0 (vers la suivante (1.6.0))
                 echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?etape=2&version=$new_installed_version&lang=$lang\">";
-            } elseif($start_version=="1.6.0") {
-                $file_upgrade='upgrade_from_v1.6.0.php';
-                $new_installed_version="1.7.0";
+            } elseif ($start_version == "1.6.0") {
+                $file_upgrade          = 'upgrade_from_v1.6.0.php';
+                $new_installed_version = "1.7.0";
                 // execute le script php d'upgrade de la version1.6.0 (vers la suivante (1.7.0))
                 echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?etape=2&version=$new_installed_version&lang=$lang\">";
-            } elseif($start_version=="1.7.0") {
-                $file_upgrade='upgrade_from_v1.7.0.php';
-                $new_installed_version="1.8";
+            } elseif ($start_version == "1.7.0") {
+                $file_upgrade          = 'upgrade_from_v1.7.0.php';
+                $new_installed_version = "1.8";
                 // execute le script php d'upgrade de la version1.7.0 (vers la suivante (1.8))
                 echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?etape=2&version=$new_installed_version&lang=$lang\">";
-	    } elseif($start_version=="1.8") {
-		$file_upgrade='upgrade_from_v1.8.php';
-		$new_installed_version="1.8.1";
-		// execute le script php d'upgrade de la version1.8 (vers la suivante (1.8.1))
-		echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?etape=2&version=$new_installed_version&lang=$lang\">";
-            } elseif($start_version=="1.8.1") {
-		$file_upgrade='upgrade_from_v1.8.1.php';
-		$new_installed_version="1.9";
-		// execute le script php d'upgrade de la version 1.8.1 (vers la suivante (1.9))
-		echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?etape=2&version=$new_installed_version&lang=$lang\">";
+            } elseif ($start_version == "1.8") {
+                $file_upgrade          = 'upgrade_from_v1.8.php';
+                $new_installed_version = "1.8.1";
+                // execute le script php d'upgrade de la version1.8 (vers la suivante (1.8.1))
+                echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?etape=2&version=$new_installed_version&lang=$lang\">";
+            } elseif ($start_version == "1.8.1") {
+                $file_upgrade          = 'upgrade_from_v1.8.1.php';
+                $new_installed_version = "1.9";
+                // execute le script php d'upgrade de la version 1.8.1 (vers la suivante (1.9))
+                echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?etape=2&version=$new_installed_version&lang=$lang\">";
             } else {
                 echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$PHP_SELF?etape=3&version=$installed_version&lang=$lang\">";
             }
         }
         //*** ETAPE 3
-        elseif($etape==3)
-        {
+        elseif ($etape == 3) {
             // FIN
             // test si fichiers config.php ou config_old.php existent encore (si oui : demande de les éffacer !
-            if( (\install\Fonctions::test_config_file()) || (\install\Fonctions::test_old_config_file()) )
-            {
-                if(test_config_file())
-                {
-                    echo  _('install_le_fichier') ." <b>\"config.php\"</b> ". _('install_remove_fichier') .".<br> \n";
+            if ((\install\Fonctions::test_config_file()) || (\install\Fonctions::test_old_config_file())) {
+                if (test_config_file()) {
+                    echo _('install_le_fichier') . " <b>\"config.php\"</b> " . _('install_remove_fichier') . ".<br> \n";
                 }
-                if(test_old_config_file())
-                {
-                    echo  _('install_le_fichier') ." <b>\"install/config_old.php\"</b> ". _('install_remove_fichier') .".<br> \n";
+                if (test_old_config_file()) {
+                    echo _('install_le_fichier') . " <b>\"install/config_old.php\"</b> " . _('install_remove_fichier') . ".<br> \n";
                 }
-                echo "<br><a href=\"$PHP_SELF?etape=5&version=$config_php_conges_version&lang=$lang\">". _('install_reload_page') ." ....</a><br>\n";
-            }
-            else
-            {
+                echo "<br><a href=\"$PHP_SELF?etape=5&version=$config_php_conges_version&lang=$lang\">" . _('install_reload_page') . " ....</a><br>\n";
+            } else {
                 // mise à jour de la "installed_version" et de la langue dans la table conges_config
-                $sql_update_version="UPDATE conges_config SET conf_valeur = '$config_php_conges_version' WHERE conf_nom='installed_version' ";
-                $result_update_version = \includes\SQL::query($sql_update_version) ;
+                $sql_update_version    = "UPDATE conges_config SET conf_valeur = '$config_php_conges_version' WHERE conf_nom='installed_version' ";
+                $result_update_version = \includes\SQL::query($sql_update_version);
 
-                $sql_update_lang="UPDATE conges_config SET conf_valeur = '$lang' WHERE conf_nom='lang' ";
-                $result_update_lang = \includes\SQL::query($sql_update_lang) ;
+                $sql_update_lang    = "UPDATE conges_config SET conf_valeur = '$lang' WHERE conf_nom='lang' ";
+                $result_update_lang = \includes\SQL::query($sql_update_lang);
 
-                $comment_log = _('install_maj_titre_2')." (version $installed_version --> version $config_php_conges_version) ";
+                $comment_log = _('install_maj_titre_2') . " (version $installed_version --> version $config_php_conges_version) ";
                 log_action(0, "", "", $comment_log);
 
                 // on propose la page de config ....
-                echo "<br><br><h2>". _('install_ok') ." !</h2><br>\n";
+                echo "<br><br><h2>" . _('install_ok') . " !</h2><br>\n";
 
                 echo "<META HTTP-EQUIV=REFRESH CONTENT=\"2; URL=../config/\">";
             }

--- a/install/index.php
+++ b/install/index.php
@@ -6,139 +6,137 @@ require_once ROOT_PATH . 'define.php';
 session_start();
 $_SESSION['lang'] = 'fr_FR';
 
-include_once INCLUDE_PATH .'fonction.php';
+include_once INCLUDE_PATH . 'fonction.php';
 
-include_once ROOT_PATH .'fonctions_conges.php' ;
+include_once ROOT_PATH . 'fonctions_conges.php';
 
 $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
-$session= htmlentities(session_id());
+$session = htmlentities(session_id());
 
 //recup de la langue
-$lang=(isset($_GET['lang']) ? $_GET['lang'] : ((isset($_POST['lang'])) ? $_POST['lang'] : "") ) ;
+$lang = (isset($_GET['lang']) ? $_GET['lang'] : ((isset($_POST['lang'])) ? $_POST['lang'] : ""));
 $lang = htmlentities($lang, ENT_QUOTES | ENT_HTML401);
 
 //recup de la config db
-$dbserver=(isset($_GET['dbserver']) ? $_GET['dbserver'] : ((isset($_POST['dbserver'])) ? $_POST['dbserver'] : "") ) ;
+$dbserver = (isset($_GET['dbserver']) ? $_GET['dbserver'] : ((isset($_POST['dbserver'])) ? $_POST['dbserver'] : ""));
 $dbserver = htmlentities($dbserver, ENT_QUOTES | ENT_HTML401);
 
-$dbuser=(isset($_GET['dbuser']) ? $_GET['dbuser'] : ((isset($_POST['dbuser'])) ? $_POST['dbuser'] : "") ) ;
+$dbuser = (isset($_GET['dbuser']) ? $_GET['dbuser'] : ((isset($_POST['dbuser'])) ? $_POST['dbuser'] : ""));
 $dbuser = htmlentities($dbuser, ENT_QUOTES | ENT_HTML401);
 
-$dbpasswd=(isset($_GET['dbpasswd']) ? $_GET['dbpasswd'] : ((isset($_POST['dbpasswd'])) ? $_POST['dbpasswd'] : "") ) ;
+$dbpasswd = (isset($_GET['dbpasswd']) ? $_GET['dbpasswd'] : ((isset($_POST['dbpasswd'])) ? $_POST['dbpasswd'] : ""));
 $dbpasswd = htmlentities($dbpasswd, ENT_QUOTES | ENT_HTML401);
 
-$dbdb=(isset($_GET['dbdb']) ? $_GET['dbdb'] : ((isset($_POST['dbdb'])) ? $_POST['dbdb'] : "") ) ;
+$dbdb = (isset($_GET['dbdb']) ? $_GET['dbdb'] : ((isset($_POST['dbdb'])) ? $_POST['dbdb'] : ""));
 $dbdb = htmlentities($dbdb, ENT_QUOTES | ENT_HTML401);
 
+if ($lang == "") {
+    header_popup();
+    echo "<br><br>\n";
+    echo "Choisissez votre langue :<br> \n";
+    echo "Choose your language :<br>\n";
+    echo "<form action=\"$PHP_SELF?session=$session\" method=\"POST\">\n";
+    // affichage de la liste des langues supportées ...
+    // on lit le contenu du répertoire lang et on parse les nom de ficher (ex lang_fr_francais.php)
+    echo affiche_select_from_lang_directory("", "");
 
-    if($lang=="") {
-        header_popup();
-        echo "<br><br>\n";
-        echo "Choisissez votre langue :<br> \n";
-        echo "Choose your language :<br>\n";
+    echo "<br>\n";
+    echo "<input type=\"submit\" value=\"OK\">\n";
+    echo "</form>\n";
+    bottom();
+} elseif (\install\Fonctions::test_dbconnect_file() != true) {
+    $_SESSION['langue'] = $lang; // sert ensuite pour mettre la langue dans la table config
+    //        $tab_lang_file = glob("lang/lang_".$lang.'_*.php');
+    //        include$tab_lang_file[0] ;
+    //        include$lang_file ;
+
+    header_popup();
+    echo "<center>\n";
+    echo "<br><br>\n";
+    if ($dbserver == "" || $dbuser == "" || $dbpasswd == "") {
+        echo _('db_configuration');
         echo "<form action=\"$PHP_SELF?session=$session\" method=\"POST\">\n";
-        // affichage de la liste des langues supportées ...
-        // on lit le contenu du répertoire lang et on parse les nom de ficher (ex lang_fr_francais.php)
-        echo affiche_select_from_lang_directory("", "");
-
+        echo _('db_configuration_server');
+        echo '<INPUT type="text" value="localhost" name="dbserver"><br>';
+        echo _('db_configuration_name');
+        echo '<INPUT type="text" value="db_conges" name="dbdb"><br>';
+        echo _('db_configuration_user');
+        echo '<INPUT type="text" value="conges" name="dbuser"><br>';
+        echo _('db_configuration_password');
+        echo '<INPUT type="password" name="dbpasswd" autocomplete="off"><br>';
+        echo "<INPUT type=\"hidden\" value=\"" . $lang . "\" name=\"lang\"><br>";
         echo "<br>\n";
         echo "<input type=\"submit\" value=\"OK\">\n";
         echo "</form>\n";
-        bottom();
-    } elseif(\install\Fonctions::test_dbconnect_file()!=TRUE) {
-        $_SESSION['langue']=$lang;      // sert ensuite pour mettre la langue dans la table config
-//        $tab_lang_file = glob("lang/lang_".$lang.'_*.php');
-//        include$tab_lang_file[0] ;
-//        include$lang_file ;
 
+    } else {
+        $is_dbconf_ok = \install\Fonctions::write_db_config($dbserver, $dbuser, $dbpasswd, $dbdb);
+        if ($is_dbconf_ok != true) {
+            echo "le dossier " . CONFIG_PATH . " n'est pas accessible en écriture";
+        } else {
+            echo _('db_configuration_ok');
+            echo "<br><a href=\"$PHP_SELF?session=$session&lang=$lang\"> continuez....</a><br>\n";
+        }
+    }
+    bottom();
+} else {
+    include_once CONFIG_PATH . 'dbconnect.php';
+    include_once ROOT_PATH . 'version.php';
+
+    if (!\install\Fonctions::test_database()) {
         header_popup();
         echo "<center>\n";
         echo "<br><br>\n";
-        if($dbserver=="" || $dbuser=="" || $dbpasswd=="") {
-            echo  _('db_configuration');
+        echo "<b>" . _('install_db_inaccessible') . " ... <br><br>\n";
+        echo _('install_verifiez_param_file');
+        echo "(" . _('install_verifiez_priv_mysql') . ")<br><br>\n";
+
+        echo "<center>\n";
+        echo "<br><br>\n";
+        if ($dbserver == "" || $dbuser == "" || $dbpasswd == "") {
+            echo _('db_configuration');
             echo "<form action=\"$PHP_SELF?session=$session\" method=\"POST\">\n";
-            echo  _('db_configuration_server');
+            echo _('db_configuration_server');
             echo '<INPUT type="text" value="localhost" name="dbserver"><br>';
-            echo  _('db_configuration_name');
+            echo _('db_configuration_name');
             echo '<INPUT type="text" value="db_conges" name="dbdb"><br>';
-            echo  _('db_configuration_user');
+            echo _('db_configuration_user');
             echo '<INPUT type="text" value="conges" name="dbuser"><br>';
-            echo  _('db_configuration_password');
+            echo _('db_configuration_password');
             echo '<INPUT type="password" name="dbpasswd" autocomplete="off"><br>';
-            echo "<INPUT type=\"hidden\" value=\"".$lang."\" name=\"lang\"><br>";
+            echo "<INPUT type=\"hidden\" value=\"" . $lang . "\" name=\"lang\"><br>";
             echo "<br>\n";
             echo "<input type=\"submit\" value=\"OK\">\n";
             echo "</form>\n";
-
         } else {
-            $is_dbconf_ok= \install\Fonctions::write_db_config($dbserver,$dbuser,$dbpasswd,$dbdb);
-            if($is_dbconf_ok!=true) {
-                echo "le dossier ".CONFIG_PATH." n'est pas accessible en écriture";
+            $is_dbconf_ok = write_db_config($dbserver, $dbuser, $dbpasswd, $dbdb);
+            if ($is_dbconf_ok != true) {
+                echo "le dossier " . CONFIG_PATH . " n'est pas accessible en écriture";
             } else {
                 echo _('db_configuration_ok');
                 echo "<br><a href=\"$PHP_SELF?session=$session&lang=$lang\"> continuez....</a><br>\n";
             }
         }
+
         bottom();
     } else {
-        include_once CONFIG_PATH .'dbconnect.php';
-        include_once ROOT_PATH .'version.php';
+        $installed_version = \install\Fonctions::get_installed_version();
+        $installed_version = 0;
 
-        if(!\install\Fonctions::test_database()) {
-            header_popup();
-            echo "<center>\n";
-            echo "<br><br>\n";
-            echo "<b>". _('install_db_inaccessible') ." ... <br><br>\n";
-            echo  _('install_verifiez_param_file');
-            echo "(". _('install_verifiez_priv_mysql') .")<br><br>\n";
-
-            echo "<center>\n";
-            echo "<br><br>\n";
-            if($dbserver=="" || $dbuser=="" || $dbpasswd=="") {
-                echo  _('db_configuration');
-                echo "<form action=\"$PHP_SELF?session=$session\" method=\"POST\">\n";
-                echo  _('db_configuration_server');
-                echo '<INPUT type="text" value="localhost" name="dbserver"><br>';
-                echo  _('db_configuration_name');
-                echo '<INPUT type="text" value="db_conges" name="dbdb"><br>';
-                echo  _('db_configuration_user');
-                echo '<INPUT type="text" value="conges" name="dbuser"><br>';
-                echo  _('db_configuration_password');
-                echo '<INPUT type="password" name="dbpasswd" autocomplete="off"><br>';
-                echo "<INPUT type=\"hidden\" value=\"".$lang."\" name=\"lang\"><br>";
-                echo "<br>\n";
-                echo "<input type=\"submit\" value=\"OK\">\n";
-                echo "</form>\n";
-            } else {
-                $is_dbconf_ok=write_db_config($dbserver,$dbuser,$dbpasswd,$dbdb);
-                if($is_dbconf_ok!=true) {
-                    echo "le dossier ".CONFIG_PATH." n'est pas accessible en écriture";
-                } else {
-                    echo _('db_configuration_ok');
-                    echo "<br><a href=\"$PHP_SELF?session=$session&lang=$lang\"> continuez....</a><br>\n";
-                }
-            }
-
-            bottom();
+        if ($installed_version == 0) // num de version inconnu
+        {
+            \install\Fonctions::install($lang);
         } else {
-            $installed_version = \install\Fonctions::get_installed_version();
-            $installed_version = 0;
-
-            if($installed_version==0)   // num de version inconnu
-            {
-                \install\Fonctions::install($lang);
+            // on compare la version déclarée dans la database avec la version déclarée dans le fichier de config
+            if ($installed_version != $config_php_conges_version) {
+                // on attaque une mise a jour à partir de la version installée
+                echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=mise_a_jour.php?version=$installed_version&lang=$lang\">";
             } else {
-                // on compare la version déclarée dans la database avec la version déclarée dans le fichier de config
-                if($installed_version != $config_php_conges_version) {
-                    // on attaque une mise a jour à partir de la version installée
-                    echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=mise_a_jour.php?version=$installed_version&lang=$lang\">";
-                } else {
-                    // pas de mise a jour a faire : on propose les pages de config
-                    echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=../config/\">";
-                }
+                // pas de mise a jour a faire : on propose les pages de config
+                echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=../config/\">";
             }
-
-
         }
+
     }
+}

--- a/install/install.php
+++ b/install/install.php
@@ -3,26 +3,25 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-include_once ROOT_PATH .'fonctions_conges.php' ;
-include_once INCLUDE_PATH .'fonction.php';
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
 
 $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
 //recup de la langue
-$lang=(isset($_GET['lang']) ? $_GET['lang'] : ((isset($_POST['lang'])) ? $_POST['lang'] : "") ) ;
+$lang = (isset($_GET['lang']) ? $_GET['lang'] : ((isset($_POST['lang'])) ? $_POST['lang'] : ""));
 $lang = htmlentities($lang, ENT_QUOTES | ENT_HTML401);
 if (!in_array($lang, ['fr_FR', 'en_US', 'es_ES'], true)) {
     $lang = '';
 }
 
+header_popup('PHP_CONGES : Installation');
 
-	header_popup('PHP_CONGES : Installation');
+// affichage du titre
+echo "<center>\n";
+echo "<br><H1><img src=\"" . IMG_PATH . "tux_config_32x32.png\" width=\"32\" height=\"32\" border=\"0\" title=\"" . _('install_install_phpconges') . "\" alt=\"" . _('install_install_phpconges') . "\"> " . _('install_install_titre') . "</H1>\n";
+echo "<br><br>\n";
 
-	// affichage du titre
-	echo "<center>\n";
-	echo "<br><H1><img src=\"". IMG_PATH ."tux_config_32x32.png\" width=\"32\" height=\"32\" border=\"0\" title=\"". _('install_install_phpconges') ."\" alt=\"". _('install_install_phpconges') ."\"> ". _('install_install_titre') ."</H1>\n";
-	echo "<br><br>\n";
+\install\Fonctions::lance_install($lang);
 
-	\install\Fonctions::lance_install($lang);
-
-	bottom();
+bottom();

--- a/install/mise_a_jour.php
+++ b/install/mise_a_jour.php
@@ -3,38 +3,38 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-include_once ROOT_PATH .'fonctions_conges.php' ;
-include_once INCLUDE_PATH .'fonction.php';
-include ROOT_PATH .'version.php' ;
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+include ROOT_PATH . 'version.php';
 
 $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 
 //recup de la langue
-$lang=(isset($_GET['lang']) ? $_GET['lang'] : ((isset($_POST['lang'])) ? $_POST['lang'] : "") ) ;
+$lang = (isset($_GET['lang']) ? $_GET['lang'] : ((isset($_POST['lang'])) ? $_POST['lang'] : ""));
 $lang = htmlentities($lang, ENT_QUOTES | ENT_HTML401);
 if (!in_array($lang, ['fr_FR', 'en_US', 'es_ES'], true)) {
     $lang = '';
 }
 
 // recup des parametres
-$action = (isset($_GET['action']) ? $_GET['action'] : (isset($_POST['action']) ? $_POST['action'] : "")) ;
+$action = (isset($_GET['action']) ? $_GET['action'] : (isset($_POST['action']) ? $_POST['action'] : ""));
 $action = htmlentities($action, ENT_QUOTES | ENT_HTML401);
 
-$version = (isset($_GET['version']) ? $_GET['version'] : (isset($_POST['version']) ? $_POST['version'] : "")) ;
+$version = (isset($_GET['version']) ? $_GET['version'] : (isset($_POST['version']) ? $_POST['version'] : ""));
 $version = htmlentities($version, ENT_QUOTES | ENT_HTML401);
-$etape = (isset($_GET['etape']) ? $_GET['etape'] : (isset($_POST['etape']) ? $_POST['etape'] : 0 )) ;
-$etape = htmlentities($etape, ENT_QUOTES | ENT_HTML401);
+$etape   = (isset($_GET['etape']) ? $_GET['etape'] : (isset($_POST['etape']) ? $_POST['etape'] : 0));
+$etape   = htmlentities($etape, ENT_QUOTES | ENT_HTML401);
 
-
-if($version == 0) {  // la version à mettre à jour dans le formulaire de index.php n'a pas été choisie : renvoit sur le formulaire
-    redirect( ROOT_PATH . 'install/index.php?lang='.$lang);
+if ($version == 0) {
+    // la version à mettre à jour dans le formulaire de index.php n'a pas été choisie : renvoit sur le formulaire
+    redirect(ROOT_PATH . 'install/index.php?lang=' . $lang);
 }
 
-header_popup(' PHP_CONGES : '. _('install_maj_titre_1') );
+header_popup(' PHP_CONGES : ' . _('install_maj_titre_1'));
 
 // affichage du titre
 echo "<center>\n";
-echo "<br><H1><img src=\"".IMG_PATH."tux_config_32x32.png\" width=\"32\" height=\"32\" border=\"0\" title=\"". _('install_install_phpconges') ."\" alt=\"". _('install_install_phpconges') ."\"> ". _('install_maj_titre_2') ."</H1>\n";
+echo "<br><H1><img src=\"" . IMG_PATH . "tux_config_32x32.png\" width=\"32\" height=\"32\" border=\"0\" title=\"" . _('install_install_phpconges') . "\" alt=\"" . _('install_install_phpconges') . "\"> " . _('install_maj_titre_2') . "</H1>\n";
 echo "<br><br>\n";
 
 // $config_php_conges_version est fourni par include_once ROOT_PATH .'version.php' ;

--- a/library/authLDAP.php
+++ b/library/authLDAP.php
@@ -5,175 +5,181 @@
 /****************************************************************************/
 class authLDAP
 {
-  var $searchdn;
-  var $basedn;
-  var $ldap_server;
-  var $ldap_server_backup;
-  var $ldap_user;
-  var $ldap_pass;
-  var $ldap_group;
-  var $ldap_login;
+    public $searchdn;
+    public $basedn;
+    public $ldap_server;
+    public $ldap_server_backup;
+    public $ldap_user;
+    public $ldap_pass;
+    public $ldap_group;
+    public $ldap_login;
 
-  var $user_login = "";
-  var $user_password = "";
-  var $user_auth  = 0;
+    public $user_login    = "";
+    public $user_password = "";
+    public $user_auth     = 0;
 
-  // liste des groupes autorisés
-  var $auth_dn_groups;
-  // liste des persones autorisées
-  var $auth_users;
+    // liste des groupes autorisés
+    public $auth_dn_groups;
+    // liste des persones autorisées
+    public $auth_users;
 
-  var $DEBUG = 0;
+    public $DEBUG = 0;
 
-  function servers()
-  {
- 
-	include CONFIG_PATH .'config_ldap.php';
-
-    $this->searchdn[0]    = $config_searchdn;
-    $this->basedn[0]      = $config_basedn;
-    $this->ldap_server[0] = $config_ldap_server;
-    $this->ldap_server_backup[0] = $config_ldap_bupsvr;
-    $this->ldap_protocol_version[0] = $config_ldap_protocol_version;
-    $this->ldap_user[0]   = $config_ldap_user;
-    $this->ldap_pass[0]   = $config_ldap_pass;
-    $this->ldap_login     = $config_ldap_login;
-
-
-     if ($this->DEBUG) print "Auth par defaut";
-  }
-
-  function AuthLDAP($utils="",$searchdn=0,$basedn=0,$ldap_server=0,$ldap_user=0,$ldap_pass=0,$ldap_group=0)
-  {
-
-
-    if ( is_array($searchdn) && is_array($basedn) && is_array($ldap_server) && is_array($ldap_user) && is_array($ldap_pass) )
+    public function servers()
     {
-      $this->searchdn           = $searchdn;
-      $this->basedn             = $basedn;
-      $this->ldap_server        = $ldap_server;
-      $this->ldap_server_backup = $ldap_server_backup;
-      $this->ldap_user          = $ldap_user;
-      $this->ldap_pass          = $ldap_pass;
-      $this->ldap_group         = $ldap_group;
-      $this->ldap_login	        = $ldap_login;
 
-      if ($this->DEBUG) print "Auth personnalisée ";
-    }
-    else //serveurs par défaut
-    {
-      $this->servers();
-    }
-    $this->auth_users($utils);
-  }
+        include CONFIG_PATH . 'config_ldap.php';
 
-  function auth_users($utils)
-  {
-    $this->auth_users = $utils;
-  }
+        $this->searchdn[0]              = $config_searchdn;
+        $this->basedn[0]                = $config_basedn;
+        $this->ldap_server[0]           = $config_ldap_server;
+        $this->ldap_server_backup[0]    = $config_ldap_bupsvr;
+        $this->ldap_protocol_version[0] = $config_ldap_protocol_version;
+        $this->ldap_user[0]             = $config_ldap_user;
+        $this->ldap_pass[0]             = $config_ldap_pass;
+        $this->ldap_login               = $config_ldap_login;
 
-
-  function bind($login,$password)
-  {
-    $this->user_login    = $login;
-    $this->user_password = $password;
-    if ( !($this->auth_users) || (in_array($login,$this->auth_users)) )
-      $this->ldap_query();
-    else
-      $this->user_auth=0;
-  }
-
-  function ldap_query()
-  {
-
-    $n = count($this->ldap_server);
-    for ($i=0;$i<$n;$i++)
-    {
-      if ($this->DEBUG) print "<p><hr>SERVEUR $i = ".$this->ldap_server[$i]."<br>searchdn=".$this->searchdn[$i]."</p>";
-
-
-      $ds = @ldap_connect($this->ldap_server[$i]);
-      //essaie le 2eme seveur au cas ou le 1er est parterre
-      if (!$ds )
-          $ds = @ldap_connect($this->ldap_server_backup[$i]);
-
-      if ( $ds  )
-      {
-		if($this->ldap_protocol_version[$i] != 0)
-        	ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, $this->ldap_protocol_version[$i]) ;
-		// Support Active Directory
-		ldap_set_option($ds, LDAP_OPT_REFERRALS, 0);
-        //$bound = @ldap_bind($ds, $this->ldap_user[$i], $this->ldap_pass[$i]);
-  	 if ($this->ldap_user[$i] == "")
-  	 	$bound = @ldap_bind($ds);
-  	 else   $bound = @ldap_bind($ds, $this->ldap_user[$i], $this->ldap_pass[$i]);
-
-  	if ( $bound )
-  	{
-
-
-          if  ( $this->ldap_group[$i] )
-          {
-
-            if ($this->DEBUG) print "<p>Filtre sur memberOf=" . $this->ldap_group[$i] ."</p>";
-
-            $sr   = ldap_search($ds,$this->searchdn[$i],"(&(".$config_ldap_login."=".$this->user_login.")(memberof=" . $this->ldap_group[$i] ."))" );
-
-
-          }
-          else
-          {
-            $filtre = $this->ldap_login."=".$this->user_login;
-            if ($this->DEBUG) print "filtre : $filtre";
-            $sr   = ldap_search($ds,$this->searchdn[$i],$filtre   );
-          }
-
-
-          $info = ldap_get_entries($ds,$sr);
-          if( isset($info['count']) && $info['count']>0)
-            $dn=$info[0]["dn"];
-          else 
-            $dn=false;
-
-
-          if ($this->DEBUG) print "<p>".$this->user_login." = $dn</p>";
-
-
-          if ( $dn && !empty($this->user_password))
-          {
-            if (@ldap_bind($ds,$dn,$this->user_password))
-	    {
-
-              $this->user_auth = 1;
-
-              if ($this->DEBUG) print " OUI ";
-            }
-            else
-	    {
-
-	      if ($this->DEBUG) print " NON ";
-
-	    }
-          }
-          else
-          {
-            if ($this->DEBUG) print "<p>Utilisateur introuvable</p>";
-          }
+        if ($this->DEBUG) {
+            print "Auth par defaut";
         }
-        else
-          if ($this->DEBUG) print "<p>serveur injoignable</p>";
-      }
 
     }
-  }
 
-  function is_authentificated()
-  {
-    return $this->user_auth;
-  }
+    public function AuthLDAP($utils = "", $searchdn = 0, $basedn = 0, $ldap_server = 0, $ldap_user = 0, $ldap_pass = 0, $ldap_group = 0)
+    {
+
+        if (is_array($searchdn) && is_array($basedn) && is_array($ldap_server) && is_array($ldap_user) && is_array($ldap_pass)) {
+            $this->searchdn           = $searchdn;
+            $this->basedn             = $basedn;
+            $this->ldap_server        = $ldap_server;
+            $this->ldap_server_backup = $ldap_server_backup;
+            $this->ldap_user          = $ldap_user;
+            $this->ldap_pass          = $ldap_pass;
+            $this->ldap_group         = $ldap_group;
+            $this->ldap_login         = $ldap_login;
+
+            if ($this->DEBUG) {
+                print "Auth personnalisée ";
+            }
+
+        } else //serveurs par défaut
+        {
+            $this->servers();
+        }
+        $this->auth_users($utils);
+    }
+
+    public function auth_users($utils)
+    {
+        $this->auth_users = $utils;
+    }
+
+    public function bind($login, $password)
+    {
+        $this->user_login    = $login;
+        $this->user_password = $password;
+        if (!($this->auth_users) || (in_array($login, $this->auth_users))) {
+            $this->ldap_query();
+        } else {
+            $this->user_auth = 0;
+        }
+
+    }
+
+    public function ldap_query()
+    {
+
+        $n = count($this->ldap_server);
+        for ($i = 0; $i < $n; $i++) {
+            if ($this->DEBUG) {
+                print "<p><hr>SERVEUR $i = " . $this->ldap_server[$i] . "<br>searchdn=" . $this->searchdn[$i] . "</p>";
+            }
+
+            $ds = @ldap_connect($this->ldap_server[$i]);
+            //essaie le 2eme seveur au cas ou le 1er est parterre
+            if (!$ds) {
+                $ds = @ldap_connect($this->ldap_server_backup[$i]);
+            }
+
+            if ($ds) {
+                if ($this->ldap_protocol_version[$i] != 0) {
+                    ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, $this->ldap_protocol_version[$i]);
+                }
+
+                // Support Active Directory
+                ldap_set_option($ds, LDAP_OPT_REFERRALS, 0);
+                //$bound = @ldap_bind($ds, $this->ldap_user[$i], $this->ldap_pass[$i]);
+                if ($this->ldap_user[$i] == "") {
+                    $bound = @ldap_bind($ds);
+                } else {
+                    $bound = @ldap_bind($ds, $this->ldap_user[$i], $this->ldap_pass[$i]);
+                }
+
+                if ($bound) {
+
+                    if ($this->ldap_group[$i]) {
+
+                        if ($this->DEBUG) {
+                            print "<p>Filtre sur memberOf=" . $this->ldap_group[$i] . "</p>";
+                        }
+
+                        $sr = ldap_search($ds, $this->searchdn[$i], "(&(" . $config_ldap_login . "=" . $this->user_login . ")(memberof=" . $this->ldap_group[$i] . "))");
+
+                    } else {
+                        $filtre = $this->ldap_login . "=" . $this->user_login;
+                        if ($this->DEBUG) {
+                            print "filtre : $filtre";
+                        }
+
+                        $sr = ldap_search($ds, $this->searchdn[$i], $filtre);
+                    }
+
+                    $info = ldap_get_entries($ds, $sr);
+                    if (isset($info['count']) && $info['count'] > 0) {
+                        $dn = $info[0]["dn"];
+                    } else {
+                        $dn = false;
+                    }
+
+                    if ($this->DEBUG) {
+                        print "<p>" . $this->user_login . " = $dn</p>";
+                    }
+
+                    if ($dn && !empty($this->user_password)) {
+                        if (@ldap_bind($ds, $dn, $this->user_password)) {
+
+                            $this->user_auth = 1;
+
+                            if ($this->DEBUG) {
+                                print " OUI ";
+                            }
+
+                        } else {
+
+                            if ($this->DEBUG) {
+                                print " NON ";
+                            }
+
+                        }
+                    } else {
+                        if ($this->DEBUG) {
+                            print "<p>Utilisateur introuvable</p>";
+                        }
+
+                    }
+                } else
+                if ($this->DEBUG) {
+                    print "<p>serveur injoignable</p>";
+                }
+
+            }
+
+        }
+    }
+
+    public function is_authentificated()
+    {
+        return $this->user_auth;
+    }
 
 }
-
-
-
-?>

--- a/responsable/Fonctions.php
+++ b/responsable/Fonctions.php
@@ -3,16 +3,16 @@
 namespace responsable;
 
 /**
-* Regroupement des fonctions liées au responsable
-*/
+ * Regroupement des fonctions liées au responsable
+ */
 class Fonctions
 {
     // on insert l'ajout de conges dans la table periode
     public static function insert_ajout_dans_periode($login, $nb_jours, $id_type_abs, $commentaire)
     {
-        $date_today=date("Y-m-d");
+        $date_today = date("Y-m-d");
 
-        $result=insert_dans_periode($login, $date_today, "am", $date_today, "am", $nb_jours, $commentaire, $id_type_abs, "ajout", 0);
+        $result = insert_dans_periode($login, $date_today, "am", $date_today, "am", $nb_jours, $commentaire, $id_type_abs, "ajout", 0);
     }
 
     public static function ajout_global_groupe($choix_groupe, $tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all)
@@ -21,31 +21,31 @@ class Fonctions
         // $tab_calcul_proportionnel[$id_conges]= TRUE / FALSE
 
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // recup de la liste des users d'un groupe donné
         $list_users = get_list_users_du_groupe($choix_groupe);
 
-        foreach($tab_new_nb_conges_all as $id_conges => $nb_jours) {
-            if($nb_jours!=0) {
+        foreach ($tab_new_nb_conges_all as $id_conges => $nb_jours) {
+            if ($nb_jours != 0) {
                 $comment = $tab_new_comment_all[$id_conges];
 
-                $sql1="SELECT u_login, u_quotite FROM conges_users WHERE u_login IN ($list_users) ORDER BY u_login ";
+                $sql1    = "SELECT u_login, u_quotite FROM conges_users WHERE u_login IN ($list_users) ORDER BY u_login ";
                 $ReqLog1 = \includes\SQL::query($sql1);
 
                 while ($resultat1 = $ReqLog1->fetch_array()) {
-                    $current_login  =$resultat1["u_login"];
-                    $current_quotite=$resultat1["u_quotite"];
+                    $current_login   = $resultat1["u_login"];
+                    $current_quotite = $resultat1["u_quotite"];
 
-                    if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
-                        $nb_conges=$nb_jours;
+                    if ((!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges] != true)) {
+                        $nb_conges = $nb_jours;
                     } else {
                         // pour arrondir au 1/2 le + proche on  fait x 2, on arrondit, puis on divise par 2
-                        $nb_conges = (ROUND(($nb_jours*($current_quotite/100))*2))/2  ;
+                        $nb_conges = (ROUND(($nb_jours * ($current_quotite / 100)) * 2)) / 2;
                     }
                     $nb_conges_ok = verif_saisie_decimal($nb_conges);
-                    if($nb_conges_ok){
+                    if ($nb_conges_ok) {
                         // 1 : on update conges_solde_user
                         $req_update = "UPDATE conges_solde_user SET su_solde = su_solde+$nb_conges
                             WHERE  su_login = '$current_login' AND su_abs_id = $id_conges   ";
@@ -53,8 +53,8 @@ class Fonctions
 
                         // 2 : on insert l'ajout de conges dans la table periode
                         // recup du nom du groupe
-                        $groupename= get_group_name_from_id($choix_groupe);
-                        $commentaire =  _('resp_ajout_conges_comment_periode_groupe') ." $groupename";
+                        $groupename  = get_group_name_from_id($choix_groupe);
+                        $commentaire = _('resp_ajout_conges_comment_periode_groupe') . " $groupename";
 
                         // ajout conges
                         \responsable\Fonctions::insert_ajout_dans_periode($current_login, $nb_conges, $id_conges, $commentaire);
@@ -64,7 +64,7 @@ class Fonctions
 
                 $group_name = get_group_name_from_id($choix_groupe);
                 // 3 : Enregistrement du commentaire relatif à l'ajout de jours de congés
-                if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
+                if ((!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges] != true)) {
                     $comment_log = "ajout conges pour groupe $group_name ($nb_jours jour(s)) ($comment) (calcul proportionnel : No)";
                 } else {
                     $comment_log = "ajout conges pour groupe $group_name ($nb_jours jour(s)) ($comment) (calcul proportionnel : Yes)";
@@ -73,15 +73,15 @@ class Fonctions
             }
         }
         $return .= ' ' . _('form_modif_ok') . '<br><br>';
-        redirect( ROOT_PATH .'responsable/resp_index.php?session=' . $session );
+        redirect(ROOT_PATH . 'responsable/resp_index.php?session=' . $session);
         return $return;
     }
 
     public static function ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // $tab_new_nb_conges_all[$id_conges]= nb_jours
         // $tab_calcul_proportionnel[$id_conges]= TRUE / FALSE
@@ -91,22 +91,22 @@ class Fonctions
         // renvoit une liste de login entre quotes et séparés par des virgules
         $list_users_du_resp = get_list_all_users_du_resp($_SESSION['userlogin']);
 
-        foreach($tab_new_nb_conges_all as $id_conges => $nb_jours) {
-            if($nb_jours!=0) {
+        foreach ($tab_new_nb_conges_all as $id_conges => $nb_jours) {
+            if ($nb_jours != 0) {
                 $comment = $tab_new_comment_all[$id_conges];
 
-                $sql1="SELECT u_login, u_quotite FROM conges_users WHERE u_login IN ($list_users_du_resp) ORDER BY u_login ";
+                $sql1    = "SELECT u_login, u_quotite FROM conges_users WHERE u_login IN ($list_users_du_resp) ORDER BY u_login ";
                 $ReqLog1 = \includes\SQL::query($sql1);
 
-                while($resultat1 = $ReqLog1->fetch_array()) {
-                    $current_login  =$resultat1["u_login"];
-                    $current_quotite=$resultat1["u_quotite"];
+                while ($resultat1 = $ReqLog1->fetch_array()) {
+                    $current_login   = $resultat1["u_login"];
+                    $current_quotite = $resultat1["u_quotite"];
 
-                    if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
-                        $nb_conges=$nb_jours;
+                    if ((!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges] != true)) {
+                        $nb_conges = $nb_jours;
                     } else {
                         // pour arrondir au 1/2 le + proche on  fait x 2, on arrondit, puis on divise par 2
-                        $nb_conges = (ROUND(($nb_jours*($current_quotite/100))*2))/2  ;
+                        $nb_conges = (ROUND(($nb_jours * ($current_quotite / 100)) * 2)) / 2;
                     }
 
                     $nb_conges_ok = verif_saisie_decimal($nb_conges);
@@ -117,13 +117,13 @@ class Fonctions
                         $ReqLog_update = \includes\SQL::query($req_update);
 
                         // 2 : on insert l'ajout de conges GLOBAL (pour tous les users) dans la table periode
-                        $commentaire =  _('resp_ajout_conges_comment_periode_all') ;
+                        $commentaire = _('resp_ajout_conges_comment_periode_all');
                         // ajout conges
                         \responsable\Fonctions::insert_ajout_dans_periode($current_login, $nb_conges, $id_conges, $commentaire);
                     }
                 }
                 // 3 : Enregistrement du commentaire relatif à l'ajout de jours de congés
-                if( (!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges]!=TRUE) ) {
+                if ((!isset($tab_calcul_proportionnel[$id_conges])) || ($tab_calcul_proportionnel[$id_conges] != true)) {
                     $comment_log = "ajout conges global ($nb_jours jour(s)) ($comment) (calcul proportionnel : No)";
                 } else {
                     $comment_log = "ajout conges global ($nb_jours jour(s)) ($comment) (calcul proportionnel : Yes)";
@@ -134,42 +134,42 @@ class Fonctions
 
         $return .= ' ' . _('form_modif_ok') . '<br><br>';
         /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-        redirect( ROOT_PATH .'responsable/resp_index.php?session=' . $session );
+        redirect(ROOT_PATH . 'responsable/resp_index.php?session=' . $session);
         return $return;
     }
 
     public static function ajout_conges($tab_champ_saisie, $tab_commentaire_saisie)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
-        foreach($tab_champ_saisie as $user_name => $tab_conges)   // tab_champ_saisie[$current_login][$id_conges]=valeur du nb de jours ajouté saisi
+        foreach ($tab_champ_saisie as $user_name => $tab_conges) // tab_champ_saisie[$current_login][$id_conges]=valeur du nb de jours ajouté saisi
         {
-            foreach($tab_conges as $id_conges => $user_nb_jours_ajout) {
-                $user_nb_jours_ajout_float =(float) $user_nb_jours_ajout ;
-                $valid=verif_saisie_decimal($user_nb_jours_ajout_float);   //verif la bonne saisie du nombre décimal
-                if($valid) {
-                    if($user_nb_jours_ajout_float!=0) {
+            foreach ($tab_conges as $id_conges => $user_nb_jours_ajout) {
+                $user_nb_jours_ajout_float = (float) $user_nb_jours_ajout;
+                $valid                     = verif_saisie_decimal($user_nb_jours_ajout_float); //verif la bonne saisie du nombre décimal
+                if ($valid) {
+                    if ($user_nb_jours_ajout_float != 0) {
                         /* Modification de la table conges_users */
-                        $sql1 = "UPDATE conges_solde_user SET su_solde = su_solde+$user_nb_jours_ajout_float WHERE su_login='$user_name' AND su_abs_id = $id_conges " ;
+                        $sql1 = "UPDATE conges_solde_user SET su_solde = su_solde+$user_nb_jours_ajout_float WHERE su_login='$user_name' AND su_abs_id = $id_conges ";
                         /* On valide l'UPDATE dans la table ! */
-                        $ReqLog1 = \includes\SQL::query($sql1) ;
+                        $ReqLog1 = \includes\SQL::query($sql1);
 
-                        /*			// Enregistrement du commentaire relatif à l'ajout de jours de congés
-                                    $comment = $tab_commentaire_saisie[$user_name];
-                                    $sql1 = "INSERT INTO conges_historique_ajout (ha_login, ha_date, ha_abs_id, ha_nb_jours, ha_commentaire)
-                                    VALUES ('$user_name', NOW(), $id_conges, $user_nb_jours_ajout_float , '$comment')";
-                                    $ReqLog1 = SQL::query($sql1) ;
+                        /*            // Enregistrement du commentaire relatif à l'ajout de jours de congés
+                        $comment = $tab_commentaire_saisie[$user_name];
+                        $sql1 = "INSERT INTO conges_historique_ajout (ha_login, ha_date, ha_abs_id, ha_nb_jours, ha_commentaire)
+                        VALUES ('$user_name', NOW(), $id_conges, $user_nb_jours_ajout_float , '$comment')";
+                        $ReqLog1 = SQL::query($sql1) ;
                          */
                         // on insert l'ajout de conges dans la table periode
-                        $commentaire =  _('resp_ajout_conges_comment_periode_user') ;
+                        $commentaire = _('resp_ajout_conges_comment_periode_user');
                         \responsable\Fonctions::insert_ajout_dans_periode($user_name, $user_nb_jours_ajout_float, $id_conges, $commentaire);
                     }
                 }
             }
         }
-        $return .= ' '. _('form_modif_ok') . '<br><br>';
+        $return .= ' ' . _('form_modif_ok') . '<br><br>';
         /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
         $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?session=' . $session . '">';
         return $return;
@@ -178,34 +178,33 @@ class Fonctions
     public static function affichage_saisie_globale_groupe($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /***********************************************************************/
         /* SAISIE GROUPE pour tous les utilisateurs d'un groupe du responsable */
 
         // on établi la liste complète des groupes dont on est le resp (ou le grd resp)
-        $list_group_resp=get_list_groupes_du_resp($_SESSION['userlogin']);
-        if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) ) {
-            $list_group_grd_resp=get_list_groupes_du_grand_resp($_SESSION['userlogin']);
+        $list_group_resp = get_list_groupes_du_resp($_SESSION['userlogin']);
+        if (($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges'])) {
+            $list_group_grd_resp = get_list_groupes_du_grand_resp($_SESSION['userlogin']);
         } else {
-            $list_group_grd_resp="";
+            $list_group_grd_resp = "";
         }
 
-        $list_group="";
-        if($list_group_resp!="") {
+        $list_group = "";
+        if ($list_group_resp != "") {
             $list_group = $list_group_resp;
-            if($list_group_grd_resp!="") {
-                $list_group = $list_group.",".$list_group_grd_resp;
+            if ($list_group_grd_resp != "") {
+                $list_group = $list_group . "," . $list_group_grd_resp;
             }
         } else {
-            if($list_group_grd_resp!="") {
+            if ($list_group_grd_resp != "") {
                 $list_group = $list_group_grd_resp;
             }
         }
 
-
-        if($list_group!="") //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
+        if ($list_group != "") //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
         {
             $return .= '<h2>' . _('resp_ajout_conges_ajout_groupe') . '</h2>';
             $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout_conges" method="POST">';
@@ -214,25 +213,25 @@ class Fonctions
             $return .= '<tr>';
             $return .= '<td class="big">' . _('resp_ajout_conges_choix_groupe') . ' : </td>';
             // création du select pour le choix du groupe
-            $text_choix_group="<select name=\"choix_groupe\" >";
-            $sql_group = "SELECT g_gid, g_groupename FROM conges_groupe WHERE g_gid IN ($list_group) ORDER BY g_groupename "  ;
-            $ReqLog_group = \includes\SQL::query($sql_group) ;
+            $text_choix_group = "<select name=\"choix_groupe\" >";
+            $sql_group        = "SELECT g_gid, g_groupename FROM conges_groupe WHERE g_gid IN ($list_group) ORDER BY g_groupename ";
+            $ReqLog_group     = \includes\SQL::query($sql_group);
 
             while ($resultat_group = $ReqLog_group->fetch_array()) {
-                $current_group_id=$resultat_group["g_gid"];
-                $current_group_name=$resultat_group["g_groupename"];
-                $text_choix_group=$text_choix_group."<option value=\"$current_group_id\" >$current_group_name</option>";
+                $current_group_id   = $resultat_group["g_gid"];
+                $current_group_name = $resultat_group["g_groupename"];
+                $text_choix_group   = $text_choix_group . "<option value=\"$current_group_id\" >$current_group_name</option>";
             }
-            $text_choix_group=$text_choix_group."</select>" ;
+            $text_choix_group = $text_choix_group . "</select>";
 
             $return .= '<td colspan="3">' . $text_choix_group . '</td>';
             $return .= '</tr>';
             $return .= '<tr>';
             $return .= '<th colspan="2">' . _('resp_ajout_conges_nb_jours_all_1') . ' ' . _('resp_ajout_conges_nb_jours_all_2') . '</th>';
-            $return .= '<th>' ._('resp_ajout_conges_calcul_prop') . '</th>';
+            $return .= '<th>' . _('resp_ajout_conges_calcul_prop') . '</th>';
             $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
             $return .= '</tr>';
-            foreach($tab_type_conges as $id_conges => $libelle) {
+            foreach ($tab_type_conges as $id_conges => $libelle) {
                 $return .= '<tr>';
                 $return .= '<td><strong>' . $libelle . '<strong></td>';
                 $return .= '<td><input class="form-control" type="text" name="tab_new_nb_conges_all[' . $id_conges . ']" size="6" maxlength="6" value="0"></td>';
@@ -254,8 +253,8 @@ class Fonctions
     public static function affichage_saisie_globale_pour_tous($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /************************************************************/
         /* SAISIE GLOBALE pour tous les utilisateurs du responsable */
@@ -266,11 +265,11 @@ class Fonctions
         $return .= '<thead>';
         $return .= '<tr>';
         $return .= '<th colspan="2">' . _('resp_ajout_conges_nb_jours_all_1') . ' ' . _('resp_ajout_conges_nb_jours_all_2') . '</th>';
-        $return .= '<th>' ._('resp_ajout_conges_calcul_prop') . '</th>';
+        $return .= '<th>' . _('resp_ajout_conges_calcul_prop') . '</th>';
         $return .= '<th>' . _('divers_comment_maj_1') . '</th>';
         $return .= '</tr>';
         $return .= '</thead>';
-        foreach($tab_type_conges as $id_conges => $libelle) {
+        foreach ($tab_type_conges as $id_conges => $libelle) {
             $return .= '<tr>';
             $return .= '<td><strong>' . $libelle . '<strong></td>';
             $return .= '<td><input class="form-control" type="text" name="tab_new_nb_conges_all[' . $id_conges . ']" size="6" maxlength="6" value="0"></td>';
@@ -293,8 +292,8 @@ class Fonctions
     public static function affichage_saisie_user_par_user($tab_type_conges, $tab_type_conges_exceptionnels, $tab_all_users_du_resp, $tab_all_users_du_grand_resp)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /************************************************************/
         /* SAISIE USER PAR USER pour tous les utilisateurs du responsable */
@@ -306,7 +305,7 @@ class Fonctions
         //$tab_all_users_du_resp=recup_infos_all_users_du_resp($_SESSION['userlogin']);
         //$tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
 
-        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
+        if ((count($tab_all_users_du_resp) != 0) || (count($tab_all_users_du_grand_resp) != 0)) {
             // AFFICHAGE TITRES TABLEAU
             $return .= '<div class="table-responsive"><table class="table table-hover table-condensed table-striped">';
             $return .= '<thead>';
@@ -314,12 +313,12 @@ class Fonctions
             $return .= '<th>' . _('divers_nom_maj_1') . '</th>';
             $return .= '<th>' . _('divers_prenom_maj_1') . '</th>';
             $return .= '<th>' . _('divers_quotite_maj_1') . '</td>';
-            foreach($tab_type_conges as $id_conges => $libelle) {
+            foreach ($tab_type_conges as $id_conges => $libelle) {
                 $return .= '<th>' . $libelle . '<br><i>(' . _('divers_solde') . ')</i></th>';
                 $return .= '<th>' . $libelle . '<br>' . _('resp_ajout_conges_nb_jours_ajout') . '</th>';
             }
             if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-                foreach($tab_type_conges_exceptionnels as $id_conges => $libelle) {
+                foreach ($tab_type_conges_exceptionnels as $id_conges => $libelle) {
                     $return .= '<th>' . $libelle . '<br><i>(' . _('divers_solde') . ')</i></th>';
                     $return .= '<th>' . $libelle . '<br>' . _('resp_ajout_conges_nb_jours_ajout') . '</th>';
                 }
@@ -330,74 +329,74 @@ class Fonctions
             $return .= '<tbody>';
 
             // AFFICHAGE LIGNES TABLEAU
-            $cpt_lignes=0 ;
-            $tab_champ_saisie_conges=array();
+            $cpt_lignes              = 0;
+            $tab_champ_saisie_conges = array();
 
             $i = true;
             // affichage des users dont on est responsable :
-            foreach($tab_all_users_du_resp as $current_login => $tab_current_user) {
-                $return .= '<tr class="'.($i?'i':'p').'">';
+            foreach ($tab_all_users_du_resp as $current_login => $tab_current_user) {
+                $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
                 //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-                $tab_conges=$tab_current_user['conges'];
+                $tab_conges = $tab_current_user['conges'];
 
                 /** sur la ligne ,   **/
                 $return .= '<td>' . $tab_current_user['nom'] . '</td>';
                 $return .= '<td>' . $tab_current_user['prenom'] . '</td>';
                 $return .= '<td>' . $tab_current_user['quotite'] . '%</td>';
 
-                foreach($tab_type_conges as $id_conges => $libelle) {
+                foreach ($tab_type_conges as $id_conges => $libelle) {
                     /** le champ de saisie est <input type="text" name="tab_champ_saisie[valeur de u_login][id_du_type_de_conges]" value="[valeur du nb de jours ajouté saisi]"> */
-                    $champ_saisie_conges="<input class=\"form-control\" type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
+                    $champ_saisie_conges = "<input class=\"form-control\" type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
                     $return .= '<td>' . $tab_conges[$libelle]['nb_an'] . ' <i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
                     $return .= '<td align="center" class="histo">' . $champ_saisie_conges . '</td>';
                 }
                 if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-                    foreach($tab_type_conges_exceptionnels as $id_conges => $libelle) {
+                    foreach ($tab_type_conges_exceptionnels as $id_conges => $libelle) {
                         /** le champ de saisie est <input type="text" name="tab_champ_saisie[valeur de u_login][id_du_type_de_conges]" value="[valeur du nb de jours ajouté saisi]"> */
-                        $champ_saisie_conges="<input class=\"form-control\" type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
+                        $champ_saisie_conges = "<input class=\"form-control\" type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
                         $return .= '<td><i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
                         $return .= '<td align="center" class="histo">' . $champ_saisie_conges . '</td>';
                     }
                 }
                 $return .= '<td align="center" class="histo"><input class="form-control" type="text" name="tab_commentaire_saisie[' . $current_login . ']" size="30" maxlength="200" value=""></td>';
                 $return .= '</tr>';
-                $cpt_lignes++ ;
+                $cpt_lignes++;
                 $i = !$i;
             }
 
             // affichage des users dont on est grand responsable :
-            if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) ) {
-                $nb_colspan=50;
+            if (($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges'])) {
+                $nb_colspan = 50;
                 $return .= '<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="' . $nb_colspan . '"><i>' . _('resp_etat_users_titre_double_valid') . '</i></td></tr>';
 
                 $i = true;
-                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user) {
-                    $return .= '<tr class="'.($i?'i':'p').'">';
+                foreach ($tab_all_users_du_grand_resp as $current_login => $tab_current_user) {
+                    $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
                     //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-                    $tab_conges=$tab_current_user['conges'];
+                    $tab_conges = $tab_current_user['conges'];
 
                     /** sur la ligne ,   **/
                     $return .= '<td>' . $tab_current_user['nom'] . '</td>';
                     $return .= '<td>' . $tab_current_user['prenom'] . '</td>';
                     $return .= '<td>' . $tab_current_user['quotite'] . '%</td>';
 
-                    foreach($tab_type_conges as $id_conges => $libelle) {
+                    foreach ($tab_type_conges as $id_conges => $libelle) {
                         /** le champ de saisie est <input type="text" name="tab_champ_saisie[valeur de u_login][id_du_type_de_conges]" value="[valeur du nb de jours ajouté saisi]"> */
-                        $champ_saisie_conges="<input type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
+                        $champ_saisie_conges = "<input type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
                         $return .= '<td>' . $tab_conges[$libelle]['nb_an'] . ' <i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
                         $return .= '<td align="center" class="histo">' . $champ_saisie_conges . '</td>';
                     }
                     if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-                        foreach($tab_type_conges_exceptionnels as $id_conges => $libelle) {
+                        foreach ($tab_type_conges_exceptionnels as $id_conges => $libelle) {
                             /** le champ de saisie est <input type="text" name="tab_champ_saisie[valeur de u_login][id_du_type_de_conges]" value="[valeur du nb de jours ajouté saisi]"> */
-                            $champ_saisie_conges="<input type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
+                            $champ_saisie_conges = "<input type=\"text\" name=\"tab_champ_saisie[$current_login][$id_conges]\" size=\"6\" maxlength=\"6\" value=\"0\">";
                             $return .= '<td><i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
                             $return .= '<td align="center" class="histo">' . $champ_saisie_conges . '</td>';
                         }
                     }
                     $return .= '<td align="center" class="histo"><input type="text" name="tab_commentaire_saisie[' . $current_login . ']" size="30" maxlength="200" value=""></td>';
                     $return .= '</tr>';
-                    $cpt_lignes++ ;
+                    $cpt_lignes++;
                     $i = !$i;
                 }
             }
@@ -413,11 +412,11 @@ class Fonctions
         return $return;
     }
 
-    public static function saisie_ajout( $tab_type_conges)
+    public static function saisie_ajout($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // recup du tableau des types de conges (seulement les congesexceptionnels )
         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
@@ -429,9 +428,9 @@ class Fonctions
         // recup de la liste de TOUS les users dont $resp_login est responsable
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
-        $tab_all_users_du_resp=recup_infos_all_users_du_resp($_SESSION['userlogin']);
-        $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
-        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
+        $tab_all_users_du_resp       = recup_infos_all_users_du_resp($_SESSION['userlogin']);
+        $tab_all_users_du_grand_resp = recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
+        if ((count($tab_all_users_du_resp) != 0) || (count($tab_all_users_du_grand_resp) != 0)) {
             /************************************************************/
             /* SAISIE GLOBALE pour tous les utilisateurs du responsable */
             $return .= \responsable\Fonctions::affichage_saisie_globale_pour_tous($tab_type_conges);
@@ -439,7 +438,7 @@ class Fonctions
 
             /***********************************************************************/
             /* SAISIE GROUPE pour tous les utilisateurs d'un groupe du responsable */
-            if( $_SESSION['config']['gestion_groupes'] ) {
+            if ($_SESSION['config']['gestion_groupes']) {
                 $return .= \responsable\Fonctions::affichage_saisie_globale_groupe($tab_type_conges);
             }
 
@@ -465,26 +464,26 @@ class Fonctions
     public static function ajoutCongesModule($tab_type_cong)
     {
         //var pour resp_ajout_conges_all.php
-        $ajout_conges            = getpost_variable('ajout_conges');
-        $tab_champ_saisie        = getpost_variable('tab_champ_saisie');
-        $tab_commentaire_saisie        = getpost_variable('tab_commentaire_saisie');
+        $ajout_conges           = getpost_variable('ajout_conges');
+        $tab_champ_saisie       = getpost_variable('tab_champ_saisie');
+        $tab_commentaire_saisie = getpost_variable('tab_commentaire_saisie');
         //$tab_champ_saisie_rtt    = getpost_variable('tab_champ_saisie_rtt') ;
-        $ajout_global            = getpost_variable('ajout_global');
-        $ajout_groupe            = getpost_variable('ajout_groupe');
-        $choix_groupe            = getpost_variable('choix_groupe');
-        $tab_new_nb_conges_all   = getpost_variable('tab_new_nb_conges_all');
+        $ajout_global             = getpost_variable('ajout_global');
+        $ajout_groupe             = getpost_variable('ajout_groupe');
+        $choix_groupe             = getpost_variable('choix_groupe');
+        $tab_new_nb_conges_all    = getpost_variable('tab_new_nb_conges_all');
         $tab_calcul_proportionnel = getpost_variable('tab_calcul_proportionnel');
-        $tab_new_comment_all     = getpost_variable('tab_new_comment_all');
-        $return = '';
+        $tab_new_comment_all      = getpost_variable('tab_new_comment_all');
+        $return                   = '';
 
         // titre
         $return .= '<h1>' . _('resp_ajout_conges_titre') . '</h1>';
 
-        if($ajout_conges=="TRUE") {
+        if ($ajout_conges == "TRUE") {
             $return .= \responsable\Fonctions::ajout_conges($tab_champ_saisie, $tab_commentaire_saisie);
-        } elseif($ajout_global=="TRUE") {
+        } elseif ($ajout_global == "TRUE") {
             $return .= \responsable\Fonctions::ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all);
-        } elseif($ajout_groupe=="TRUE") {
+        } elseif ($ajout_groupe == "TRUE") {
             $return .= \responsable\Fonctions::ajout_global_groupe($choix_groupe, $tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all);
         } else {
             $return .= \responsable\Fonctions::saisie_ajout($tab_type_cong);
@@ -496,18 +495,18 @@ class Fonctions
     public static function set_nouvelle_date_limite_reliquat()
     {
         //si on autorise les reliquats
-        if($_SESSION['config']['autorise_reliquats_exercice']) {
+        if ($_SESSION['config']['autorise_reliquats_exercice']) {
             // s'il y a une date limite d'utilisationdes reliquats (au format jj-mm)
-            if($_SESSION['config']['jour_mois_limite_reliquats']!=0) {
+            if ($_SESSION['config']['jour_mois_limite_reliquats'] != 0) {
                 // nouvelle date limite au format aaa-mm-jj
-                $t=explode("-", $_SESSION['config']['jour_mois_limite_reliquats']);
-                $new_date_limite = date("Y")."-".$t[1]."-".$t[0];
+                $t               = explode("-", $_SESSION['config']['jour_mois_limite_reliquats']);
+                $new_date_limite = date("Y") . "-" . $t[1] . "-" . $t[0];
 
                 //si la date limite n'a pas encore été updatée
-                if($_SESSION['config']['date_limite_reliquats'] < $new_date_limite) {
+                if ($_SESSION['config']['date_limite_reliquats'] < $new_date_limite) {
                     /* Modification de la table conges_appli */
-                    $sql_update= "UPDATE conges_appli SET appli_valeur = '$new_date_limite' WHERE appli_variable='date_limite_reliquats' " ;
-                    $ReqLog_update = \includes\SQL::query($sql_update) ;
+                    $sql_update    = "UPDATE conges_appli SET appli_valeur = '$new_date_limite' WHERE appli_variable='date_limite_reliquats' ";
+                    $ReqLog_update = \includes\SQL::query($sql_update);
 
                 }
             }
@@ -518,17 +517,17 @@ class Fonctions
     public static function cloture_globale_groupe($group_id, $tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // recup de la liste de TOUS les users du groupe
-        $tab_all_users_du_groupe=recup_infos_all_users_du_groupe($group_id);
+        $tab_all_users_du_groupe = recup_infos_all_users_du_groupe($group_id);
 
-        $comment_cloture =  _('resp_cloture_exercice_commentaire') ." ".date("m/Y");
+        $comment_cloture = _('resp_cloture_exercice_commentaire') . " " . date("m/Y");
 
-        if(count($tab_all_users_du_groupe)!=0) {
+        if (count($tab_all_users_du_groupe) != 0) {
             // traitement des users dont on est responsable :
-            foreach($tab_all_users_du_groupe as $current_login => $tab_current_user) {
+            foreach ($tab_all_users_du_groupe as $current_login => $tab_current_user) {
                 $return .= cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $comment_cloture);
             }
         }
@@ -542,25 +541,25 @@ class Fonctions
     public static function cloture_globale($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
-        $tab_all_users_du_resp=recup_infos_all_users_du_resp($_SESSION['userlogin']);
-        $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
+        $tab_all_users_du_resp       = recup_infos_all_users_du_resp($_SESSION['userlogin']);
+        $tab_all_users_du_grand_resp = recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
 
-        $comment_cloture =  _('resp_cloture_exercice_commentaire') ." ".date("m/Y");
+        $comment_cloture = _('resp_cloture_exercice_commentaire') . " " . date("m/Y");
 
-        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
+        if ((count($tab_all_users_du_resp) != 0) || (count($tab_all_users_du_grand_resp) != 0)) {
             // traitement des users dont on est responsable :
-            foreach($tab_all_users_du_resp as $current_login => $tab_current_user) {
+            foreach ($tab_all_users_du_resp as $current_login => $tab_current_user) {
                 $return .= cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $comment_cloture);
             }
             // traitement des users dont on est grand responsable :
-            if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) ) {
-                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user) {
+            if (($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges'])) {
+                foreach ($tab_all_users_du_grand_resp as $current_login => $tab_current_user) {
                     $return .= cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $comment_cloture);
                 }
             }
@@ -576,18 +575,18 @@ class Fonctions
     public static function update_appli_num_exercice()
     {
         // verif
-        $appli_num_exercice = $_SESSION['config']['num_exercice'] ;
-        $sql_verif = 'SELECT u_login FROM conges_users WHERE u_login != \'admin\' AND u_login != \'conges\' AND u_num_exercice != '. \includes\SQL::quote($appli_num_exercice).';';
-        $ReqLog_verif = \includes\SQL::query($sql_verif);
+        $appli_num_exercice = $_SESSION['config']['num_exercice'];
+        $sql_verif          = 'SELECT u_login FROM conges_users WHERE u_login != \'admin\' AND u_login != \'conges\' AND u_num_exercice != ' . \includes\SQL::quote($appli_num_exercice) . ';';
+        $ReqLog_verif       = \includes\SQL::query($sql_verif);
 
-        if($ReqLog_verif->num_rows == 0) {
+        if ($ReqLog_verif->num_rows == 0) {
             /* Modification de la table conges_appli */
-            $sql_update= 'UPDATE conges_appli SET appli_valeur = appli_valeur+1 WHERE appli_variable=\'num_exercice\' ;';
-            $ReqLog_update = \includes\SQL::query($sql_update) ;
+            $sql_update    = 'UPDATE conges_appli SET appli_valeur = appli_valeur+1 WHERE appli_variable=\'num_exercice\' ;';
+            $ReqLog_update = \includes\SQL::query($sql_update);
 
             // ecriture dans les logs
-            $new_appli_num_exercice = $appli_num_exercice+1 ;
-            log_action(0, '', '', 'fin/debut exercice (appli_num_exercice : '.$appli_num_exercice.' -> '.$new_appli_num_exercice.')');
+            $new_appli_num_exercice = $appli_num_exercice + 1;
+            log_action(0, '', '', 'fin/debut exercice (appli_num_exercice : ' . $appli_num_exercice . ' -> ' . $new_appli_num_exercice . ')');
         }
     }
 
@@ -595,69 +594,68 @@ class Fonctions
     {
         $return = '';
         // si le num d'exercice du user est < à celui de l'appli (il n'a pas encore été basculé): on le bascule d'exercice
-        if($tab_current_user['num_exercice'] < $_SESSION['config']['num_exercice']) {
+        if ($tab_current_user['num_exercice'] < $_SESSION['config']['num_exercice']) {
             // calcule de la date limite d'utilisation des reliquats (si on utilise une date limite et qu'elle n'est pas encore calculée)
             \responsable\Fonctions::set_nouvelle_date_limite_reliquat();
 
             //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-            $tab_conges_current_user=$tab_current_user['conges'];
-            foreach($tab_type_conges as $id_conges => $libelle) {
+            $tab_conges_current_user = $tab_current_user['conges'];
+            foreach ($tab_type_conges as $id_conges => $libelle) {
                 $user_nb_jours_ajout_an = $tab_conges_current_user[$libelle]['nb_an'];
-                $user_solde_actuel=$tab_conges_current_user[$libelle]['solde'];
-                $user_reliquat_actuel=$tab_conges_current_user[$libelle]['reliquat'];
+                $user_solde_actuel      = $tab_conges_current_user[$libelle]['solde'];
+                $user_reliquat_actuel   = $tab_conges_current_user[$libelle]['reliquat'];
 
                 /**********************************************/
                 /* Modification de la table conges_solde_user */
 
-                if($_SESSION['config']['autorise_reliquats_exercice']) {
+                if ($_SESSION['config']['autorise_reliquats_exercice']) {
                     // ATTENTION : si le solde du user est négatif, on ne compte pas de reliquat et le nouveau solde est nb_jours_an + le solde actuel (qui est négatif)
-                    if($user_solde_actuel>0) {
+                    if ($user_solde_actuel > 0) {
                         //calcul du reliquat pour l'exercice suivant
-                        if($_SESSION['config']['nb_maxi_jours_reliquats']!=0) {
-                            if($user_solde_actuel <= $_SESSION['config']['nb_maxi_jours_reliquats']) {
-                                $new_reliquat = $user_solde_actuel ;
+                        if ($_SESSION['config']['nb_maxi_jours_reliquats'] != 0) {
+                            if ($user_solde_actuel <= $_SESSION['config']['nb_maxi_jours_reliquats']) {
+                                $new_reliquat = $user_solde_actuel;
                             } else {
-                                $new_reliquat = $_SESSION['config']['nb_maxi_jours_reliquats'] ;
+                                $new_reliquat = $_SESSION['config']['nb_maxi_jours_reliquats'];
                             }
                         } else {
-                            $new_reliquat = $user_reliquat_actuel + $user_solde_actuel ;
+                            $new_reliquat = $user_reliquat_actuel + $user_solde_actuel;
                         }
 
                         //
                         // update D'ABORD du reliquat
-                        $VerifDec=verif_saisie_decimal($new_reliquat);
-                        $sql_reliquat = "UPDATE conges_solde_user SET su_reliquat = $new_reliquat WHERE su_login='$current_login' AND su_abs_id = $id_conges " ;
-                        $ReqLog_reliquat = \includes\SQL::query($sql_reliquat) ;
+                        $VerifDec        = verif_saisie_decimal($new_reliquat);
+                        $sql_reliquat    = "UPDATE conges_solde_user SET su_reliquat = $new_reliquat WHERE su_login='$current_login' AND su_abs_id = $id_conges ";
+                        $ReqLog_reliquat = \includes\SQL::query($sql_reliquat);
                     } else {
-                        $new_reliquat = $user_solde_actuel ; // qui est nul ou negatif
+                        $new_reliquat = $user_solde_actuel; // qui est nul ou negatif
                     }
 
-
-                    $new_solde = $user_nb_jours_ajout_an + $new_reliquat  ;
-                    $VerifDec=verif_saisie_decimal($new_solde);
+                    $new_solde = $user_nb_jours_ajout_an + $new_reliquat;
+                    $VerifDec  = verif_saisie_decimal($new_solde);
                     // update du solde
-                    $sql_solde = 'UPDATE conges_solde_user SET su_solde = \''.$new_solde.'\' WHERE su_login="'. \includes\SQL::quote($current_login).'" AND su_abs_id ="'. \includes\SQL::quote($id_conges).'" ';
-                    $ReqLog_solde = \includes\SQL::query($sql_solde) ;
+                    $sql_solde    = 'UPDATE conges_solde_user SET su_solde = \'' . $new_solde . '\' WHERE su_login="' . \includes\SQL::quote($current_login) . '" AND su_abs_id ="' . \includes\SQL::quote($id_conges) . '" ';
+                    $ReqLog_solde = \includes\SQL::query($sql_solde);
                 } else {
                     // ATTENTION : meme si on accepte pas les reliquats, si le solde du user est négatif, il faut le reporter: le nouveau solde est nb_jours_an + le solde actuel (qui est négatif)
-                    if($user_solde_actuel < 0) {
-                        $new_solde = $user_nb_jours_ajout_an + $user_solde_actuel ; // qui est nul ou negatif
+                    if ($user_solde_actuel < 0) {
+                        $new_solde = $user_nb_jours_ajout_an + $user_solde_actuel; // qui est nul ou negatif
                     } else {
-                        $new_solde = $user_nb_jours_ajout_an ;
+                        $new_solde = $user_nb_jours_ajout_an;
                     }
-                    $VerifDec=verif_saisie_decimal($new_solde);
-                    $sql_solde = 'UPDATE conges_solde_user SET su_solde = \''.$new_solde.'\' WHERE su_login="'. \includes\SQL::quote($current_login).'"  AND su_abs_id = "'. \includes\SQL::quote($id_conges).'" ';
-                    $ReqLog_solde = \includes\SQL::query($sql_solde) ;
+                    $VerifDec     = verif_saisie_decimal($new_solde);
+                    $sql_solde    = 'UPDATE conges_solde_user SET su_solde = \'' . $new_solde . '\' WHERE su_login="' . \includes\SQL::quote($current_login) . '"  AND su_abs_id = "' . \includes\SQL::quote($id_conges) . '" ';
+                    $ReqLog_solde = \includes\SQL::query($sql_solde);
                 }
 
                 /* Modification de la table conges_users */
                 // ATTENTION : ne pas faire "SET u_num_exercice = u_num_exercice+1" dans la requete SQL car on incrémenterait pour chaque type d'absence !
-                $new_num_exercice=$_SESSION['config']['num_exercice'] ;
-                $sql2 = 'UPDATE conges_users SET u_num_exercice = \''.$new_num_exercice.'\' WHERE u_login="'. \includes\SQL::quote($current_login).'" ';
-                $ReqLog2 = \includes\SQL::query($sql2) ;
+                $new_num_exercice = $_SESSION['config']['num_exercice'];
+                $sql2             = 'UPDATE conges_users SET u_num_exercice = \'' . $new_num_exercice . '\' WHERE u_login="' . \includes\SQL::quote($current_login) . '" ';
+                $ReqLog2          = \includes\SQL::query($sql2);
 
                 // on insert l'ajout de conges dans la table periode (avec le commentaire)
-                $date_today=date("Y-m-d");
+                $date_today = date("Y-m-d");
                 insert_dans_periode($current_login, $date_today, "am", $date_today, "am", $user_nb_jours_ajout_an, $commentaire, $id_conges, "ajout", 0);
             }
 
@@ -671,29 +669,29 @@ class Fonctions
     public static function cloture_users($tab_type_conges, $tab_cloture_users, $tab_commentaire_saisie)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
-        $tab_all_users_du_resp=recup_infos_all_users_du_resp($_SESSION['userlogin']);
-        $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
+        $tab_all_users_du_resp       = recup_infos_all_users_du_resp($_SESSION['userlogin']);
+        $tab_all_users_du_grand_resp = recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
 
-        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
+        if ((count($tab_all_users_du_resp) != 0) || (count($tab_all_users_du_grand_resp) != 0)) {
             // traitement des users dont on est responsable :
-            foreach($tab_all_users_du_resp as $current_login => $tab_current_user) {
+            foreach ($tab_all_users_du_resp as $current_login => $tab_current_user) {
                 // tab_cloture_users[$current_login]=TRUE si checkbox "cloturer" est cochée
-                if( (isset($tab_cloture_users[$current_login])) && ($tab_cloture_users[$current_login]=TRUE) ) {
+                if ((isset($tab_cloture_users[$current_login])) && ($tab_cloture_users[$current_login] = true)) {
                     $commentaire = $tab_commentaire_saisie[$current_login];
                     $return .= \responsable\Fonctions::cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $commentaire);
                 }
             }
             // traitement des users dont on est grand responsable :
-            if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) ) {
-                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user) {
+            if (($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges'])) {
+                foreach ($tab_all_users_du_grand_resp as $current_login => $tab_current_user) {
                     // tab_cloture_users[$current_login]=TRUE si checkbox "cloturer" est cochée
-                    if( (isset($tab_cloture_users[$current_login])) && ($tab_cloture_users[$current_login]=TRUE) ) {
+                    if ((isset($tab_cloture_users[$current_login])) && ($tab_cloture_users[$current_login] = true)) {
                         $commentaire = $tab_commentaire_saisie[$current_login];
                         $return .= \responsable\Fonctions::cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $commentaire);
                     }
@@ -709,34 +707,33 @@ class Fonctions
     public static function affichage_cloture_globale_groupe($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /***********************************************************************/
         /* SAISIE GROUPE pour tous les utilisateurs d'un groupe du responsable */
 
         // on établi la liste complète des groupes dont on est le resp (ou le grd resp)
-        $list_group_resp=get_list_groupes_du_resp($_SESSION['userlogin']);
-        if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) ) {
-            $list_group_grd_resp=get_list_groupes_du_grand_resp($_SESSION['userlogin']);
+        $list_group_resp = get_list_groupes_du_resp($_SESSION['userlogin']);
+        if (($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges'])) {
+            $list_group_grd_resp = get_list_groupes_du_grand_resp($_SESSION['userlogin']);
         } else {
-            $list_group_grd_resp="";
+            $list_group_grd_resp = "";
         }
 
-        $list_group="";
-        if($list_group_resp!="") {
+        $list_group = "";
+        if ($list_group_resp != "") {
             $list_group = $list_group_resp;
-            if($list_group_grd_resp!="") {
-                $list_group = $list_group.",".$list_group_grd_resp;
+            if ($list_group_grd_resp != "") {
+                $list_group = $list_group . "," . $list_group_grd_resp;
             }
         } else {
-            if($list_group_grd_resp!="") {
+            if ($list_group_grd_resp != "") {
                 $list_group = $list_group_grd_resp;
             }
         }
 
-
-        if($list_group!="") //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
+        if ($list_group != "") //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
         {
             $return .= '<form action="' . $PHP_SELF . '" method="POST">';
             $return .= '<table>';
@@ -748,18 +745,18 @@ class Fonctions
             $return .= '<tr>';
 
             // création du select pour le choix du groupe
-            $text_choix_group="<select name=\"choix_groupe\" >";
-            $sql_group = "SELECT g_gid, g_groupename FROM conges_groupe WHERE g_gid IN ($list_group) ORDER BY g_groupename "  ;
-            $ReqLog_group = \includes\SQL::query($sql_group) ;
+            $text_choix_group = "<select name=\"choix_groupe\" >";
+            $sql_group        = "SELECT g_gid, g_groupename FROM conges_groupe WHERE g_gid IN ($list_group) ORDER BY g_groupename ";
+            $ReqLog_group     = \includes\SQL::query($sql_group);
 
             while ($resultat_group = $ReqLog_group->fetch_array()) {
-                $current_group_id=$resultat_group["g_gid"];
-                $current_group_name=$resultat_group["g_groupename"];
-                $text_choix_group=$text_choix_group."<option value=\"$current_group_id\" >$current_group_name</option>";
+                $current_group_id   = $resultat_group["g_gid"];
+                $current_group_name = $resultat_group["g_groupename"];
+                $text_choix_group   = $text_choix_group . "<option value=\"$current_group_id\" >$current_group_name</option>";
             }
-            $text_choix_group=$text_choix_group."</select>" ;
+            $text_choix_group = $text_choix_group . "</select>";
 
-            $return .= '<td class="big">' . _('resp_ajout_conges_choix_groupe') .' : ' . $text_choix_group . '</td>';
+            $return .= '<td class="big">' . _('resp_ajout_conges_choix_groupe') . ' : ' . $text_choix_group . '</td>';
 
             $return .= '</tr>';
             $return .= '<tr>';
@@ -785,8 +782,8 @@ class Fonctions
     public static function affichage_cloture_globale_pour_tous($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /************************************************************/
         /* CLOTURE EXERCICE GLOBALE pour tous les utilisateurs du responsable */
@@ -818,25 +815,25 @@ class Fonctions
     {
         $return .= '<tr align="center">';
         //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-        $tab_conges=$tab_current_user['conges'];
+        $tab_conges = $tab_current_user['conges'];
 
         /** sur la ligne ,   **/
         $return .= '<td>' . $tab_current_user['nom'] . '</td>';
         $return .= '<td>' . $tab_current_user['prenom'] . '</td>';
         $return .= '<td>' . $tab_current_user['quotite'] . '%</td>';
 
-        foreach($tab_type_conges as $id_conges => $libelle) {
+        foreach ($tab_type_conges as $id_conges => $libelle) {
             $return .= '<td>' . $tab_conges[$libelle]['nb_an'] . ' <i>(' . $tab_conges[$libelle]['solde'] . ')</i></td>';
         }
 
         // si le num d'exercice du user est < à celui de l'appli (il n'a pas encore été basculé): on peut le cocher
-        if($tab_current_user['num_exercice'] < $_SESSION['config']['num_exercice']) {
+        if ($tab_current_user['num_exercice'] < $_SESSION['config']['num_exercice']) {
             $return .= '<td align="center" class="histo"><input type="checkbox" name="tab_cloture_users[' . $current_login . ']" value="TRUE" checked></td>';
         } else {
             $return .= '<td align="center" class="histo"><img src="' . IMG_PATH . 'stop.png" width="16" height="16" border="0" ></td>';
         }
 
-        $comment_cloture =  _('resp_cloture_exercice_commentaire') ." ".date("m/Y");
+        $comment_cloture = _('resp_cloture_exercice_commentaire') . " " . date("m/Y");
         $return .= '<td align="center" class="histo"><input type="text" name="tab_commentaire_saisie[' . $current_login . ']" size="20" maxlength="200" value="' . $comment_cloture . '"></td>';
         $return .= '</tr>';
         return $return;
@@ -845,13 +842,13 @@ class Fonctions
     public static function affichage_cloture_user_par_user($tab_type_conges, $tab_all_users_du_resp, $tab_all_users_du_grand_resp)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         /************************************************************/
         /* CLOTURE EXERCICE USER PAR USER pour tous les utilisateurs du responsable */
 
-        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
+        if ((count($tab_all_users_du_resp) != 0) || (count($tab_all_users_du_grand_resp) != 0)) {
             $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=cloture_exercice" method="POST">';
             $return .= '<table>';
             $return .= '<tr>';
@@ -869,7 +866,7 @@ class Fonctions
             $return .= '<th>' . _('divers_nom_maj_1') . '</th>';
             $return .= '<th>' . _('divers_prenom_maj_1') . '</th>';
             $return .= '<th>' . _('divers_quotite_maj_1') . '</th>';
-            foreach($tab_type_conges as $id_conges => $libelle) {
+            foreach ($tab_type_conges as $id_conges => $libelle) {
                 $return .= '<th>' . $libelle . '<br><i>(' . _('divers_solde') . ')</i></th>';
             }
             $return .= '<th>' . _('divers_cloturer_maj_1') . '<br></th>';
@@ -881,16 +878,16 @@ class Fonctions
             // AFFICHAGE LIGNES TABLEAU
 
             // affichage des users dont on est responsable :
-            foreach($tab_all_users_du_resp as $current_login => $tab_current_user) {
+            foreach ($tab_all_users_du_resp as $current_login => $tab_current_user) {
                 $return .= \responsable\Fonctions::affiche_ligne_du_user($current_login, $tab_type_conges, $tab_current_user);
             }
 
             // affichage des users dont on est grand responsable :
-            if( ($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges']) ) {
-                $nb_colspan=50;
+            if (($_SESSION['config']['double_validation_conges']) && ($_SESSION['config']['grand_resp_ajout_conges'])) {
+                $nb_colspan = 50;
                 $return .= '<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="' . $nb_colspan . '"><i>' . _('resp_etat_users_titre_double_valid') . '</i></td></tr>';
 
-                foreach($tab_all_users_du_grand_resp as $current_login => $tab_current_user) {
+                foreach ($tab_all_users_du_grand_resp as $current_login => $tab_current_user) {
                     $return .= \responsable\Fonctions::affiche_ligne_du_user($current_login, $tab_type_conges, $tab_current_user);
                 }
             }
@@ -910,25 +907,25 @@ class Fonctions
             $return .= '</td></tr>';
             $return .= '</table>';
             $return .= '<input type="hidden" name="cloture_users" value="TRUE">';
-            $return .= '<input type="hidden" name="session" value="' . $session  . '">';
+            $return .= '<input type="hidden" name="session" value="' . $session . '">';
             $return .= '</form>';
         }
         return $return;
     }
 
-    public static function saisie_cloture( $tab_type_conges)
+    public static function saisie_cloture($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
         // (prend en compte le resp direct, les groupes, le resp virtuel, etc ...)
         // renvoit une liste de login entre quotes et séparés par des virgules
-        $tab_all_users_du_resp=recup_infos_all_users_du_resp($_SESSION['userlogin']);
-        $tab_all_users_du_grand_resp=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
+        $tab_all_users_du_resp       = recup_infos_all_users_du_resp($_SESSION['userlogin']);
+        $tab_all_users_du_grand_resp = recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
 
-        if( (count($tab_all_users_du_resp)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
+        if ((count($tab_all_users_du_resp) != 0) || (count($tab_all_users_du_grand_resp) != 0)) {
             /************************************************************/
             /* SAISIE GLOBALE pour tous les utilisateurs du responsable */
             $return .= affichage_cloture_globale_pour_tous($tab_type_conges);
@@ -936,7 +933,7 @@ class Fonctions
 
             /***********************************************************************/
             /* SAISIE GROUPE pour tous les utilisateurs d'un groupe du responsable */
-            if( $_SESSION['config']['gestion_groupes'] ) {
+            if ($_SESSION['config']['gestion_groupes']) {
                 $return .= \responsable\Fonctions::affichage_cloture_globale_groupe($tab_type_conges);
             }
             $return .= '<br>';
@@ -961,17 +958,16 @@ class Fonctions
      */
     public static function clotureExerciceModule()
     {
-        $choix_groupe            = getpost_variable('choix_groupe');
-        $cloture_users           = getpost_variable('cloture_users');
-        $cloture_globale         = getpost_variable('cloture_globale');
-        $cloture_groupe          = getpost_variable('cloture_groupe');
-        $tab_cloture_users       = getpost_variable('tab_cloture_users');
-        $tab_commentaire_saisie       = getpost_variable('tab_commentaire_saisie');
-        $return = '';
+        $choix_groupe           = getpost_variable('choix_groupe');
+        $cloture_users          = getpost_variable('cloture_users');
+        $cloture_globale        = getpost_variable('cloture_globale');
+        $cloture_groupe         = getpost_variable('cloture_groupe');
+        $tab_cloture_users      = getpost_variable('tab_cloture_users');
+        $tab_commentaire_saisie = getpost_variable('tab_commentaire_saisie');
+        $return                 = '';
         /*************************************/
 
-        header_popup( $_SESSION['config']['titre_resp_index'] );
-
+        header_popup($_SESSION['config']['titre_resp_index']);
 
         /*************************************/
         /***  suite de la page             ***/
@@ -980,16 +976,16 @@ class Fonctions
         /** initialisation des tableaux des types de conges/absences  **/
         // recup du tableau des types de conges (conges et congesexceptionnels)
         // on concatene les 2 tableaux
-        $tab_type_cong = ( recup_tableau_types_conges() + recup_tableau_types_conges_exceptionnels()  );
+        $tab_type_cong = (recup_tableau_types_conges() + recup_tableau_types_conges_exceptionnels());
 
         // titre
         $return .= '<H2>' . _('resp_cloture_exercice_titre') . '</H2>';
 
-        if($cloture_users=="TRUE") {
+        if ($cloture_users == "TRUE") {
             $return .= \responsable\Fonctions::cloture_users($tab_type_cong, $tab_cloture_users, $tab_commentaire_saisie);
-        } elseif($cloture_globale=="TRUE") {
+        } elseif ($cloture_globale == "TRUE") {
             $return .= \responsable\Fonctions::cloture_globale($tab_type_cong);
-        } elseif($cloture_groupe=="TRUE") {
+        } elseif ($cloture_groupe == "TRUE") {
             $return .= \responsable\Fonctions::cloture_globale_groupe($choix_groupe, $tab_type_cong);
         } else {
             $return .= \responsable\Fonctions::saisie_cloture($tab_type_cong);
@@ -1020,27 +1016,27 @@ class Fonctions
         $nb_colonnes = 0;
 
         $return .= '<tr>';
-        $return .= '<th>' . _('divers_nom_maj') .'</th>';
-        $return .= '<th>'. _('divers_prenom_maj') .'</th>';
-        $return .= '<th>'. _('divers_quotite_maj_1') .'</th>';
+        $return .= '<th>' . _('divers_nom_maj') . '</th>';
+        $return .= '<th>' . _('divers_prenom_maj') . '</th>';
+        $return .= '<th>' . _('divers_quotite_maj_1') . '</th>';
         $nb_colonnes = 3;
-        foreach($tab_type_cong as $id_conges => $libelle) {
+        foreach ($tab_type_cong as $id_conges => $libelle) {
             // cas d'une absence ou d'un congé
             $return .= '<th>' . $libelle . ' / ' . _('divers_an_maj') . '</th>';
-            $return .= '<th>'. _('divers_solde_maj') . ' ' . $libelle . '</th>';
+            $return .= '<th>' . _('divers_solde_maj') . ' ' . $libelle . '</th>';
             $nb_colonnes += 2;
         }
         // conges exceptionnels
         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-            foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
-                $return .= '<th>'. _('divers_solde_maj') . ' ' . $libelle . '</th>';
+            foreach ($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
+                $return .= '<th>' . _('divers_solde_maj') . ' ' . $libelle . '</th>';
                 $nb_colonnes += 1;
             }
         }
-        $return .= '<th>'. _('solde_heure') .'</th>' ;
+        $return .= '<th>' . _('solde_heure') . '</th>';
         $return .= '<th></th>';
         $nb_colonnes += 1;
-        if($_SESSION['config']['editions_papier']) {
+        if ($_SESSION['config']['editions_papier']) {
             $return .= '<th></th>';
             $nb_colonnes += 1;
         }
@@ -1055,33 +1051,34 @@ class Fonctions
         // AFFICHAGE DE USERS DIRECTS DU RESP
 
         // Récup dans un tableau de tableau des informations de tous les users dont $_SESSION['userlogin'] est responsable
-        $tab_all_users=recup_infos_all_users_du_resp($_SESSION['userlogin']);
-        if(count($tab_all_users)==0) {// si le tableau est vide (resp sans user !!) on affiche une alerte !
-            $return .= '<tr align="center"><td class="histo" colspan="' .  $nb_colonnes . '">' . _('resp_etat_aucun_user') . '</td></tr>';
+        $tab_all_users = recup_infos_all_users_du_resp($_SESSION['userlogin']);
+        if (count($tab_all_users) == 0) {
+// si le tableau est vide (resp sans user !!) on affiche une alerte !
+            $return .= '<tr align="center"><td class="histo" colspan="' . $nb_colonnes . '">' . _('resp_etat_aucun_user') . '</td></tr>';
         } else {
             $i = true;
-            foreach($tab_all_users as $current_login => $tab_current_user) {
-                if($tab_current_user['is_active'] == "Y" || $_SESSION['config']['print_disable_users'] == 'TRUE') {
+            foreach ($tab_all_users as $current_login => $tab_current_user) {
+                if ($tab_current_user['is_active'] == "Y" || $_SESSION['config']['print_disable_users'] == 'TRUE') {
                     //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-                    $tab_conges=$tab_current_user['conges'];
-                    $text_affich_user="<a class=\"action show\" href=\"resp_index.php?session=$session&onglet=traite_user&user_login=$current_login\" title=\""._('resp_etat_users_afficher')."\"><i class=\"fa fa-eye\"></i></a>" ;
-                    $text_edit_papier="<a class=\"action edit\" href=\"../edition/edit_user.php?session=$session&user_login=$current_login\" target=\"_blank\" title=\""._('resp_etat_users_imprim')."\"><i class=\"fa fa-file-text\"></i></a>";
+                    $tab_conges       = $tab_current_user['conges'];
+                    $text_affich_user = "<a class=\"action show\" href=\"resp_index.php?session=$session&onglet=traite_user&user_login=$current_login\" title=\"" . _('resp_etat_users_afficher') . "\"><i class=\"fa fa-eye\"></i></a>";
+                    $text_edit_papier = "<a class=\"action edit\" href=\"../edition/edit_user.php?session=$session&user_login=$current_login\" target=\"_blank\" title=\"" . _('resp_etat_users_imprim') . "\"><i class=\"fa fa-file-text\"></i></a>";
 
                     $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
                     $return .= '<td>' . $tab_current_user['nom'] . '</td><td>' . $tab_current_user['prenom'] . '</td><td>' . $tab_current_user['quotite'] . '%</td>';
-                    foreach($tab_type_cong as $id_conges => $libelle) {
+                    foreach ($tab_type_cong as $id_conges => $libelle) {
                         $return .= '<td>' . $tab_conges[$libelle]['nb_an'] . '</td>';
                         $return .= '<td>' . $tab_conges[$libelle]['solde'] . '</td>';
                     }
                     if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-                        foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
+                        foreach ($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
                             $return .= '<td>' . $tab_conges[$libelle]['solde'] . '</td>';
                         }
                     }
                     $soldeHeure = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($current_login)['u_heure_solde'];
                     $return .= '<td>' . \App\Helpers\Formatter::timestamp2Duree($soldeHeure) . '</td>';
                     $return .= '<td>' . $text_affich_user . '</td>';
-                    if($_SESSION['config']['editions_papier']) {
+                    if ($_SESSION['config']['editions_papier']) {
                         $return .= '<td>' . $text_edit_papier . '</td>';
                     }
                     $return .= '</tr>';
@@ -1093,44 +1090,44 @@ class Fonctions
         /***********************************/
         // AFFICHAGE DE USERS DONT LE RESP EST GRAND RESP
 
-        if($_SESSION['config']['double_validation_conges']) {
+        if ($_SESSION['config']['double_validation_conges']) {
             // Récup dans un tableau de tableau des informations de tous les users dont $_SESSION['userlogin'] est GRAND responsable
-            $tab_all_users_2=recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
+            $tab_all_users_2 = recup_infos_all_users_du_grand_resp($_SESSION['userlogin']);
 
-            $compteur=0;  // compteur de ligne a afficher en dessous (dés que passe à 1 : on affiche une ligne de titre)
+            $compteur = 0; // compteur de ligne a afficher en dessous (dés que passe à 1 : on affiche une ligne de titre)
 
             $i = true;
-            foreach($tab_all_users_2 as $current_login_2 => $tab_current_user_2) {
-                if( !array_key_exists($current_login_2, $tab_all_users) ) // si le user n'est pas déjà dans le tableau précédent (deja affiché)
+            foreach ($tab_all_users_2 as $current_login_2 => $tab_current_user_2) {
+                if (!array_key_exists($current_login_2, $tab_all_users)) // si le user n'est pas déjà dans le tableau précédent (deja affiché)
                 {
                     $compteur++;
-                    if($compteur==1)  // alors on affiche une ligne de titre
+                    if ($compteur == 1) // alors on affiche une ligne de titre
                     {
-                        $nb_colspan=9;
+                        $nb_colspan = 9;
                         if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-                            $nb_colspan=10;
+                            $nb_colspan = 10;
                         }
 
                         $return .= '<tr align="center"><td class="histo" style="background-color: #CCC;" colspan="' . $nb_colonnes . '"><i>' . _('resp_etat_users_titre_double_valid') . '</i></td></tr>';
                     }
 
                     //tableau de tableaux les nb et soldes de conges d'un user (indicé par id de conges)
-                    $tab_conges_2=$tab_current_user_2['conges'];
+                    $tab_conges_2 = $tab_current_user_2['conges'];
 
-                    $text_affich_user="<a class=\"action show\" href=\"resp_index.php?session=$session&onglet=traite_user&user_login=$current_login_2\" title=\"". _('resp_etat_users_afficher') ."\"><i class=\"fa fa-eye\"></i></a>" ;
-                    $text_edit_papier="<a class=\"action print\" href=\"../edition/edit_user.php?session=$session&user_login=$current_login_2\" target=\"_blank\" title=\""._('resp_etat_users_imprim')."\"><i class=\"fa fa-file-text\"></i></a>";
-                    $return .= '<tr class="'.($i?'i':'p').'">';
+                    $text_affich_user = "<a class=\"action show\" href=\"resp_index.php?session=$session&onglet=traite_user&user_login=$current_login_2\" title=\"" . _('resp_etat_users_afficher') . "\"><i class=\"fa fa-eye\"></i></a>";
+                    $text_edit_papier = "<a class=\"action print\" href=\"../edition/edit_user.php?session=$session&user_login=$current_login_2\" target=\"_blank\" title=\"" . _('resp_etat_users_imprim') . "\"><i class=\"fa fa-file-text\"></i></a>";
+                    $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
                     $return .= '<td>' . $tab_current_user_2['nom'] . '</td><td>' . $tab_current_user_2['prenom'] . '</td><td>' . $tab_current_user_2['quotite'] . '%</td>';
-                    foreach($tab_type_cong as $id_conges => $libelle) {
+                    foreach ($tab_type_cong as $id_conges => $libelle) {
                         $return .= '<td>' . $tab_conges_2[$libelle]['nb_an'] . '</td><td>' . $tab_conges_2[$libelle]['solde'] . '</td>';
                     }
                     if ($_SESSION['config']['gestion_conges_exceptionnels']) {
-                        foreach($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
+                        foreach ($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
                             $return .= '<td>' . $tab_conges_2[$libelle]['solde'] . '</td>';
                         }
                     }
                     $return .= '<td>' . $text_affich_user . '</td>';
-                    if($_SESSION['config']['editions_papier']) {
+                    if ($_SESSION['config']['editions_papier']) {
                         $return .= '<td>' . $text_edit_papier . '</td>';
                     }
                     $return .= '</tr>';
@@ -1147,18 +1144,18 @@ class Fonctions
     public static function new_conges($user_login, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         //conversion des dates
         $new_debut = convert_date($new_debut);
-        $new_fin = convert_date($new_fin);
+        $new_fin   = convert_date($new_fin);
 
         // verif validité des valeurs saisies
-        $valid=verif_saisie_new_demande($new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment);
+        $valid = verif_saisie_new_demande($new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment);
 
         if ($valid) {
-            $return .= $user_login . '---' . $new_debut . '_' . $new_demi_jour_deb . '---' . $new_fin . '_' .  $new_demi_jour_fin . '---' . $new_nb_jours . '---' . $new_comment . '---' . $new_type_id . '<br>';
+            $return .= $user_login . '---' . $new_debut . '_' . $new_demi_jour_deb . '---' . $new_fin . '_' . $new_demi_jour_fin . '---' . $new_nb_jours . '---' . $new_comment . '---' . $new_type_id . '<br>';
 
             // recup dans un tableau de tableau les infos des types de conges et absences
             $tab_tout_type_abs = recup_tableau_tout_types_abs();
@@ -1166,21 +1163,21 @@ class Fonctions
             /**********************************/
             /* insert dans conges_periode     */
             /**********************************/
-            $new_etat="ok";
-            $result=insert_dans_periode($user_login, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id, $new_etat, 0);
+            $new_etat = "ok";
+            $result   = insert_dans_periode($user_login, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id, $new_etat, 0);
 
             /************************************************/
             /* UPDATE table "conges_solde_user" (jours restants) */
             // on retranche les jours seulement pour des conges pris (pas pour les absences)
             // donc seulement si le type de l'absence qu'on annule est un "conges"
-            if(isset($tab_tout_type_abs[$new_type_id]['type']) && $tab_tout_type_abs[$new_type_id]['type']=="conges") {
-                $user_nb_jours_pris_float=(float) $new_nb_jours ;
+            if (isset($tab_tout_type_abs[$new_type_id]['type']) && $tab_tout_type_abs[$new_type_id]['type'] == "conges") {
+                $user_nb_jours_pris_float = (float) $new_nb_jours;
                 soustrait_solde_et_reliquat_user($user_login, "", $user_nb_jours_pris_float, $new_type_id, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin);
             }
             $comment_log = "saisie conges par le responsable pour $user_login ($new_nb_jours jour(s)) type_conges = $new_type_id ( de $new_debut $new_demi_jour_deb a $new_fin $new_demi_jour_fin) ($new_comment)";
             log_action(0, "", $user_login, $comment_log);
 
-            if($result) {
+            if ($result) {
                 $return .= _('form_modif_ok') . '<br><br>';
             } else {
                 $return .= _('form_modif_not_ok') . '<br><br>';
@@ -1198,79 +1195,77 @@ class Fonctions
 
     public static function traite_demandes($user_login, $tab_radio_traite_demande, $tab_text_refus)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id();
-        $return = '';
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session  = session_id();
+        $return   = '';
 
         // recup dans un tableau de tableau les infos des types de conges et absences
         $tab_tout_type_abs = recup_tableau_tout_types_abs();
 
-        while($elem_tableau = each($tab_radio_traite_demande)) {
-            $champs = explode("--", $elem_tableau['value']);
-            $user_login=$champs[0];
-            $user_nb_jours_pris=$champs[1];
-            $user_nb_jours_pris_float=(float) $user_nb_jours_pris ;
-            $value_type_abs_id=$champs[2];
-            $date_deb=$champs[3];
-            $demi_jour_deb=$champs[4];
-            $date_fin=$champs[5];
-            $demi_jour_fin=$champs[6];
-            $reponse=$champs[7];
-            $numero=$elem_tableau['key'];
-            $numero_int=(int) $numero;
+        while ($elem_tableau = each($tab_radio_traite_demande)) {
+            $champs                   = explode("--", $elem_tableau['value']);
+            $user_login               = $champs[0];
+            $user_nb_jours_pris       = $champs[1];
+            $user_nb_jours_pris_float = (float) $user_nb_jours_pris;
+            $value_type_abs_id        = $champs[2];
+            $date_deb                 = $champs[3];
+            $demi_jour_deb            = $champs[4];
+            $date_fin                 = $champs[5];
+            $demi_jour_fin            = $champs[6];
+            $reponse                  = $champs[7];
+            $numero                   = $elem_tableau['key'];
+            $numero_int               = (int) $numero;
 
-            if($reponse == "ACCEPTE") // acceptation definitive d'un conges
+            if ($reponse == "ACCEPTE") // acceptation definitive d'un conges
             {
                 /* UPDATE table "conges_periode" */
-                $sql1 = 'UPDATE conges_periode SET p_etat="ok", p_date_traitement=NOW() WHERE p_num="'.\includes\SQL::quote($numero_int).'" AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
+                $sql1    = 'UPDATE conges_periode SET p_etat="ok", p_date_traitement=NOW() WHERE p_num="' . \includes\SQL::quote($numero_int) . '" AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
                 $ReqLog1 = \includes\SQL::query($sql1);
 
                 if ($ReqLog1 && \includes\SQL::getVar('affected_rows')) {
                     // Log de l'action
-                    log_action($numero_int,"ok", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $date_deb");
+                    log_action($numero_int, "ok", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $date_deb");
 
                     /* UPDATE table "conges_solde_user" (jours restants) */
                     // on retranche les jours seulement pour des conges pris (pas pour les absences)
                     // donc seulement si le type de l'absence qu'on accepte est un "conges"
-                    if(($tab_tout_type_abs[$value_type_abs_id]['type']=="conges")||($tab_tout_type_abs[$value_type_abs_id]['type']=="conges_exceptionnels")) {
+                    if (($tab_tout_type_abs[$value_type_abs_id]['type'] == "conges") || ($tab_tout_type_abs[$value_type_abs_id]['type'] == "conges_exceptionnels")) {
                         soustrait_solde_et_reliquat_user($user_login, $numero_int, $user_nb_jours_pris_float, $value_type_abs_id, $date_deb, $demi_jour_deb, $date_fin, $demi_jour_fin);
                     }
 
                     //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                    if($_SESSION['config']['mail_valid_conges_alerte_user']) {
+                    if ($_SESSION['config']['mail_valid_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "accept_conges");
                     }
                 }
-            }
-            elseif($reponse == "VALID") // première validation dans le cas d'une double validation
+            } elseif ($reponse == "VALID") // première validation dans le cas d'une double validation
             {
                 /* UPDATE table "conges_periode" */
-                $sql1 = 'UPDATE conges_periode SET p_etat="valid", p_date_traitement=NOW() WHERE p_num="'.\includes\SQL::quote($numero_int).'" AND p_etat=\'demande\';';
+                $sql1    = 'UPDATE conges_periode SET p_etat="valid", p_date_traitement=NOW() WHERE p_num="' . \includes\SQL::quote($numero_int) . '" AND p_etat=\'demande\';';
                 $ReqLog1 = \includes\SQL::query($sql1);
 
                 if ($ReqLog1 && \includes\SQL::getVar('affected_rows')) {
                     // Log de l'action
-                    log_action($numero_int,"valid", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $date_deb");
+                    log_action($numero_int, "valid", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $date_deb");
 
                     //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                    if($_SESSION['config']['mail_valid_conges_alerte_user']) {
+                    if ($_SESSION['config']['mail_valid_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "valid_conges");
                     }
                 }
-            }
-            elseif($reponse == "REFUSE") // refus d'un conges
+            } elseif ($reponse == "REFUSE") // refus d'un conges
             {
                 // recup di motif de refus
                 $motif_refus = addslashes($tab_text_refus[$numero_int]);
-                $sql3 = 'UPDATE conges_periode SET p_etat="refus", p_motif_refus=\''.$motif_refus.'\', p_date_traitement=NOW() WHERE p_num="'. \includes\SQL::quote($numero_int).'" AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
-                $ReqLog3 = \includes\SQL::query($sql3);
+                $sql3        = 'UPDATE conges_periode SET p_etat="refus", p_motif_refus=\'' . $motif_refus . '\', p_date_traitement=NOW() WHERE p_num="' . \includes\SQL::quote($numero_int) . '" AND ( p_etat=\'valid\' OR p_etat=\'demande\' );';
+                $ReqLog3     = \includes\SQL::query($sql3);
 
                 if ($ReqLog3 && \includes\SQL::getVar('affected_rows')) {
                     // Log de l'action
-                    log_action($numero_int,"refus", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $date_deb");
+                    log_action($numero_int, "refus", $user_login, "traite demande $numero ($user_login) ($user_nb_jours_pris jours) : $date_deb");
 
                     //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                    if($_SESSION['config']['mail_refus_conges_alerte_user']) {
+                    if ($_SESSION['config']['mail_refus_conges_alerte_user']) {
                         alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "refus_conges");
                     }
                 }
@@ -1284,42 +1279,42 @@ class Fonctions
 
     public static function annule_conges($user_login, $tab_checkbox_annule, $tab_text_annul)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id() ;
-        $return = '';
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session  = session_id();
+        $return   = '';
 
         // recup dans un tableau de tableau les infos des types de conges et absences
         $tab_tout_type_abs = recup_tableau_tout_types_abs();
 
-        while($elem_tableau = each($tab_checkbox_annule)) {
-            $champs = explode("--", $elem_tableau['value']);
-            $user_login=$champs[0];
-            $user_nb_jours_pris_float=$champs[1];
-            $VerifDec=verif_saisie_decimal($user_nb_jours_pris_float);
-            $numero=$elem_tableau['key'];
-            $numero_int=(int) $numero;
-            $user_type_abs_id=$champs[2];
+        while ($elem_tableau = each($tab_checkbox_annule)) {
+            $champs                   = explode("--", $elem_tableau['value']);
+            $user_login               = $champs[0];
+            $user_nb_jours_pris_float = $champs[1];
+            $VerifDec                 = verif_saisie_decimal($user_nb_jours_pris_float);
+            $numero                   = $elem_tableau['key'];
+            $numero_int               = (int) $numero;
+            $user_type_abs_id         = $champs[2];
 
-            $motif_annul=addslashes($tab_text_annul[$numero_int]);
+            $motif_annul = addslashes($tab_text_annul[$numero_int]);
 
             /* UPDATE table "conges_periode" */
-            $sql1 = 'UPDATE conges_periode SET p_etat="annul", p_motif_refus="'. \includes\SQL::quote($motif_annul).'", p_date_traitement=NOW() WHERE p_num="'. \includes\SQL::quote($numero_int).'" AND p_etat=\'ok\';';
+            $sql1    = 'UPDATE conges_periode SET p_etat="annul", p_motif_refus="' . \includes\SQL::quote($motif_annul) . '", p_date_traitement=NOW() WHERE p_num="' . \includes\SQL::quote($numero_int) . '" AND p_etat=\'ok\';';
             $ReqLog1 = \includes\SQL::query($sql1);
 
             if ($ReqLog1 && \includes\SQL::getVar('affected_rows')) {
                 // Log de l'action
-                log_action($numero_int,"annul", $user_login, "annulation conges $numero ($user_login) ($user_nb_jours_pris_float jours)");
+                log_action($numero_int, "annul", $user_login, "annulation conges $numero ($user_login) ($user_nb_jours_pris_float jours)");
 
                 /* UPDATE table "conges_solde_user" (jours restants) */
                 // on re-crédite les jours seulement pour des conges pris (pas pour les absences)
                 // donc seulement si le type de l'absence qu'on annule est un "conges"
-                if(in_array($tab_tout_type_abs[$user_type_abs_id]['type'],["conges","conges_exceptionnels"])) {
-                    $sql2 = 'UPDATE conges_solde_user SET su_solde = su_solde+"'. \includes\SQL::quote($user_nb_jours_pris_float).'" WHERE su_login="'. \includes\SQL::quote($user_login).'" AND su_abs_id="'. \includes\SQL::quote($user_type_abs_id).'";';
+                if (in_array($tab_tout_type_abs[$user_type_abs_id]['type'], ["conges", "conges_exceptionnels"])) {
+                    $sql2    = 'UPDATE conges_solde_user SET su_solde = su_solde+"' . \includes\SQL::quote($user_nb_jours_pris_float) . '" WHERE su_login="' . \includes\SQL::quote($user_login) . '" AND su_abs_id="' . \includes\SQL::quote($user_type_abs_id) . '";';
                     $ReqLog2 = \includes\SQL::query($sql2);
                 }
 
                 //envoi d'un mail d'alerte au user (si demandé dans config de php_conges)
-                if($_SESSION['config']['mail_annul_conges_alerte_user']) {
+                if ($_SESSION['config']['mail_annul_conges_alerte_user']) {
                     alerte_mail($_SESSION['userlogin'], $user_login, $numero_int, "annul_conges");
                 }
             }
@@ -1333,13 +1328,13 @@ class Fonctions
     //affiche l'état des conges du user (avec le formulaire pour le responsable)
     public static function affiche_etat_conges_user_for_resp($user_login, $year_affichage, $tri_date, $onglet)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id() ;
-        $return = '';
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session  = session_id();
+        $return   = '';
 
         // affichage de l'année et des boutons de défilement
-        $year_affichage_prec = $year_affichage-1 ;
-        $year_affichage_suiv = $year_affichage+1 ;
+        $year_affichage_prec = $year_affichage - 1;
+        $year_affichage_suiv = $year_affichage + 1;
         $return .= '<div class="calendar-nav">';
         $return .= '<ul>';
         $return .= '<li><a class="action previous" href="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user&user_login=' . $user_login . '&year_affichage=' . $year_affichage_prec . '"><i class="fa fa-chevron-left"></i></a></li>';
@@ -1356,20 +1351,20 @@ class Fonctions
             "AND p_etat !='demande' " .
             "AND p_etat !='valid' " .
             "AND (p_date_deb LIKE '$year_affichage%' OR p_date_fin LIKE '$year_affichage%') ";
-        if($tri_date=="descendant") {
-            $sql3=$sql3." ORDER BY p_date_deb DESC ";
+        if ($tri_date == "descendant") {
+            $sql3 = $sql3 . " ORDER BY p_date_deb DESC ";
         } else {
-            $sql3=$sql3." ORDER BY p_date_deb ASC ";
+            $sql3 = $sql3 . " ORDER BY p_date_deb ASC ";
         }
 
         $ReqLog3 = \includes\SQL::query($sql3);
 
-        $count3=$ReqLog3->num_rows;
-        if($count3==0) {
+        $count3 = $ReqLog3->num_rows;
+        if ($count3 == 0) {
             $return .= '<b>' . _('resp_traite_user_aucun_conges') . '</b><br><br>';
         } else {
             // recup dans un tableau de tableau les infos des types de conges et absences
-            $tab_types_abs = recup_tableau_tout_types_abs() ;
+            $tab_types_abs = recup_tableau_tout_types_abs();
 
             // AFFICHAGE TABLEAU
             $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user" method="POST">';
@@ -1389,58 +1384,60 @@ class Fonctions
             $return .= '<th>' . _('divers_etat_maj_1') . '</th>';
             $return .= '<th>' . _('resp_traite_user_annul') . '</th>';
             $return .= '<th>' . _('resp_traite_user_motif_annul') . '</th>';
-            if($_SESSION['config']['affiche_date_traitement']) {
+            if ($_SESSION['config']['affiche_date_traitement']) {
                 $return .= '<th>' . _('divers_date_traitement') . '</th>';
             }
             $return .= '</tr>';
             $return .= '</thead>';
             $return .= '<tbody>';
-            $tab_checkbox=array();
-            $i = true;
+            $tab_checkbox = array();
+            $i            = true;
             while ($resultat3 = $ReqLog3->fetch_array()) {
-                $sql_login=$resultat3["p_login"] ;
-                $sql_date_deb=eng_date_to_fr($resultat3["p_date_deb"]) ;
-                $sql_demi_jour_deb=$resultat3["p_demi_jour_deb"] ;
-                if($sql_demi_jour_deb=="am") {
-                    $demi_j_deb =  _('divers_am_short') ;
+                $sql_login         = $resultat3["p_login"];
+                $sql_date_deb      = eng_date_to_fr($resultat3["p_date_deb"]);
+                $sql_demi_jour_deb = $resultat3["p_demi_jour_deb"];
+                if ($sql_demi_jour_deb == "am") {
+                    $demi_j_deb = _('divers_am_short');
                 } else {
-                    $demi_j_deb =  _('divers_pm_short') ;
+                    $demi_j_deb = _('divers_pm_short');
                 }
-                $sql_date_fin=eng_date_to_fr($resultat3["p_date_fin"]) ;
-                $sql_demi_jour_fin=$resultat3["p_demi_jour_fin"] ;
-                if($sql_demi_jour_fin=="am") {
-                    $demi_j_fin =  _('divers_am_short') ;
+                $sql_date_fin      = eng_date_to_fr($resultat3["p_date_fin"]);
+                $sql_demi_jour_fin = $resultat3["p_demi_jour_fin"];
+                if ($sql_demi_jour_fin == "am") {
+                    $demi_j_fin = _('divers_am_short');
                 } else {
-                    $demi_j_fin =  _('divers_pm_short') ;
+                    $demi_j_fin = _('divers_pm_short');
                 }
-                $sql_nb_jours=affiche_decimal($resultat3["p_nb_jours"]) ;
-                $sql_commentaire=$resultat3["p_commentaire"] ;
-                $sql_type=$resultat3["p_type"] ;
-                $sql_etat=$resultat3["p_etat"] ;
-                $sql_motif_refus=$resultat3["p_motif_refus"] ;
-                $sql_p_date_demande = $resultat3["p_date_demande"];
+                $sql_nb_jours          = affiche_decimal($resultat3["p_nb_jours"]);
+                $sql_commentaire       = $resultat3["p_commentaire"];
+                $sql_type              = $resultat3["p_type"];
+                $sql_etat              = $resultat3["p_etat"];
+                $sql_motif_refus       = $resultat3["p_motif_refus"];
+                $sql_p_date_demande    = $resultat3["p_date_demande"];
                 $sql_p_date_traitement = $resultat3["p_date_traitement"];
-                $sql_num=$resultat3["p_num"] ;
+                $sql_num               = $resultat3["p_num"];
 
-                if(($sql_etat=="annul") || ($sql_etat=="refus") || ($sql_etat=="ajout")) {
-                    $casecocher1="";
-                    if($sql_etat=="refus") {
-                        if($sql_motif_refus=="") {
-                            $sql_motif_refus =  _('divers_inconnu')  ;
+                if (($sql_etat == "annul") || ($sql_etat == "refus") || ($sql_etat == "ajout")) {
+                    $casecocher1 = "";
+                    if ($sql_etat == "refus") {
+                        if ($sql_motif_refus == "") {
+                            $sql_motif_refus = _('divers_inconnu');
                         }
                         //$text_annul="<i>motif du refus : $sql_motif_refus</i>";
-                        $text_annul="<i>". _('resp_traite_user_motif') ." : $sql_motif_refus</i>";
-                    } elseif($sql_etat=="annul") {
-                        if($sql_motif_refus=="")
-                            $sql_motif_refus =  _('divers_inconnu')  ;
+                        $text_annul = "<i>" . _('resp_traite_user_motif') . " : $sql_motif_refus</i>";
+                    } elseif ($sql_etat == "annul") {
+                        if ($sql_motif_refus == "") {
+                            $sql_motif_refus = _('divers_inconnu');
+                        }
+
                         //$text_annul="<i>motif de l'annulation : $sql_motif_refus</i>";
-                        $text_annul="<i>". _('resp_traite_user_motif') ." : $sql_motif_refus</i>";
-                    } elseif($sql_etat=="ajout") {
-                        $text_annul="&nbsp;";
+                        $text_annul = "<i>" . _('resp_traite_user_motif') . " : $sql_motif_refus</i>";
+                    } elseif ($sql_etat == "ajout") {
+                        $text_annul = "&nbsp;";
                     }
                 } else {
-                    $casecocher1=sprintf("<input type=\"checkbox\" name=\"tab_checkbox_annule[$sql_num]\" value=\"$sql_login--$sql_nb_jours--$sql_type--ANNULE\">");
-                    $text_annul="<input type=\"text\" name=\"tab_text_annul[$sql_num]\" size=\"20\" max=\"100\">";
+                    $casecocher1 = sprintf("<input type=\"checkbox\" name=\"tab_checkbox_annule[$sql_num]\" value=\"$sql_login--$sql_nb_jours--$sql_type--ANNULE\">");
+                    $text_annul  = "<input type=\"text\" name=\"tab_text_annul[$sql_num]\" size=\"20\" max=\"100\">";
                 }
 
                 $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
@@ -1450,18 +1447,18 @@ class Fonctions
                 $return .= '<td>' . $sql_commentaire . '</td>';
                 $return .= '<td>' . $tab_types_abs[$sql_type]['libelle'] . '</td>';
                 $return .= '<td>';
-                if($sql_etat=="refus") {
-                    $return .= _('divers_refuse') ;
-                } elseif($sql_etat=="annul") {
-                    $return .= _('divers_annule') ;
+                if ($sql_etat == "refus") {
+                    $return .= _('divers_refuse');
+                } elseif ($sql_etat == "annul") {
+                    $return .= _('divers_annule');
                 } else {
                     $return .= $sql_etat;
                 }
                 $return .= '</td>';
                 $return .= '<td>' . $casecocher1 . '</td>';
                 $return .= '<td>' . $text_annul . '</td>';
-                if($_SESSION['config']['affiche_date_traitement']) {
-                    if(empty($sql_p_date_traitement)) {
+                if ($_SESSION['config']['affiche_date_traitement']) {
+                    if (empty($sql_p_date_traitement)) {
                         $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : pas traité</td>';
                     } else {
                         $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_p_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_p_date_traitement . '</td>';
@@ -1483,9 +1480,9 @@ class Fonctions
     //affiche l'état des demande en attente de 2ieme validation du user (avec le formulaire pour le responsable)
     public static function affiche_etat_demande_2_valid_user_for_resp($user_login)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id() ;
-        $return = '';
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session  = session_id();
+        $return   = '';
 
         // Récupération des informations
         $sql2 = "SELECT p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_date_demande, p_date_traitement, p_num " .
@@ -1493,8 +1490,8 @@ class Fonctions
             "WHERE p_login = '$user_login' AND p_etat ='valid' ORDER BY p_date_deb";
         $ReqLog2 = \includes\SQL::query($sql2);
 
-        $count2=$ReqLog2->num_rows;
-        if($count2==0) {
+        $count2 = $ReqLog2->num_rows;
+        if ($count2 == 0) {
             $return .= '<b>' . _('resp_traite_user_aucune_demande') . '</b><br><br>';
         } else {
             // recup dans un tableau des types de conges
@@ -1514,42 +1511,41 @@ class Fonctions
             $return .= '<th>' . _('divers_accepter_maj_1') . '</th>';
             $return .= '<th>' . _('divers_refuser_maj_1') . '</th>';
             $return .= '<th>' . _('resp_traite_user_motif_refus') . '</th>';
-            if($_SESSION['config']['affiche_date_traitement']) {
+            if ($_SESSION['config']['affiche_date_traitement']) {
                 $return .= '<th>' . _('divers_date_traitement') . '</th>';
             }
             $return .= '</tr>';
             $return .= '</thead>';
             $return .= '<tbody>';
 
-            $i = true;
-            $tab_checkbox=array();
+            $i            = true;
+            $tab_checkbox = array();
             while ($resultat2 = $ReqLog2->fetch_array()) {
-                $sql_date_deb = $resultat2["p_date_deb"];
-                $sql_date_deb_fr = eng_date_to_fr($resultat2["p_date_deb"]) ;
-                $sql_demi_jour_deb=$resultat2["p_demi_jour_deb"] ;
-                if($sql_demi_jour_deb=="am") {
-                    $demi_j_deb =  _('divers_am_short') ;
+                $sql_date_deb      = $resultat2["p_date_deb"];
+                $sql_date_deb_fr   = eng_date_to_fr($resultat2["p_date_deb"]);
+                $sql_demi_jour_deb = $resultat2["p_demi_jour_deb"];
+                if ($sql_demi_jour_deb == "am") {
+                    $demi_j_deb = _('divers_am_short');
                 } else {
-                    $demi_j_deb =  _('divers_pm_short') ;
+                    $demi_j_deb = _('divers_pm_short');
                 }
-                $sql_date_fin = $resultat2["p_date_fin"];
-                $sql_date_fin_fr = eng_date_to_fr($resultat2["p_date_fin"]) ;
-                $sql_demi_jour_fin=$resultat2["p_demi_jour_fin"] ;
-                if($sql_demi_jour_fin=="am") {
-                    $demi_j_fin =  _('divers_am_short') ;
+                $sql_date_fin      = $resultat2["p_date_fin"];
+                $sql_date_fin_fr   = eng_date_to_fr($resultat2["p_date_fin"]);
+                $sql_demi_jour_fin = $resultat2["p_demi_jour_fin"];
+                if ($sql_demi_jour_fin == "am") {
+                    $demi_j_fin = _('divers_am_short');
                 } else {
-                    $demi_j_fin =  _('divers_pm_short') ;
+                    $demi_j_fin = _('divers_pm_short');
                 }
-                $sql_nb_jours=affiche_decimal($resultat2["p_nb_jours"]) ;
-                $sql_commentaire=$resultat2["p_commentaire"] ;
-                $sql_type=$resultat2["p_type"] ;
-                $sql_date_demande = $resultat2["p_date_demande"];
+                $sql_nb_jours        = affiche_decimal($resultat2["p_nb_jours"]);
+                $sql_commentaire     = $resultat2["p_commentaire"];
+                $sql_type            = $resultat2["p_type"];
+                $sql_date_demande    = $resultat2["p_date_demande"];
                 $sql_date_traitement = $resultat2["p_date_traitement"];
-                $sql_num=$resultat2["p_num"] ;
+                $sql_num             = $resultat2["p_num"];
 
                 // on construit la chaine qui servira de valeur à passer dans les boutons-radio
                 $chaine_bouton_radio = "$user_login--$sql_nb_jours--$sql_type--$sql_date_deb--$sql_demi_jour_deb--$sql_date_fin--$sql_demi_jour_fin";
-
 
                 $casecocher1 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--ACCEPTE\">";
                 $casecocher2 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--REFUSE\">";
@@ -1564,8 +1560,8 @@ class Fonctions
                 $return .= '<td>' . $casecocher1 . '</td>';
                 $return .= '<td>' . $casecocher2 . '</td>';
                 $return .= '<td>' . $text_refus . '</td>';
-                if($_SESSION['config']['affiche_date_traitement']) {
-                    if(empty($sql_date_traitement)) {
+                if ($_SESSION['config']['affiche_date_traitement']) {
+                    if (empty($sql_date_traitement)) {
                         $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_date_demande . '<br>' . _('divers_traitement') . ' : pas traité</td>';
                     } else {
                         $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_date_traitement . '</td>';
@@ -1587,19 +1583,19 @@ class Fonctions
     //affiche l'état des demandes du user (avec le formulaire pour le responsable)
     public static function affiche_etat_demande_user_for_resp($user_login, $tab_user, $tab_grd_resp)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id();
-        $return = '';
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session  = session_id();
+        $return   = '';
 
         // Récupération des informations
         $sql2 = "SELECT p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_date_demande, p_date_traitement, p_num " .
             "FROM conges_periode " .
-            "WHERE p_login = '$user_login' AND p_etat ='demande' ".
+            "WHERE p_login = '$user_login' AND p_etat ='demande' " .
             "ORDER BY p_date_deb";
         $ReqLog2 = \includes\SQL::query($sql2);
 
-        $count2=$ReqLog2->num_rows;
-        if($count2==0) {
+        $count2 = $ReqLog2->num_rows;
+        if ($count2 == 0) {
             $return .= '<p><strong>' . _('resp_traite_user_aucune_demande') . '</strong></p>';
         } else {
             // recup dans un tableau des types de conges
@@ -1618,57 +1614,58 @@ class Fonctions
             $return .= '<td>' . _('divers_accepter_maj_1') . '</td>';
             $return .= '<td>' . _('divers_refuser_maj_1') . '</td>';
             $return .= '<td>' . _('resp_traite_user_motif_refus') . '</td>';
-            if($_SESSION['config']['affiche_date_traitement']) {
+            if ($_SESSION['config']['affiche_date_traitement']) {
                 $return .= '<td>' . _('divers_date_traitement') . '</td>';
             } else {
                 $return .= '<td></td>';
             }
             $return .= '</tr>';
 
-            $tab_checkbox=array();
+            $tab_checkbox = array();
             while ($resultat2 = $ReqLog2->fetch_array()) {
-                $sql_date_deb = $resultat2["p_date_deb"];
-                $sql_date_deb_fr = eng_date_to_fr($resultat2["p_date_deb"]) ;
-                $sql_demi_jour_deb=$resultat2["p_demi_jour_deb"] ;
-                if($sql_demi_jour_deb=="am") {
-                    $demi_j_deb =  _('divers_am_short') ;
+                $sql_date_deb      = $resultat2["p_date_deb"];
+                $sql_date_deb_fr   = eng_date_to_fr($resultat2["p_date_deb"]);
+                $sql_demi_jour_deb = $resultat2["p_demi_jour_deb"];
+                if ($sql_demi_jour_deb == "am") {
+                    $demi_j_deb = _('divers_am_short');
                 } else {
-                    $demi_j_deb =  _('divers_pm_short') ;
+                    $demi_j_deb = _('divers_pm_short');
                 }
-                $sql_date_fin = $resultat2["p_date_fin"];
-                $sql_date_fin_fr = eng_date_to_fr($resultat2["p_date_fin"]) ;
-                $sql_demi_jour_fin=$resultat2["p_demi_jour_fin"] ;
-                if($sql_demi_jour_fin=="am") {
-                    $demi_j_fin =  _('divers_am_short') ;
+                $sql_date_fin      = $resultat2["p_date_fin"];
+                $sql_date_fin_fr   = eng_date_to_fr($resultat2["p_date_fin"]);
+                $sql_demi_jour_fin = $resultat2["p_demi_jour_fin"];
+                if ($sql_demi_jour_fin == "am") {
+                    $demi_j_fin = _('divers_am_short');
                 } else {
-                    $demi_j_fin =  _('divers_pm_short') ;
+                    $demi_j_fin = _('divers_pm_short');
                 }
-                $sql_nb_jours=affiche_decimal($resultat2["p_nb_jours"]) ;
-                $sql_commentaire=$resultat2["p_commentaire"] ;
-                $sql_type=$resultat2["p_type"] ;
-                $sql_date_demande = $resultat2["p_date_demande"];
+                $sql_nb_jours        = affiche_decimal($resultat2["p_nb_jours"]);
+                $sql_commentaire     = $resultat2["p_commentaire"];
+                $sql_type            = $resultat2["p_type"];
+                $sql_date_demande    = $resultat2["p_date_demande"];
                 $sql_date_traitement = $resultat2["p_date_traitement"];
-                $sql_num=$resultat2["p_num"] ;
+                $sql_num             = $resultat2["p_num"];
 
                 // on construit la chaine qui servira de valeur à passer dans les boutons-radio
                 $chaine_bouton_radio = "$user_login--$sql_nb_jours--$sql_type--$sql_date_deb--$sql_demi_jour_deb--$sql_date_fin--$sql_demi_jour_fin";
 
                 // si le user fait l'objet d'une double validation on a pas le meme resultat sur le bouton !
-                if($tab_user['double_valid'] == "Y") {
+                if ($tab_user['double_valid'] == "Y") {
                     /*******************************/
                     /* verif si le resp est grand_responsable pour ce user*/
-                    if(in_array($_SESSION['userlogin'], $tab_grd_resp)) { // si user_login est dans le tableau des grand responsable
-                        $boutonradio1="<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--ACCEPTE\">";
+                    if (in_array($_SESSION['userlogin'], $tab_grd_resp)) {
+                        // si user_login est dans le tableau des grand responsable
+                        $boutonradio1 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--ACCEPTE\">";
                     } else {
-                        $boutonradio1="<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--VALID\">";
+                        $boutonradio1 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--VALID\">";
                     }
                 } else {
-                    $boutonradio1="<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--ACCEPTE\">";
+                    $boutonradio1 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--ACCEPTE\">";
                 }
 
                 $boutonradio2 = "<input type=\"radio\" name=\"tab_radio_traite_demande[$sql_num]\" value=\"$chaine_bouton_radio--REFUSE\">";
 
-                $text_refus  = "<input type=\"text\" name=\"tab_text_refus[$sql_num]\" size=\"20\" max=\"100\">";
+                $text_refus = "<input type=\"text\" name=\"tab_text_refus[$sql_num]\" size=\"20\" max=\"100\">";
 
                 $return .= '<tr align="center">';
                 $return .= '<td>' . $sql_date_deb_fr . '_' . $demi_j_deb . '</td>';
@@ -1681,8 +1678,8 @@ class Fonctions
                 $return .= '<td>' . $text_refus . '</td>';
                 $return .= '<td>' . $sql_date_demande . '</td>';
 
-                if($_SESSION['config']['affiche_date_traitement']) {
-                    if(empty($sql_date_traitement)) {
+                if ($_SESSION['config']['affiche_date_traitement']) {
+                    if (empty($sql_date_traitement)) {
                         $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_date_demande . '<br>' . _('divers_traitement') . ' : pas traité</td>';
                     } else {
                         $return .= '<td class="histo-left">' . _('divers_demande') . ' : ' . $sql_date_demande . '<br>' . _('divers_traitement') . ' : ' . $sql_date_traitement . '</td>';
@@ -1701,14 +1698,14 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage($user_login,  $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date)
+    public static function affichage($user_login, $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date)
     {
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id();
-        $return = '';
+        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session  = session_id();
+        $return   = '';
 
         // on initialise le tableau global des jours fériés s'il ne l'est pas déjà :
-        if(!isset($_SESSION["tab_j_feries"])) {
+        if (!isset($_SESSION["tab_j_feries"])) {
             init_tab_jours_feries();
         }
 
@@ -1716,14 +1713,14 @@ class Fonctions
         /* Récupération des informations sur le user : */
         /********************/
         $list_group_dbl_valid_du_resp = get_list_groupes_double_valid_du_resp($_SESSION['userlogin']);
-        $tab_user=array();
-        $tab_user = recup_infos_du_user($user_login, $list_group_dbl_valid_du_resp);
+        $tab_user                     = array();
+        $tab_user                     = recup_infos_du_user($user_login, $list_group_dbl_valid_du_resp);
 
-        $list_all_users_du_resp=get_list_all_users_du_resp($_SESSION['userlogin']);
+        $list_all_users_du_resp = get_list_all_users_du_resp($_SESSION['userlogin']);
 
         // recup des grd resp du user
-        $tab_grd_resp=array();
-        if($_SESSION['config']['double_validation_conges']) {
+        $tab_grd_resp = array();
+        if ($_SESSION['config']['double_validation_conges']) {
             get_tab_grd_resp_du_user($user_login, $tab_grd_resp);
         }
 
@@ -1731,7 +1728,6 @@ class Fonctions
         /* Titre */
         /********************/
         $return .= '<h1>' . $tab_user['prenom'] . ' ' . $tab_user['nom'] . '</h1>';
-
 
         /********************/
         /* Bilan des Conges */
@@ -1745,19 +1741,19 @@ class Fonctions
         /* SAISIE NOUVEAU CONGES */
         /*************************/
         // dans le cas ou les users ne peuvent pas saisir de demande, le responsable saisi les congès :
-        if( !$_SESSION['config']['user_saisie_demande'] || $_SESSION['config']['resp_saisie_mission'] ) {
+        if (!$_SESSION['config']['user_saisie_demande'] || $_SESSION['config']['resp_saisie_mission']) {
             // si les mois et année ne sont pas renseignés, on prend ceux du jour
-            if($year_calendrier_saisie_debut==0) {
-                $year_calendrier_saisie_debut=date("Y");
+            if ($year_calendrier_saisie_debut == 0) {
+                $year_calendrier_saisie_debut = date("Y");
             }
-            if($mois_calendrier_saisie_debut==0) {
-                $mois_calendrier_saisie_debut=date("m");
+            if ($mois_calendrier_saisie_debut == 0) {
+                $mois_calendrier_saisie_debut = date("m");
             }
-            if($year_calendrier_saisie_fin==0) {
-                $year_calendrier_saisie_fin=date("Y");
+            if ($year_calendrier_saisie_fin == 0) {
+                $year_calendrier_saisie_fin = date("Y");
             }
-            if($mois_calendrier_saisie_fin==0) {
-                $mois_calendrier_saisie_fin=date("m");
+            if ($mois_calendrier_saisie_fin == 0) {
+                $mois_calendrier_saisie_fin = date("m");
             }
 
             $return .= '<h2>' . _('resp_traite_user_new_conges') . '</h2>';
@@ -1772,9 +1768,9 @@ class Fonctions
         /*********************/
         /* Etat des Demandes */
         /*********************/
-        if($_SESSION['config']['user_saisie_demande']) {
+        if ($_SESSION['config']['user_saisie_demande']) {
             //verif si le user est bien un user du resp (et pas seulement du grand resp)
-            if(strstr($list_all_users_du_resp, "'$user_login'")!=FALSE) {
+            if (strstr($list_all_users_du_resp, "'$user_login'") != false) {
                 $return .= '<h2>' . _('resp_traite_user_etat_demandes') . '</h2>';
 
                 //affiche l'état des demandes du user (avec le formulaire pour le responsable)
@@ -1787,11 +1783,11 @@ class Fonctions
         /*********************/
         /* Etat des Demandes en attente de 2ieme validation */
         /*********************/
-        if($_SESSION['config']['double_validation_conges']) {
+        if ($_SESSION['config']['double_validation_conges']) {
             /*******************************/
             /* verif si le resp est grand_responsable pour ce user*/
 
-            if(in_array($_SESSION['userlogin'], $tab_grd_resp)) // si resp_login est dans le tableau
+            if (in_array($_SESSION['userlogin'], $tab_grd_resp)) // si resp_login est dans le tableau
             {
                 $return .= '<h2>' . _('resp_traite_user_etat_demandes_2_valid') . '</h2>';
 
@@ -1807,7 +1803,7 @@ class Fonctions
         /*******************/
         //affiche l'état des conges du user (avec le formulaire pour le responsable)
         $onglet = "traite_user";
-        $return .= \responsable\Fonctions::affiche_etat_conges_user_for_resp($user_login,  $year_affichage, $tri_date, $onglet);
+        $return .= \responsable\Fonctions::affiche_etat_conges_user_for_resp($user_login, $year_affichage, $tri_date, $onglet);
         return $return;
     }
 
@@ -1821,56 +1817,56 @@ class Fonctions
     public static function traiteUserModule()
     {
         //var pour resp_traite_user.php
-        $user_login   = getpost_variable('user_login') ;
-        $year_calendrier_saisie_debut = getpost_variable('year_calendrier_saisie_debut', 0) ;
-        $mois_calendrier_saisie_debut = getpost_variable('mois_calendrier_saisie_debut', 0) ;
-        $year_calendrier_saisie_fin = getpost_variable('year_calendrier_saisie_fin', 0) ;
-        $mois_calendrier_saisie_fin = getpost_variable('mois_calendrier_saisie_fin', 0) ;
-        $tri_date = getpost_variable('tri_date', "ascendant") ;
-        $tab_checkbox_annule = getpost_variable('tab_checkbox_annule') ;
-        $tab_radio_traite_demande = getpost_variable('tab_radio_traite_demande') ;
-        $tab_text_refus = getpost_variable('tab_text_refus') ;
-        $tab_text_annul = getpost_variable('tab_text_annul') ;
-        $new_demande_conges = getpost_variable('new_demande_conges', 0) ;
-        $new_debut = getpost_variable('new_debut') ;
-        $new_demi_jour_deb = htmlentities(getpost_variable('new_demi_jour_deb'), ENT_QUOTES | ENT_HTML401);
-        $new_fin = getpost_variable('new_fin') ;
-        $new_demi_jour_fin = htmlentities(getpost_variable('new_demi_jour_fin'), ENT_QUOTES | ENT_HTML401);
-        $return = '';
+        $user_login                   = getpost_variable('user_login');
+        $year_calendrier_saisie_debut = getpost_variable('year_calendrier_saisie_debut', 0);
+        $mois_calendrier_saisie_debut = getpost_variable('mois_calendrier_saisie_debut', 0);
+        $year_calendrier_saisie_fin   = getpost_variable('year_calendrier_saisie_fin', 0);
+        $mois_calendrier_saisie_fin   = getpost_variable('mois_calendrier_saisie_fin', 0);
+        $tri_date                     = getpost_variable('tri_date', "ascendant");
+        $tab_checkbox_annule          = getpost_variable('tab_checkbox_annule');
+        $tab_radio_traite_demande     = getpost_variable('tab_radio_traite_demande');
+        $tab_text_refus               = getpost_variable('tab_text_refus');
+        $tab_text_annul               = getpost_variable('tab_text_annul');
+        $new_demande_conges           = getpost_variable('new_demande_conges', 0);
+        $new_debut                    = getpost_variable('new_debut');
+        $new_demi_jour_deb            = htmlentities(getpost_variable('new_demi_jour_deb'), ENT_QUOTES | ENT_HTML401);
+        $new_fin                      = getpost_variable('new_fin');
+        $new_demi_jour_fin            = htmlentities(getpost_variable('new_demi_jour_fin'), ENT_QUOTES | ENT_HTML401);
+        $return                       = '';
 
-        if($_SESSION['config']['disable_saise_champ_nb_jours_pris']) { // zone de texte en readonly et grisée
-            $new_nb_jours = compter($user_login, '', $new_debut,  $new_fin, $new_demi_jour_deb, $new_demi_jour_fin, $comment);
+        if ($_SESSION['config']['disable_saise_champ_nb_jours_pris']) {
+            // zone de texte en readonly et grisée
+            $new_nb_jours = compter($user_login, '', $new_debut, $new_fin, $new_demi_jour_deb, $new_demi_jour_fin, $comment);
         } else {
-            $new_nb_jours = getpost_variable('new_nb_jours') ;
+            $new_nb_jours = getpost_variable('new_nb_jours');
         }
 
-        $new_comment = htmlentities(getpost_variable('new_comment'), ENT_QUOTES | ENT_HTML401);
-        $new_type = htmlentities(getpost_variable('new_type'), ENT_QUOTES | ENT_HTML401);
-        $year_affichage = (int) getpost_variable('year_affichage' , date("Y") );
+        $new_comment    = htmlentities(getpost_variable('new_comment'), ENT_QUOTES | ENT_HTML401);
+        $new_type       = htmlentities(getpost_variable('new_type'), ENT_QUOTES | ENT_HTML401);
+        $year_affichage = (int) getpost_variable('year_affichage', date("Y"));
 
         /*************************************/
 
-        if ( !is_resp_of_user($_SESSION['userlogin'] , $user_login)) {
+        if (!is_resp_of_user($_SESSION['userlogin'], $user_login)) {
             redirect(ROOT_PATH . 'deconnexion.php');
             exit;
         }
 
         /************************************/
 
-
         // si une annulation de conges a été selectionée :
-        if($tab_checkbox_annule!="") {
+        if ($tab_checkbox_annule != "") {
             $return .= \responsable\Fonctions::annule_conges($user_login, $tab_checkbox_annule, $tab_text_annul);
         }
         // si le traitement des demandes a été selectionée :
-        elseif($tab_radio_traite_demande!="") {
+        elseif ($tab_radio_traite_demande != "") {
             $return .= \responsable\Fonctions::traite_demandes($user_login, $tab_radio_traite_demande, $tab_text_refus);
         }
         // si un nouveau conges ou absence a été saisi pour un user :
-        elseif($new_demande_conges==1) {
+        elseif ($new_demande_conges == 1) {
             $return .= \responsable\Fonctions::new_conges($user_login, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type);
         } else {
-            $return .= \responsable\Fonctions::affichage($user_login,  $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date);
+            $return .= \responsable\Fonctions::affichage($user_login, $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date);
         }
         return $return;
     }
@@ -1889,10 +1885,10 @@ class Fonctions
 
         /* Préparation et requêtage */
         $listPlanningId = \App\ProtoControllers\HautResponsable\Planning::getListPlanningId();
-        $return = '<h1>' . _('resp_affichage_liste_planning_titre') . '</h1>';
+        $return         = '<h1>' . _('resp_affichage_liste_planning_titre') . '</h1>';
         $return .= $message;
         $session = session_id();
-        $table = new \App\Libraries\Structure\Table();
+        $table   = new \App\Libraries\Structure\Table();
         $table->addClasses([
             'table',
             'table-hover',
@@ -1910,7 +1906,7 @@ class Fonctions
                 $childTable .= '<tr><td>' . $planning['name'] . '</td>';
                 $childTable .= '<td><form action="" method="post" accept-charset="UTF-8"
 enctype="application/x-www-form-urlencoded"><a  title="' . _('form_modif') . '" href="resp_index.php?onglet=modif_planning&id=' . $planning['planning_id'] .
-                '&session=' . $session . '"><i class="fa fa-pencil"></i></a>&nbsp;&nbsp;';
+                    '&session=' . $session . '"><i class="fa fa-pencil"></i></a>&nbsp;&nbsp;';
                 $childTable .= '</form></td></tr>';
             }
         }
@@ -1938,7 +1934,7 @@ enctype="application/x-www-form-urlencoded"><a  title="' . _('form_modif') . '" 
         if (!empty($_POST)) {
             if (0 < (int) \App\ProtoControllers\Responsable\Planning::putPlanning($id, $_POST, $errorsLst)) {
                 log_action(0, '', '', 'Édition des associations du planning ' . $id);
-                redirect(ROOT_PATH . 'responsable/resp_index.php?session='. session_id() . '&onglet=liste_planning', false);
+                redirect(ROOT_PATH . 'responsable/resp_index.php?session=' . session_id() . '&onglet=liste_planning', false);
             } else {
                 if (!empty($errorsLst)) {
                     $errors = '';
@@ -1964,14 +1960,14 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
-        $childTable = '<thead><tr><th class="col-md-4">' . _('Nom') .'</th><th></th></tr></thead><tbody>';
-        $sql   = 'SELECT * FROM planning WHERE planning_id = ' . $id;
-        $query = \includes\SQL::query($sql);
-        $data = $query->fetch_assoc();
-        $valueName = $data['name'];
-        $idSemaine = uniqid();
+        $childTable = '<thead><tr><th class="col-md-4">' . _('Nom') . '</th><th></th></tr></thead><tbody>';
+        $sql        = 'SELECT * FROM planning WHERE planning_id = ' . $id;
+        $query      = \includes\SQL::query($sql);
+        $data       = $query->fetch_assoc();
+        $valueName  = $data['name'];
+        $idSemaine  = uniqid();
         $childTable .= '<tr><td>' . $valueName . '<input type="hidden" name="planning_id" value="' . $id . '" /><input type="hidden" name="_METHOD" value="PUT" /></td><td><input type="button" id="' . $idSemaine . '" class="btn btn-default " /></td></tr></tbody>';
         $table->addChild($childTable);
         ob_start();
@@ -1986,7 +1982,7 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
         $return .= '</div><div id="' . $idImpaire . '"><h4>' . _('resp_temps_partiel_sem_impaires') . '</h4>';
         $idPaire = uniqid();
         $return .= static::getFormPlanningTable(\App\Models\Planning\Creneau::TYPE_SEMAINE_IMPAIRE, $id, $_POST);
-        $return .= '</div><div id="' . $idPaire . '"><h4>' .  _('resp_temps_partiel_sem_paires') . '</h4>';
+        $return .= '</div><div id="' . $idPaire . '"><h4>' . _('resp_temps_partiel_sem_paires') . '</h4>';
 
         $return .= static::getFormPlanningTable(\App\Models\Planning\Creneau::TYPE_SEMAINE_PAIRE, $id, $_POST);
         $typeSemaine = [
@@ -2002,7 +1998,7 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
         $return .= '<h3>Employés associés</h3>';
         $return .= self::getFormPlanningEmployes($id);
         $return .= '<br><input type="submit" class="btn btn-success" value="' . _('form_submit') . '" />';
-        $return .='</form>';
+        $return .= '</form>';
 
         return $return;
     }
@@ -2041,14 +2037,14 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
             'table-hover',
             'table-responsive',
             'table-striped',
-            'table-condensed'
+            'table-condensed',
         ]);
         $linkId       = uniqid();
         $selectJourId = uniqid();
         $debutId      = uniqid();
         $finId        = uniqid();
         $helperId     = uniqid();
-        $childTable = '<thead><tr><th width="20%">' . _('Jour') . '</th><th>' . _('Creneaux_travail') . '</th><tr></thead><tbody>';
+        $childTable   = '<thead><tr><th width="20%">' . _('Jour') . '</th><th>' . _('Creneaux_travail') . '</th><tr></thead><tbody>';
         foreach ($jours as $id => $jour) {
             $childTable .= '<tr data-id-jour=' . $id . '><td name="nom">' . $jour . '</td><td class="creneaux"></td></tr>';
         }
@@ -2086,8 +2082,8 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
      */
     private static function getFormPlanningEmployes($idPlanning)
     {
-        $idPlanning = (int) $idPlanning;
-        $return = '';
+        $idPlanning           = (int) $idPlanning;
+        $return               = '';
         $utilisateursAssocies = \App\ProtoControllers\Responsable\Planning::getListeUtilisateursAssocies($idPlanning);
 
         $subalternes = \App\ProtoControllers\Responsable::getUsersRespDirect($_SESSION['userlogin']);
@@ -2103,7 +2099,7 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
             $return .= '<div>' . _('resp_tout_utilisateur_associe') . '</div>';
         } else {
             $hasGroup = $_SESSION['config']['gestion_groupes'];
-            if($hasGroup) {
+            if ($hasGroup) {
                 $return .= '<div class="form-group col-md-4 col-sm-5">
                 <label class="control-label col-md-3 col-sm-3" for="groupe">Groupe&nbsp;:</label>
                 <div class="col-md-8 col-sm-8"><select class="form-control" name="groupeId" id="groupe">';
@@ -2116,26 +2112,26 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
                 }
                 $return .= '</select></div></div><br><br><br>';
                 $associations = array_map(function ($groupe) {
-                        return $groupe['utilisateurs'];
-                    },
+                    return $groupe['utilisateurs'];
+                },
                     $optionsGroupes
                 );
             }
             $return .= '<div>';
             foreach ($utilisateursAssocies as $utilisateur) {
                 $disabled = (\App\ProtoControllers\Utilisateur::hasSortiesEnCours($utilisateur['login']))
-                    ? 'disabled '
-                    : '';
+                ? 'disabled '
+                : '';
                 $checked = ($idPlanning === $utilisateur['planningId'])
-                    ? 'checked '
-                    : '';
+                ? 'checked '
+                : '';
                 $nom = \App\ProtoControllers\Utilisateur::getNomComplet($utilisateur['prenom'], $utilisateur['nom']);
                 $return .= '<div class="checkbox-utilisateur" data-user-login="' . $utilisateur['login'] . '">
-                    <label><input type="checkbox" name="utilisateurs[]" value="' . $utilisateur['login'] . '" ' . $disabled . $checked . ' />&nbsp;' . $nom  . '</label>
+                    <label><input type="checkbox" name="utilisateurs[]" value="' . $utilisateur['login'] . '" ' . $disabled . $checked . ' />&nbsp;' . $nom . '</label>
                 </div>';
             }
             $return .= '</div>';
-            if($hasGroup) {
+            if ($hasGroup) {
                 $return .= '<script type="text/javascript">
                 console.log(\'test\');
                 new selectAssociationPlanning("groupe", ' . json_encode($associations) . ', ' . NIL_INT . ');

--- a/responsable/resp_ajout_conges.php
+++ b/responsable/resp_ajout_conges.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \responsable\Fonctions::ajoutCongesModule($tab_type_cong);

--- a/responsable/resp_cloture_exercice.php
+++ b/responsable/resp_cloture_exercice.php
@@ -1,5 +1,5 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \responsable\Fonctions::clotureExerciceModule();
 bottom();

--- a/responsable/resp_index.php
+++ b/responsable/resp_index.php
@@ -2,117 +2,116 @@
 
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-include_once ROOT_PATH .'fonctions_conges.php' ;
-include_once INCLUDE_PATH .'fonction.php';
-include_once INCLUDE_PATH .'session.php';
-include_once ROOT_PATH .'fonctions_calcul.php';
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+include_once INCLUDE_PATH . 'session.php';
+include_once ROOT_PATH . 'fonctions_calcul.php';
 
 // verif des droits du user à afficher la page
 verif_droits_user($session, "is_resp");
 
+/*************************************/
+// recup des parametres reçus :
+// SERVER
+$PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+// GET / POST
+$onglet = getpost_variable('onglet', "page_principale");
 
-    /*************************************/
-    // recup des parametres reçus :
-    // SERVER
-    $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-    // GET / POST
-    $onglet = getpost_variable('onglet', "page_principale");
+/*********************************/
+/*   COMPOSITION DES ONGLETS...  */
+/*********************************/
 
-    /*********************************/
-    /*   COMPOSITION DES ONGLETS...  */
-    /*********************************/
+$onglets = array();
 
-    $onglets = array();
+$onglets['page_principale'] = _('resp_menu_button_retour_main');
+$DemandesAdd                = new \App\ProtoControllers\Responsable\Traitement\Additionnelle;
+$DemandesRep                = new \App\ProtoControllers\Responsable\Traitement\Repos;
+$DemandesConges             = new \App\ProtoControllers\Responsable\Traitement\Conge;
 
+if ($_SESSION['config']['user_saisie_demande']) {
 
-    $onglets['page_principale'] = _('resp_menu_button_retour_main');
-    $DemandesAdd = new \App\ProtoControllers\Responsable\Traitement\Additionnelle;
-    $DemandesRep = new \App\ProtoControllers\Responsable\Traitement\Repos;
-    $DemandesConges = new \App\ProtoControllers\Responsable\Traitement\Conge;
-
-    if( $_SESSION['config']['user_saisie_demande'] ) {
-
-        $nbbadgeConges='';
-        $nbdemandes = $DemandesConges->getNbDemandesATraiter($_SESSION['userlogin']);
-        if ( 0 < $nbdemandes) {
-            $nbbadgeConges = ' <span class="badge">'. $nbdemandes .'</span>';
-        }
-        $onglets['traitement_demandes'] = _('resp_menu_button_traite_demande').$nbbadgeConges ;
+    $nbbadgeConges = '';
+    $nbdemandes    = $DemandesConges->getNbDemandesATraiter($_SESSION['userlogin']);
+    if (0 < $nbdemandes) {
+        $nbbadgeConges = ' <span class="badge">' . $nbdemandes . '</span>';
     }
+    $onglets['traitement_demandes'] = _('resp_menu_button_traite_demande') . $nbbadgeConges;
+}
 
-    $nbbadgeDem='';
-    $nbdemandes = $DemandesAdd->getNbDemandesATraiter($_SESSION['userlogin']);
-    if ( 0 < $nbdemandes )
-    {
-        $nbbadgeDem = ' <span class="badge">'. $nbdemandes .'</span>';
-    }
-    $onglets['traitement_heures_additionnelles'] = _('resp_menu_button_traite_additionnelle').$nbbadgeDem;
+$nbbadgeDem = '';
+$nbdemandes = $DemandesAdd->getNbDemandesATraiter($_SESSION['userlogin']);
+if (0 < $nbdemandes) {
+    $nbbadgeDem = ' <span class="badge">' . $nbdemandes . '</span>';
+}
+$onglets['traitement_heures_additionnelles'] = _('resp_menu_button_traite_additionnelle') . $nbbadgeDem;
 
-    $nbbadgeRep = '';
-    $nbdemandes = $DemandesRep->getNbDemandesATraiter($_SESSION['userlogin']);
-    if ( 0 < $nbdemandes )
-    {
-        $nbbadgeRep = ' <span class="badge">'. $nbdemandes .'</span>';
-    }
-    $onglets['traitement_heures_repos'] = _('resp_menu_button_traite_repos').$nbbadgeRep;
+$nbbadgeRep = '';
+$nbdemandes = $DemandesRep->getNbDemandesATraiter($_SESSION['userlogin']);
+if (0 < $nbdemandes) {
+    $nbbadgeRep = ' <span class="badge">' . $nbdemandes . '</span>';
+}
+$onglets['traitement_heures_repos'] = _('resp_menu_button_traite_repos') . $nbbadgeRep;
 
-    if( $_SESSION['config']['resp_ajoute_conges'] )
-        $onglets['ajout_conges'] = _('resp_ajout_conges_titre');
+if ($_SESSION['config']['resp_ajoute_conges']) {
+    $onglets['ajout_conges'] = _('resp_ajout_conges_titre');
+}
 
-    if( $_SESSION['config']['resp_association_planning'] )
-        $onglets['liste_planning'] = _('resp_liste_planning');
+if ($_SESSION['config']['resp_association_planning']) {
+    $onglets['liste_planning'] = _('resp_liste_planning');
+}
 
-    if (false)
-        $onglets['cloture_exercice'] = _('button_cloture');
+if (false) {
+    $onglets['cloture_exercice'] = _('button_cloture');
+}
 
-    if ( !isset($onglets[ $onglet ]) && !in_array($onglet, array('traite_user', 'modif_planning')))
-        $onglet = 'page_principale';
+if (!isset($onglets[$onglet]) && !in_array($onglet, array('traite_user', 'modif_planning'))) {
+    $onglet = 'page_principale';
+}
 
-    /*********************************/
-    /*   COMPOSITION DU HEADER...    */
-    /*********************************/
+/*********************************/
+/*   COMPOSITION DU HEADER...    */
+/*********************************/
 
-    $add_css = '<style>#onglet_menu .onglet{ width: '. (str_replace(',', '.', 100 / count($onglets) )).'% ;}</style>';
-    header_menu('', 'Libertempo : '._('divers_responsable_maj_1'),$add_css);
+$add_css = '<style>#onglet_menu .onglet{ width: ' . (str_replace(',', '.', 100 / count($onglets))) . '% ;}</style>';
+header_menu('', 'Libertempo : ' . _('divers_responsable_maj_1'), $add_css);
 
-    /*********************************/
-    /*   AFFICHAGE DES ONGLETS...  */
-    /*********************************/
+/*********************************/
+/*   AFFICHAGE DES ONGLETS...  */
+/*********************************/
 
-    echo '<div id="onglet_menu">';
-    foreach($onglets as $key => $title) {
-        echo '<div class="onglet '.($onglet == $key ? ' active': '').'" >
-            <a href="'.$PHP_SELF.'?session='.$session.'&onglet='.$key.'">'. $title .'</a>
+echo '<div id="onglet_menu">';
+foreach ($onglets as $key => $title) {
+    echo '<div class="onglet ' . ($onglet == $key ? ' active' : '') . '" >
+            <a href="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $key . '">' . $title . '</a>
         </div>';
-    }
-    echo '</div>';
+}
+echo '</div>';
 
+/*********************************/
+/*   AFFICHAGE DE L'ONGLET ...    */
+/*********************************/
 
-    /*********************************/
-    /*   AFFICHAGE DE L'ONGLET ...    */
-    /*********************************/
+/** initialisation des tableaux des types de conges/absences  **/
+// recup du tableau des types de conges (seulement les conges)
+$tab_type_cong = recup_tableau_types_conges();
 
+// recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
+$tab_type_conges_exceptionnels = array();
+if ($_SESSION['config']['gestion_conges_exceptionnels']) {
+    $tab_type_conges_exceptionnels = recup_tableau_types_conges_exceptionnels();
+}
 
-    /** initialisation des tableaux des types de conges/absences  **/
-    // recup du tableau des types de conges (seulement les conges)
-    $tab_type_cong=recup_tableau_types_conges();
+echo '<div class="' . $onglet . ' main-content">';
+include_once ROOT_PATH . 'responsable/resp_' . $onglet . '.php';
+echo '</div>';
 
-    // recup du tableau des types de conges exceptionnels (seulement les conges exceptionnels)
-    $tab_type_conges_exceptionnels=array();
-  if ($_SESSION['config']['gestion_conges_exceptionnels'])
-        $tab_type_conges_exceptionnels=recup_tableau_types_conges_exceptionnels();
+/*********************************/
+/*   AFFICHAGE DU BOTTOM ...   */
+/*********************************/
 
-    echo '<div class="'.$onglet.' main-content">';
-        include_once ROOT_PATH . 'responsable/resp_'.$onglet.'.php';
-    echo '</div>';
-
-    /*********************************/
-    /*   AFFICHAGE DU BOTTOM ...   */
-    /*********************************/
-
-    bottom();
-    exit;
+bottom();
+exit;

--- a/responsable/resp_page_principale.php
+++ b/responsable/resp_page_principale.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \responsable\Fonctions::pagePrincipaleModule($tab_type_cong, $tab_type_conges_exceptionnels, $session);

--- a/responsable/resp_traite_user.php
+++ b/responsable/resp_traite_user.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \responsable\Fonctions::traiteUserModule();

--- a/responsable/resp_traitement_demandes.php
+++ b/responsable/resp_traitement_demandes.php
@@ -1,6 +1,6 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
 $conges = new \App\ProtoControllers\Responsable\Traitement\Conge();
 echo $conges->getForm();

--- a/responsable/resp_traitement_heures_additionnelles.php
+++ b/responsable/resp_traitement_heures_additionnelles.php
@@ -1,5 +1,5 @@
 <?php
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
 $additionnelle = new \App\ProtoControllers\Responsable\Traitement\Additionnelle();
 echo $additionnelle->getForm();

--- a/responsable/resp_traitement_heures_repos.php
+++ b/responsable/resp_traitement_heures_repos.php
@@ -1,5 +1,5 @@
 <?php
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
 $repos = new \App\ProtoControllers\Responsable\Traitement\Repos();
 echo $repos->getForm();

--- a/template/reboot/template_define.php
+++ b/template/reboot/template_define.php
@@ -1,3 +1,3 @@
 <?php
 
-define('BOTTOM_TEXT','Libertempo 1.9 "Ceres". <a href="https://github.com/wouldsmina/Libertempo/issues">Un bug, une remarque <i class="fa fa-github fa-2x"></i></a>');
+define('BOTTOM_TEXT', 'Libertempo 1.9 "Ceres". <a href="https://github.com/wouldsmina/Libertempo/issues">Un bug, une remarque <i class="fa fa-github fa-2x"></i></a>');

--- a/utilisateur/Fonctions.php
+++ b/utilisateur/Fonctions.php
@@ -3,47 +3,48 @@
 namespace utilisateur;
 
 /**
-* Regroupement des fonctions liées à l'utilisateur
-*/
+ * Regroupement des fonctions liées à l'utilisateur
+ */
 class Fonctions
 {
     // renvoit le type d'absence (conges ou absence) d'une absence
     public static function get_type_abs($_type_abs_id)
     {
-        $sql_abs='SELECT ta_type FROM conges_type_absence WHERE ta_id="'. \includes\SQL::quote($_type_abs_id).'"';
+        $sql_abs    = 'SELECT ta_type FROM conges_type_absence WHERE ta_id="' . \includes\SQL::quote($_type_abs_id) . '"';
         $ReqLog_abs = \includes\SQL::query($sql_abs);
 
-        if($resultat_abs = $ReqLog_abs->fetch_array())
+        if ($resultat_abs = $ReqLog_abs->fetch_array()) {
             return $resultat_abs["ta_type"];
-        else
-            return "" ;
+        } else {
+            return "";
+        }
+
     }
 
     public static function verif_solde_user($user_login, $type_conges, $nb_jours)
     {
-        $verif = TRUE;
+        $verif = true;
         // on ne tient compte du solde que pour les absences de type conges (conges avec solde annuel)
-        if (\utilisateur\Fonctions::get_type_abs($type_conges)=="conges")
-        {
+        if (\utilisateur\Fonctions::get_type_abs($type_conges) == "conges") {
             // recup du solde de conges de type $type_conges pour le user de login $user_login
-            $select_solde='SELECT su_solde FROM conges_solde_user WHERE su_login="'. \includes\SQL::quote($user_login).'" AND su_abs_id='. \includes\SQL::quote($type_conges);
+            $select_solde        = 'SELECT su_solde FROM conges_solde_user WHERE su_login="' . \includes\SQL::quote($user_login) . '" AND su_abs_id=' . \includes\SQL::quote($type_conges);
             $ReqLog_solde_conges = \includes\SQL::query($select_solde);
-            $resultat_solde = $ReqLog_solde_conges->fetch_array();
-            $sql_solde_user = $resultat_solde["su_solde"];
+            $resultat_solde      = $ReqLog_solde_conges->fetch_array();
+            $sql_solde_user      = $resultat_solde["su_solde"];
 
             // recup du nombre de jours de conges de type $type_conges pour le user de login $user_login qui sont à valider par son resp ou le grd resp
-            $select_solde_a_valider='SELECT SUM(p_nb_jours) FROM conges_periode WHERE p_login="'. \includes\SQL::quote($user_login).'" AND p_type='. \includes\SQL::quote($type_conges).' AND (p_etat=\'demande\' OR p_etat=\'valid\') ';
+            $select_solde_a_valider        = 'SELECT SUM(p_nb_jours) FROM conges_periode WHERE p_login="' . \includes\SQL::quote($user_login) . '" AND p_type=' . \includes\SQL::quote($type_conges) . ' AND (p_etat=\'demande\' OR p_etat=\'valid\') ';
             $ReqLog_solde_conges_a_valider = \includes\SQL::query($select_solde_a_valider);
-            $resultat_solde_a_valider = $ReqLog_solde_conges_a_valider->fetch_array();
-            $sql_solde_user_a_valider = $resultat_solde_a_valider["SUM(p_nb_jours)"];
-            if ($sql_solde_user_a_valider == NULL )
+            $resultat_solde_a_valider      = $ReqLog_solde_conges_a_valider->fetch_array();
+            $sql_solde_user_a_valider      = $resultat_solde_a_valider["SUM(p_nb_jours)"];
+            if ($sql_solde_user_a_valider == null) {
                 $sql_solde_user_a_valider = 0;
+            }
 
             // vérification du solde de jours de type $type_conges
-            if ($sql_solde_user < $nb_jours+$sql_solde_user_a_valider)
-            {
-                echo '<p class="bg-danger">'.schars( _('verif_solde_erreur_part_1') ).' ('.(float)schars($nb_jours).') '.schars( _('verif_solde_erreur_part_2') ).' ('.(float)schars($sql_solde_user).') '.schars( _('verif_solde_erreur_part_3') ).' ('.(float)schars($sql_solde_user_a_valider).')</p>'."\n";
-                $verif = FALSE;
+            if ($sql_solde_user < $nb_jours + $sql_solde_user_a_valider) {
+                echo '<p class="bg-danger">' . schars(_('verif_solde_erreur_part_1')) . ' (' . (float) schars($nb_jours) . ') ' . schars(_('verif_solde_erreur_part_2')) . ' (' . (float) schars($sql_solde_user) . ') ' . schars(_('verif_solde_erreur_part_3')) . ' (' . (float) schars($sql_solde_user_a_valider) . ')</p>' . "\n";
+                $verif = false;
             }
         }
         return $verif;
@@ -54,52 +55,50 @@ class Fonctions
     {
         //conversion des dates
         $new_debut = convert_date($new_debut);
-        $new_fin = convert_date($new_fin);
-        $return = '';
+        $new_fin   = convert_date($new_fin);
+        $return    = '';
 
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
+        $session  = session_id();
 
         // verif validité des valeurs saisies
         $valid = verif_saisie_new_demande($new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment);
 
         // verifie que le solde de conges sera encore positif après validation
-        if( $_SESSION['config']['solde_toujours_positif'] ) {
+        if ($_SESSION['config']['solde_toujours_positif']) {
             $valid = $valid && \utilisateur\Fonctions::verif_solde_user($_SESSION['userlogin'], $new_type, $new_nb_jours);
         }
 
-        if( $valid ) {
-            if( in_array(\utilisateur\Fonctions::get_type_abs($new_type) , array('conges','conges_exceptionnels') ) ) {
+        if ($valid) {
+            if (in_array(\utilisateur\Fonctions::get_type_abs($new_type), array('conges', 'conges_exceptionnels'))) {
                 $resp_du_user = get_tab_resp_du_user($_SESSION['userlogin']);
-                if ((1 === count($resp_du_user) && isset($resp_du_user['conges']))||empty($resp_du_user)) {
-                    $new_etat = 'ok' ;
+                if ((1 === count($resp_du_user) && isset($resp_du_user['conges'])) || empty($resp_du_user)) {
+                    $new_etat = 'ok';
                     soustrait_solde_et_reliquat_user($_SESSION['userlogin'], "", $new_nb_jours, $new_type, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin);
                 } else {
-                    $new_etat = 'demande' ;
+                    $new_etat = 'demande';
                 }
             } else {
-                $new_etat = 'ok' ;
+                $new_etat = 'ok';
             }
 
             $periode_num = insert_dans_periode($_SESSION['userlogin'], $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type, $new_etat, 0);
 
-            if ( $periode_num != 0 ) {
-                $return .= schars( _('form_modif_ok') ) . ' !<br><br>.';
+            if ($periode_num != 0) {
+                $return .= schars(_('form_modif_ok')) . ' !<br><br>.';
                 //envoi d'un mail d'alerte au responsable (si demandé dans config de php_conges)
-                if($_SESSION['config']['mail_new_demande_alerte_resp']){
-                    if(in_array(\utilisateur\Fonctions::get_type_abs($new_type), array('absences'))) {
+                if ($_SESSION['config']['mail_new_demande_alerte_resp']) {
+                    if (in_array(\utilisateur\Fonctions::get_type_abs($new_type), array('absences'))) {
                         alerte_mail($_SESSION['userlogin'], ":responsable:", $periode_num, "new_absence_conges");
                     } else {
                         alerte_mail($_SESSION['userlogin'], ":responsable:", $periode_num, "new_demande");
                     }
                 }
+            } else {
+                $return .= schars(_('form_modif_not_ok')) . ' !<br><br>.';
             }
-            else {
-                $return .= schars( _('form_modif_not_ok') ) . ' !<br><br>.';
-            }
-        }
-        else {
-            $return .= schars( _('resp_traite_user_valeurs_not_ok') ) . ' !<br><br>.';
+        } else {
+            $return .= schars(_('resp_traite_user_valeurs_not_ok')) . ' !<br><br>.';
         }
 
         $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '">' . _('form_retour') . '</a>';
@@ -117,7 +116,7 @@ class Fonctions
         $current = date('Y');
 
         return [
-            $current => $current,
+            $current     => $current,
             $current - 1 => $current - 1,
             $current - 2 => $current - 2,
         ];
@@ -166,28 +165,28 @@ class Fonctions
 
         $new_demande_conges = getpost_variable('new_demande_conges', 0);
 
-        if( $new_demande_conges == 1 && $_SESSION['config']['user_saisie_demande'] ) {
-            $new_debut        = htmlentities(getpost_variable('new_debut'), ENT_QUOTES | ENT_HTML401);
-            $new_demi_jour_deb  = htmlentities(getpost_variable('new_demi_jour_deb'), ENT_QUOTES | ENT_HTML401);
-            $new_fin        = htmlentities(getpost_variable('new_fin'), ENT_QUOTES | ENT_HTML401);
-            $new_demi_jour_fin  = htmlentities(getpost_variable('new_demi_jour_fin'), ENT_QUOTES | ENT_HTML401);
-            $new_comment        = htmlentities(getpost_variable('new_comment'), ENT_QUOTES | ENT_HTML401);
-            $new_type        = htmlentities(getpost_variable('new_type'), ENT_QUOTES | ENT_HTML401);
+        if ($new_demande_conges == 1 && $_SESSION['config']['user_saisie_demande']) {
+            $new_debut         = htmlentities(getpost_variable('new_debut'), ENT_QUOTES | ENT_HTML401);
+            $new_demi_jour_deb = htmlentities(getpost_variable('new_demi_jour_deb'), ENT_QUOTES | ENT_HTML401);
+            $new_fin           = htmlentities(getpost_variable('new_fin'), ENT_QUOTES | ENT_HTML401);
+            $new_demi_jour_fin = htmlentities(getpost_variable('new_demi_jour_fin'), ENT_QUOTES | ENT_HTML401);
+            $new_comment       = htmlentities(getpost_variable('new_comment'), ENT_QUOTES | ENT_HTML401);
+            $new_type          = htmlentities(getpost_variable('new_type'), ENT_QUOTES | ENT_HTML401);
 
-            $user_login        = $_SESSION['userlogin'];
+            $user_login = $_SESSION['userlogin'];
 
-            if( $_SESSION['config']['disable_saise_champ_nb_jours_pris'] ) {
-                $new_nb_jours = compter($user_login, '', $new_debut,  $new_fin, $new_demi_jour_deb, $new_demi_jour_fin, $new_comment);
+            if ($_SESSION['config']['disable_saise_champ_nb_jours_pris']) {
+                $new_nb_jours = compter($user_login, '', $new_debut, $new_fin, $new_demi_jour_deb, $new_demi_jour_fin, $new_comment);
             } else {
                 $new_nb_jours = htmlentities(getpost_variable('new_nb_jours'), ENT_QUOTES | ENT_HTML401);
             }
 
             $return .= \utilisateur\Fonctions::new_demande($new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type);
         } else {
-            $year_calendrier_saisie_debut   = (int) getpost_variable('year_calendrier_saisie_debut'   , date('Y'));
-            $mois_calendrier_saisie_debut   = (int) getpost_variable('mois_calendrier_saisie_debut'   , date('m'));
-            $year_calendrier_saisie_fin     = (int) getpost_variable('year_calendrier_saisie_fin'     , date('Y'));
-            $mois_calendrier_saisie_fin     = (int) getpost_variable('mois_calendrier_saisie_fin'     , date('m'));
+            $year_calendrier_saisie_debut = (int) getpost_variable('year_calendrier_saisie_debut', date('Y'));
+            $mois_calendrier_saisie_debut = (int) getpost_variable('mois_calendrier_saisie_debut', date('m'));
+            $year_calendrier_saisie_fin   = (int) getpost_variable('year_calendrier_saisie_fin', date('Y'));
+            $mois_calendrier_saisie_fin   = (int) getpost_variable('mois_calendrier_saisie_fin', date('m'));
 
             /**************************/
             /* Nouvelle Demande */
@@ -198,7 +197,7 @@ class Fonctions
             if ((false == $_SESSION['config']['dimanche_travail'])
                 && (false == $_SESSION['config']['samedi_travail'])
             ) {
-                $daysOfWeekDisabled = [0,6];
+                $daysOfWeekDisabled = [0, 6];
             } else {
                 if (false == $_SESSION['config']['dimanche_travail']) {
                     $daysOfWeekDisabled = [0];
@@ -238,31 +237,32 @@ class Fonctions
     public static function modifier($p_num_to_update, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $p_etat, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
-        $VerifNb = verif_saisie_decimal($new_nb_jours);
+        $session  = session_id();
+        $return   = '';
+        $VerifNb  = verif_saisie_decimal($new_nb_jours);
 
         $sql1 = "UPDATE conges_periode
-            SET p_date_deb='$new_debut', p_demi_jour_deb='$new_demi_jour_deb', p_date_fin='$new_fin', p_demi_jour_fin='$new_demi_jour_fin', p_nb_jours='$new_nb_jours', p_commentaire='". \includes\SQL::quote($new_comment)  ."', ";
-        if($p_etat=="demande")
-            $sql1 = $sql1." p_date_demande=NOW() ";
-        else
-            $sql1 = $sql1." p_date_traitement=NOW() ";
-        $sql1 = $sql1."    WHERE p_num='$p_num_to_update' AND p_login='".$_SESSION['userlogin']."' ;" ;
+            SET p_date_deb='$new_debut', p_demi_jour_deb='$new_demi_jour_deb', p_date_fin='$new_fin', p_demi_jour_fin='$new_demi_jour_fin', p_nb_jours='$new_nb_jours', p_commentaire='" . \includes\SQL::quote($new_comment) . "', ";
+        if ($p_etat == "demande") {
+            $sql1 = $sql1 . " p_date_demande=NOW() ";
+        } else {
+            $sql1 = $sql1 . " p_date_traitement=NOW() ";
+        }
 
-        $result = \includes\SQL::query($sql1) ;
+        $sql1 = $sql1 . "    WHERE p_num='$p_num_to_update' AND p_login='" . $_SESSION['userlogin'] . "' ;";
 
-        if($_SESSION['config']['mail_modif_demande_alerte_resp']) {
+        $result = \includes\SQL::query($sql1);
+
+        if ($_SESSION['config']['mail_modif_demande_alerte_resp']) {
             alerte_mail($_SESSION['userlogin'], ":responsable:", $p_num_to_update, "modif_demande_conges");
         }
         $comment_log = "modification de demande num $p_num_to_update ($new_nb_jours jour(s)) ( de $new_debut $new_demi_jour_deb a $new_fin $new_demi_jour_fin) ($new_comment)";
         log_action($p_num_to_update, "$p_etat", $_SESSION['userlogin'], $comment_log);
 
-
         $return .= _('form_modif_ok') . '<br><br>';
         /* APPEL D'UNE AUTRE PAGE */
-        $return .= '<form action="'.ROOT_PATH .'utilisateur/user_index.php?session='.$session.'&onglet=liste_conge" method="POST">';
-        $return .= '<input class="btn" type="submit" value="'. _('form_submit') .'">';
+        $return .= '<form action="' . ROOT_PATH . 'utilisateur/user_index.php?session=' . $session . '&onglet=liste_conge" method="POST">';
+        $return .= '<input class="btn" type="submit" value="' . _('form_submit') . '">';
         $return .= '</form>';
 
         return $return;
@@ -272,12 +272,12 @@ class Fonctions
     public static function confirmer($p_num, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // Récupération des informations
-        $sql1 = 'SELECT p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_etat, p_num FROM conges_periode where p_num = "'. \includes\SQL::quote($p_num).'"';
-        $ReqLog1 = \includes\SQL::query($sql1) ;
+        $sql1    = 'SELECT p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_etat, p_num FROM conges_periode where p_num = "' . \includes\SQL::quote($p_num) . '"';
+        $ReqLog1 = \includes\SQL::query($sql1);
 
         /* Génération du datePicker et de ses options */
         $daysOfWeekDisabled = [];
@@ -285,7 +285,7 @@ class Fonctions
         if ((false == $_SESSION['config']['dimanche_travail'])
             && (false == $_SESSION['config']['samedi_travail'])
         ) {
-            $daysOfWeekDisabled = [0,6];
+            $daysOfWeekDisabled = [0, 6];
         } else {
             if (false == $_SESSION['config']['dimanche_travail']) {
                 $daysOfWeekDisabled = [0];
@@ -317,7 +317,7 @@ class Fonctions
 
         // AFFICHAGE TABLEAU
 
-        $return .= '<form NAME="dem_conges" action="' . $PHP_SELF . '" method="POST">' ;
+        $return .= '<form NAME="dem_conges" action="' . $PHP_SELF . '" method="POST">';
         $return .= '<table class="table table-responsive">';
         $return .= '<thead>';
         // affichage première ligne : titres
@@ -332,60 +332,64 @@ class Fonctions
         // affichage 2ieme ligne : valeurs actuelles
         $return .= '<tr>';
         while ($resultat1 = $ReqLog1->fetch_array()) {
-            $sql_date_deb=eng_date_to_fr($resultat1["p_date_deb"]);
+            $sql_date_deb = eng_date_to_fr($resultat1["p_date_deb"]);
 
             $sql_demi_jour_deb = $resultat1["p_demi_jour_deb"];
-            if($sql_demi_jour_deb=="am")
-                $demi_j_deb= _('divers_am_short') ;
-            else
-                $demi_j_deb= _('divers_pm_short') ;
-            $sql_date_fin=eng_date_to_fr($resultat1["p_date_fin"]);
+            if ($sql_demi_jour_deb == "am") {
+                $demi_j_deb = _('divers_am_short');
+            } else {
+                $demi_j_deb = _('divers_pm_short');
+            }
+
+            $sql_date_fin      = eng_date_to_fr($resultat1["p_date_fin"]);
             $sql_demi_jour_fin = $resultat1["p_demi_jour_fin"];
-            if($sql_demi_jour_fin=="am")
-                $demi_j_fin= _('divers_am_short') ;
-            else
-                $demi_j_fin= _('divers_pm_short') ;
-            $sql_nb_jours=$resultat1["p_nb_jours"];
-            $aff_nb_jours=affiche_decimal($sql_nb_jours);
-            $sql_commentaire=$resultat1["p_commentaire"];
-            $sql_etat=$resultat1["p_etat"];
+            if ($sql_demi_jour_fin == "am") {
+                $demi_j_fin = _('divers_am_short');
+            } else {
+                $demi_j_fin = _('divers_pm_short');
+            }
 
-            $return .= '<td>' . $sql_date_deb . '_' . $demi_j_deb . '</td><td>' . $sql_date_fin  . '_' . $demi_j_fin . '</td><td>' . $aff_nb_jours . '</td><td>' . $sql_commentaire . '</td>';
+            $sql_nb_jours    = $resultat1["p_nb_jours"];
+            $aff_nb_jours    = affiche_decimal($sql_nb_jours);
+            $sql_commentaire = $resultat1["p_commentaire"];
+            $sql_etat        = $resultat1["p_etat"];
 
-            $compte ="";
-            if($_SESSION['config']['rempli_auto_champ_nb_jours_pris']) {
+            $return .= '<td>' . $sql_date_deb . '_' . $demi_j_deb . '</td><td>' . $sql_date_fin . '_' . $demi_j_fin . '</td><td>' . $aff_nb_jours . '</td><td>' . $sql_commentaire . '</td>';
+
+            $compte = "";
+            if ($_SESSION['config']['rempli_auto_champ_nb_jours_pris']) {
                 $compte = 'onChange="compter_jours();return false;"';
             }
 
-            $text_debut="<input class=\"form-control date\" type=\"text\" name=\"new_debut\" size=\"10\" maxlength=\"30\" value=\"" . revert_date($sql_date_deb) . "\">" ;
-            if($sql_demi_jour_deb=="am") {
-                $radio_deb_am="<input type=\"radio\" $compte name=\"new_demi_jour_deb\" value=\"am\" checked>&nbsp;". _('form_am') ;
-                $radio_deb_pm="<input type=\"radio\" $compte name=\"new_demi_jour_deb\" value=\"pm\">&nbsp;". _('form_pm') ;
+            $text_debut = "<input class=\"form-control date\" type=\"text\" name=\"new_debut\" size=\"10\" maxlength=\"30\" value=\"" . revert_date($sql_date_deb) . "\">";
+            if ($sql_demi_jour_deb == "am") {
+                $radio_deb_am = "<input type=\"radio\" $compte name=\"new_demi_jour_deb\" value=\"am\" checked>&nbsp;" . _('form_am');
+                $radio_deb_pm = "<input type=\"radio\" $compte name=\"new_demi_jour_deb\" value=\"pm\">&nbsp;" . _('form_pm');
             } else {
-                $radio_deb_am="<input type=\"radio\" $compte name=\"new_demi_jour_deb\" value=\"am\">". _('form_am') ;
-                $radio_deb_pm="<input type=\"radio\" $compte name=\"new_demi_jour_deb\" value=\"pm\" checked>". _('form_pm') ;
+                $radio_deb_am = "<input type=\"radio\" $compte name=\"new_demi_jour_deb\" value=\"am\">" . _('form_am');
+                $radio_deb_pm = "<input type=\"radio\" $compte name=\"new_demi_jour_deb\" value=\"pm\" checked>" . _('form_pm');
             }
-            $text_fin="<input class=\"form-control date\" type=\"text\" name=\"new_fin\" size=\"10\" maxlength=\"30\" value=\"" . revert_date($sql_date_fin) . "\">" ;
-            if($sql_demi_jour_fin=="am") {
-                $radio_fin_am="<input type=\"radio\" $compte name=\"new_demi_jour_fin\" value=\"am\" checked>". _('form_am') ;
-                $radio_fin_pm="<input type=\"radio\" $compte name=\"new_demi_jour_fin\" value=\"pm\">". _('form_pm') ;
+            $text_fin = "<input class=\"form-control date\" type=\"text\" name=\"new_fin\" size=\"10\" maxlength=\"30\" value=\"" . revert_date($sql_date_fin) . "\">";
+            if ($sql_demi_jour_fin == "am") {
+                $radio_fin_am = "<input type=\"radio\" $compte name=\"new_demi_jour_fin\" value=\"am\" checked>" . _('form_am');
+                $radio_fin_pm = "<input type=\"radio\" $compte name=\"new_demi_jour_fin\" value=\"pm\">" . _('form_pm');
             } else {
-                $radio_fin_am="<input type=\"radio\" $compte name=\"new_demi_jour_fin\" value=\"am\">". _('form_am') ;
-                $radio_fin_pm="<input type=\"radio\" $compte name=\"new_demi_jour_fin\" value=\"pm\" checked>". _('form_pm') ;
+                $radio_fin_am = "<input type=\"radio\" $compte name=\"new_demi_jour_fin\" value=\"am\">" . _('form_am');
+                $radio_fin_pm = "<input type=\"radio\" $compte name=\"new_demi_jour_fin\" value=\"pm\" checked>" . _('form_pm');
             }
-            if($_SESSION['config']['disable_saise_champ_nb_jours_pris'])
-                $text_nb_jours="<input class=\"form-control\" type=\"text\" name=\"new_nb_jours\" size=\"5\" maxlength=\"30\" value=\"$sql_nb_jours\" style=\"background-color: #D4D4D4; \" readonly=\"readonly\"><br><br>" ;
-            else
-                $text_nb_jours="<input class=\"form-control\" type=\"text\" name=\"new_nb_jours\" size=\"5\" maxlength=\"30\" value=\"$sql_nb_jours\"><br><br>" ;
+            if ($_SESSION['config']['disable_saise_champ_nb_jours_pris']) {
+                $text_nb_jours = "<input class=\"form-control\" type=\"text\" name=\"new_nb_jours\" size=\"5\" maxlength=\"30\" value=\"$sql_nb_jours\" style=\"background-color: #D4D4D4; \" readonly=\"readonly\"><br><br>";
+            } else {
+                $text_nb_jours = "<input class=\"form-control\" type=\"text\" name=\"new_nb_jours\" size=\"5\" maxlength=\"30\" value=\"$sql_nb_jours\"><br><br>";
+            }
 
-
-            $text_commentaire="<input class=\"form-control\" type=\"text\" name=\"new_comment\" size=\"15\" maxlength=\"30\" value=\"$sql_commentaire\"><br><br>" ;
+            $text_commentaire = "<input class=\"form-control\" type=\"text\" name=\"new_comment\" size=\"15\" maxlength=\"30\" value=\"$sql_commentaire\"><br><br>";
         }
         $return .= '</tr>';
 
         // affichage 3ieme ligne : saisie des nouvelles valeurs
         $return .= '<tr>';
-        $return .= '<td>' . $text_debut . '<br>' . $radio_deb_am . '/' . $radio_deb_pm . '</td><td>' . $text_fin . '<br>' . $radio_fin_am . '/' .  $radio_fin_pm . '</td><td>' . $text_nb_jours . '</td><td>' . $text_commentaire . '</td>';
+        $return .= '<td>' . $text_debut . '<br>' . $radio_deb_am . '/' . $radio_deb_pm . '</td><td>' . $text_fin . '<br>' . $radio_fin_am . '/' . $radio_fin_pm . '</td><td>' . $text_nb_jours . '</td><td>' . $text_commentaire . '</td>';
         $return .= '</tr>';
 
         $return .= '</tbody>';
@@ -394,7 +398,7 @@ class Fonctions
         $return .= '<input type="hidden" name="p_num_to_update" value="' . $p_num . '">';
         $return .= '<input type="hidden" name="p_etat" value="' . $sql_etat . '">';
         $return .= '<input type="hidden" name="session" value="' . $session . '">';
-        $return .= '<input type="hidden" name="user_login" value="'.$_SESSION['userlogin'].'">';
+        $return .= '<input type="hidden" name="user_login" value="' . $_SESSION['userlogin'] . '">';
         $return .= '<input type="hidden" name="onglet" value="' . $onglet . '">';
         $return .= '<p id="comment_nbj" style="color:red">&nbsp;</p>';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
@@ -418,37 +422,38 @@ class Fonctions
         $p_num             = getpost_variable('p_num');
         $onglet            = getpost_variable('onglet');
         $p_num_to_update   = getpost_variable('p_num_to_update');
-        $p_etat               = getpost_variable('p_etat');
+        $p_etat            = getpost_variable('p_etat');
         $new_debut         = getpost_variable('new_debut');
         $new_demi_jour_deb = getpost_variable('new_demi_jour_deb');
         $new_fin           = getpost_variable('new_fin');
         $new_demi_jour_fin = getpost_variable('new_demi_jour_fin');
         $new_comment       = htmlentities(getpost_variable('new_comment'), ENT_QUOTES | ENT_HTML401);
 
-        $return            = '';
+        $return = '';
 
         //conversion des dates
         $new_debut = convert_date($new_debut);
-        $new_fin = convert_date($new_fin);
+        $new_fin   = convert_date($new_fin);
 
-        if ($_SESSION['config']['disable_saise_champ_nb_jours_pris'])
-            $new_nb_jours = compter($user_login, $p_num_to_update, $new_debut,  $new_fin, $new_demi_jour_deb, $new_demi_jour_fin, $new_comment);
-        else
+        if ($_SESSION['config']['disable_saise_champ_nb_jours_pris']) {
+            $new_nb_jours = compter($user_login, $p_num_to_update, $new_debut, $new_fin, $new_demi_jour_deb, $new_demi_jour_fin, $new_comment);
+        } else {
             $new_nb_jours = getpost_variable('new_nb_jours');
+        }
 
         /*************************************/
 
         // TITRE
-        $return .= '<h1>'. _('user_modif_demande_titre') .'</h1>';
+        $return .= '<h1>' . _('user_modif_demande_titre') . '</h1>';
 
-        if($p_num!="") {
+        if ($p_num != "") {
             $return .= \utilisateur\Fonctions::confirmer($p_num, $onglet);
         } else {
-            if($p_num_to_update != "") {
+            if ($p_num_to_update != "") {
                 $return .= \utilisateur\Fonctions::modifier($p_num_to_update, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $p_etat, $onglet);
             } else {
                 // renvoit sur la page principale .
-                redirect( ROOT_PATH .'utilisateur/user_index.php', false );
+                redirect(ROOT_PATH . 'utilisateur/user_index.php', false);
             }
         }
 
@@ -459,38 +464,41 @@ class Fonctions
     public static function get_libelle_abs($_type_abs_id)
     {
 
-        $sql_abs='SELECT ta_libelle FROM conges_type_absence WHERE ta_id="'. \includes\SQL::quote($_type_abs_id).'"';
+        $sql_abs    = 'SELECT ta_libelle FROM conges_type_absence WHERE ta_id="' . \includes\SQL::quote($_type_abs_id) . '"';
         $ReqLog_abs = \includes\SQL::query($sql_abs);
-        if($resultat_abs = $ReqLog_abs->fetch_array())
+        if ($resultat_abs = $ReqLog_abs->fetch_array()) {
             return $resultat_abs['ta_libelle'];
-        else
-            return "" ;
+        } else {
+            return "";
+        }
+
     }
 
     public static function suppression($p_num_to_delete, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
-        if($_SESSION['config']['mail_supp_demande_alerte_resp']) {
+        if ($_SESSION['config']['mail_supp_demande_alerte_resp']) {
             alerte_mail($_SESSION['userlogin'], ":responsable:", $p_num_to_delete, "supp_demande_conges");
         }
 
-        $sql_delete = 'DELETE FROM conges_periode WHERE p_num = '.\includes\SQL::quote($p_num_to_delete).' AND p_login="'.\includes\SQL::quote($_SESSION['userlogin']).'";';
+        $sql_delete    = 'DELETE FROM conges_periode WHERE p_num = ' . \includes\SQL::quote($p_num_to_delete) . ' AND p_login="' . \includes\SQL::quote($_SESSION['userlogin']) . '";';
         $result_delete = \includes\SQL::query($sql_delete);
 
         $comment_log = "suppression de demande num $p_num_to_delete";
         log_action($p_num_to_delete, "", $_SESSION['userlogin'], $comment_log);
 
-        if($result_delete)
-            $return .= _('form_modif_ok') ."<br><br> \n";
-        else
-            $return .= _('form_modif_not_ok') ."<br><br> \n";
+        if ($result_delete) {
+            $return .= _('form_modif_ok') . "<br><br> \n";
+        } else {
+            $return .= _('form_modif_not_ok') . "<br><br> \n";
+        }
 
         /* APPEL D'UNE AUTRE PAGE */
-        $return .= '<form action="'.ROOT_PATH .'utilisateur/user_index.php?session='.$session.'&onglet=liste_conge" method="POST">';
-        $return .= '<input class="btn" type="submit" value="'. _('form_submit') .'">';
+        $return .= '<form action="' . ROOT_PATH . 'utilisateur/user_index.php?session=' . $session . '&onglet=liste_conge" method="POST">';
+        $return .= '<input class="btn" type="submit" value="' . _('form_submit') . '">';
         $return .= '</form>';
         $return .= '<a href="">';
 
@@ -500,13 +508,13 @@ class Fonctions
     public static function confirmerSuppression($p_num, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
         // Récupération des informations
-        $sql1 = 'SELECT p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_num FROM conges_periode WHERE p_num = "'.\includes\SQL::quote($p_num).'"';
+        $sql1 = 'SELECT p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_num FROM conges_periode WHERE p_num = "' . \includes\SQL::quote($p_num) . '"';
         //printf("sql1 = %s<br>\n", $sql1);
-        $ReqLog1 = \includes\SQL::query($sql1) ;
+        $ReqLog1 = \includes\SQL::query($sql1);
 
         // AFFICHAGE TABLEAU
         $return .= '<form action="' . $PHP_SELF . '" method="POST">';
@@ -523,22 +531,26 @@ class Fonctions
         $return .= '<tbody>';
         $return .= '<tr>';
         while ($resultat1 = $ReqLog1->fetch_array()) {
-            $sql_date_deb=eng_date_to_fr($resultat1["p_date_deb"]);
+            $sql_date_deb      = eng_date_to_fr($resultat1["p_date_deb"]);
             $sql_demi_jour_deb = $resultat1["p_demi_jour_deb"];
-            if($sql_demi_jour_deb=="am")
-                $demi_j_deb= _('divers_am_short') ;
-            else
-                $demi_j_deb= _('divers_pm_short') ;
-            $sql_date_fin=eng_date_to_fr($resultat1["p_date_fin"]);
+            if ($sql_demi_jour_deb == "am") {
+                $demi_j_deb = _('divers_am_short');
+            } else {
+                $demi_j_deb = _('divers_pm_short');
+            }
+
+            $sql_date_fin      = eng_date_to_fr($resultat1["p_date_fin"]);
             $sql_demi_jour_fin = $resultat1["p_demi_jour_fin"];
-            if($sql_demi_jour_fin=="am")
-                $demi_j_fin= _('divers_am_short') ;
-            else
-                $demi_j_fin= _('divers_pm_short') ;
-            $sql_nb_jours=affiche_decimal($resultat1["p_nb_jours"]);
+            if ($sql_demi_jour_fin == "am") {
+                $demi_j_fin = _('divers_am_short');
+            } else {
+                $demi_j_fin = _('divers_pm_short');
+            }
+
+            $sql_nb_jours = affiche_decimal($resultat1["p_nb_jours"]);
             //$sql_type=$resultat1["p_type"];
-            $sql_type= \utilisateur\Fonctions::get_libelle_abs($resultat1["p_type"]);
-            $sql_comment=htmlentities($resultat1["p_commentaire"], ENT_QUOTES | ENT_HTML401);
+            $sql_type    = \utilisateur\Fonctions::get_libelle_abs($resultat1["p_type"]);
+            $sql_comment = htmlentities($resultat1["p_commentaire"], ENT_QUOTES | ENT_HTML401);
 
             $return .= '<td>' . $sql_date_deb . '_' . $demi_j_deb . '</td>';
             $return .= '<td>' . $sql_date_fin . '_' . $demi_j_fin . '</td>';
@@ -577,43 +589,43 @@ class Fonctions
         /*************************************/
 
         // TITRE
-        $return .= '<h1>'. _('user_suppr_demande_titre') .'</h1>';
+        $return .= '<h1>' . _('user_suppr_demande_titre') . '</h1>';
         $return .= '<br>';
 
-        if($p_num!="") {
+        if ($p_num != "") {
             $return .= \utilisateur\Fonctions::confirmerSuppression($p_num, $onglet);
         } else {
-            if($p_num_to_delete!="") {
+            if ($p_num_to_delete != "") {
                 $return .= \utilisateur\Fonctions::suppression($p_num_to_delete, $onglet);
             } else {
                 // renvoit sur la page principale .
-                redirect( ROOT_PATH .'utilisateur/user_index.php', false );
+                redirect(ROOT_PATH . 'utilisateur/user_index.php', false);
             }
         }
 
         return $return;
     }
 
-    public static function change_passwd( $new_passwd1, $new_passwd2)
+    public static function change_passwd($new_passwd1, $new_passwd2)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $return = '';
+        $session  = session_id();
+        $return   = '';
 
-        if((strlen($new_passwd1)==0) || (strlen($new_passwd2)==0) || ($new_passwd1!=$new_passwd2)) // si les 2 passwd sont vides ou differents
+        if ((strlen($new_passwd1) == 0) || (strlen($new_passwd2) == 0) || ($new_passwd1 != $new_passwd2)) // si les 2 passwd sont vides ou differents
         {
-            $return .= _('user_passwd_error') ."<br>\n" ;
-        }
-        else
-        {
-            $passwd_md5=md5($new_passwd1);
-            $sql1 = 'UPDATE conges_users SET  u_passwd=\''.$passwd_md5.'\' WHERE u_login=\''.$_SESSION['userlogin'].'\' ';
-            $result = \includes\SQL::query($sql1) ;
+            $return .= _('user_passwd_error') . "<br>\n";
+        } else {
+            $passwd_md5 = md5($new_passwd1);
+            $sql1       = 'UPDATE conges_users SET  u_passwd=\'' . $passwd_md5 . '\' WHERE u_login=\'' . $_SESSION['userlogin'] . '\' ';
+            $result     = \includes\SQL::query($sql1);
 
-            if($result)
-                $return .= _('form_modif_ok') ." <br><br> \n";
-            else
-                $return .= _('form_modif_not_ok') ."<br><br> \n";
+            if ($result) {
+                $return .= _('form_modif_ok') . " <br><br> \n";
+            } else {
+                $return .= _('form_modif_not_ok') . "<br><br> \n";
+            }
+
         }
 
         $comment_log = 'changement Password';
@@ -634,41 +646,41 @@ class Fonctions
     public static function modificationMotDePasseModule($onglet)
     {
         $return = '';
-        if($_SESSION['config']['where_to_find_user_email']=="ldap"){
-            include_once CONFIG_PATH .'config_ldap.php';
+        if ($_SESSION['config']['where_to_find_user_email'] == "ldap") {
+            include_once CONFIG_PATH . 'config_ldap.php';
         }
 
         $change_passwd = getpost_variable('change_passwd', 0);
-        $new_passwd1 = getpost_variable('new_passwd1');
-        $new_passwd2 = getpost_variable('new_passwd2');
+        $new_passwd1   = getpost_variable('new_passwd1');
+        $new_passwd2   = getpost_variable('new_passwd2');
 
-        if($change_passwd==1) {
+        if ($change_passwd == 1) {
             $return .= \utilisateur\Fonctions::change_passwd($new_passwd1, $new_passwd2);
         } else {
             $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-            $session=session_id();
+            $session  = session_id();
 
             $return .= '<h1>' . _('user_change_password') . '</h1>';
-            $return .= '<form action="'.$PHP_SELF.'?session='.$session.'&onglet='.$onglet.'" method="POST">';
+            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '" method="POST">';
             $return .= '<table cellpadding="2" class="tablo" width="500">';
             $return .= '<thead>';
             /*
-               echo '<tr>
-               <td class="titre">'. _('user_passwd_saisie_1') .'</td>
-               <td class="titre">'. _('user_passwd_saisie_2') .'</td>
-               </tr>';
+            echo '<tr>
+            <td class="titre">'. _('user_passwd_saisie_1') .'</td>
+            <td class="titre">'. _('user_passwd_saisie_2') .'</td>
+            </tr>';
              */
             $return .= '<tr>
-                <th class="titre">'. _('user_passwd_saisie_1') .'</th>
-                <th class="titre">'. _('user_passwd_saisie_2') .'</th>
+                <th class="titre">' . _('user_passwd_saisie_1') . '</th>
+                <th class="titre">' . _('user_passwd_saisie_2') . '</th>
                 </tr>';
             $return .= '</thead>';
             $return .= '<tbody>';
 
-            $text_passwd1    = '<input class="form-control" type="password" name="new_passwd1" size="10" maxlength="20" value="" autocomplete="off">';
-            $text_passwd2    = '<input class="form-control" type="password" name="new_passwd2" size="10" maxlength="20" value="" autocomplete="off">';
+            $text_passwd1 = '<input class="form-control" type="password" name="new_passwd1" size="10" maxlength="20" value="" autocomplete="off">';
+            $text_passwd2 = '<input class="form-control" type="password" name="new_passwd2" size="10" maxlength="20" value="" autocomplete="off">';
             $return .= '<tr>';
-            $return .= '<td>'.($text_passwd1).'</td><td>'.($text_passwd2).'</td>'."\n";
+            $return .= '<td>' . ($text_passwd1) . '</td><td>' . ($text_passwd2) . '</td>' . "\n";
             $return .= '</tr>';
 
             $return .= '</tbody>';
@@ -676,7 +688,7 @@ class Fonctions
 
             $return .= '<hr/>';
             $return .= '<input type="hidden" name="change_passwd" value=1>';
-            $return .= '<input class="btn btn-success" type="submit" value="'. _('form_submit') .'">';
+            $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
             $return .= '</form>';
         }
 
@@ -684,69 +696,73 @@ class Fonctions
     }
 
     // affichage du calendrier du mois avec les case à cocher sur les jour de présence
-    public static function  affiche_calendrier_saisie_jour_presence($user_login, $year, $mois)
+    public static function affiche_calendrier_saisie_jour_presence($user_login, $year, $mois)
     {
-        $return = '';
-        $jour_today                    = date('j');
-        $jour_today_name            = date('D');
+        $return          = '';
+        $jour_today      = date('j');
+        $jour_today_name = date('D');
 
-        $first_jour_mois_timestamp    = mktime(0,0,0,$mois,1,$year);
-        $last_jour_mois_timestamp    = mktime(0,0,0,$mois +1 , 0,$year);
+        $first_jour_mois_timestamp = mktime(0, 0, 0, $mois, 1, $year);
+        $last_jour_mois_timestamp  = mktime(0, 0, 0, $mois + 1, 0, $year);
 
-        $mois_name                    = date_fr('F', $first_jour_mois_timestamp);
+        $mois_name = date_fr('F', $first_jour_mois_timestamp);
 
-        $first_jour_mois_rang        = date('w', $first_jour_mois_timestamp);      // jour de la semaine en chiffre (0=dim , 6=sam)
-        $last_jour_mois_rang        = date('w', $last_jour_mois_timestamp);      // jour de la semaine en chiffre (0=dim , 6=sam)
-        $nb_jours_mois                = ( $last_jour_mois_timestamp - $first_jour_mois_timestamp  + 60*60 *12 ) / (24 * 60 * 60);// + 60*60 *12 for fucking DST
+        $first_jour_mois_rang = date('w', $first_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
+        $last_jour_mois_rang  = date('w', $last_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
+        $nb_jours_mois        = ($last_jour_mois_timestamp - $first_jour_mois_timestamp + 60 * 60 * 12) / (24 * 60 * 60); // + 60*60 *12 for fucking DST
 
-        if( $first_jour_mois_rang == 0 )
-            $first_jour_mois_rang=7 ;    // jour de la semaine en chiffre (1=lun , 7=dim)
+        if ($first_jour_mois_rang == 0) {
+            $first_jour_mois_rang = 7;
+        }
+        // jour de la semaine en chiffre (1=lun , 7=dim)
 
-        if( $last_jour_mois_rang == 0 )
-            $last_jour_mois_rang=7 ;    // jour de la semaine en chiffre (1=lun , 7=dim)
+        if ($last_jour_mois_rang == 0) {
+            $last_jour_mois_rang = 7;
+        }
+        // jour de la semaine en chiffre (1=lun , 7=dim)
 
         $return .= '<table class="table calendrier_saisie_date">';
         $return .= '<thead>
             <tr>
-            <th colspan="7" class="titre"> '.$mois_name.' '.$year.' </th>
+            <th colspan="7" class="titre"> ' . $mois_name . ' ' . $year . ' </th>
             </tr>
             <tr>
-            <th class="cal-saisie2">'. _('lundi_1c') .'</th>
-            <th class="cal-saisie2">'. _('mardi_1c') .'</th>
-            <th class="cal-saisie2">'. _('mercredi_1c') .'</th>
-            <th class="cal-saisie2">'. _('jeudi_1c') .'</th>
-            <th class="cal-saisie2">'. _('vendredi_1c') .'</th>
-            <th class="cal-saisie2">'. _('samedi_1c') .'</th>
-            <th class="cal-saisie2">'. _('dimanche_1c') .'</th>
+            <th class="cal-saisie2">' . _('lundi_1c') . '</th>
+            <th class="cal-saisie2">' . _('mardi_1c') . '</th>
+            <th class="cal-saisie2">' . _('mercredi_1c') . '</th>
+            <th class="cal-saisie2">' . _('jeudi_1c') . '</th>
+            <th class="cal-saisie2">' . _('vendredi_1c') . '</th>
+            <th class="cal-saisie2">' . _('samedi_1c') . '</th>
+            <th class="cal-saisie2">' . _('dimanche_1c') . '</th>
             </tr>
             </thead>';
         $return .= '<tbody>';
 
-        $start_nb_day_before = $first_jour_mois_rang -1;
-        $stop_nb_day_before = 7 - $last_jour_mois_rang ;
-        $planningUser = \utilisateur\Fonctions::getUserPlanning($user_login);
+        $start_nb_day_before = $first_jour_mois_rang - 1;
+        $stop_nb_day_before  = 7 - $last_jour_mois_rang;
+        $planningUser        = \utilisateur\Fonctions::getUserPlanning($user_login);
 
-
-        for ( $i = - $start_nb_day_before; $i <= $nb_jours_mois + $stop_nb_day_before; $i ++) {
-            if ( ($i + $start_nb_day_before ) % 7 == 0)
+        for ($i = -$start_nb_day_before; $i <= $nb_jours_mois + $stop_nb_day_before; $i++) {
+            if (($i + $start_nb_day_before) % 7 == 0) {
                 $return .= '<tr>';
+            }
 
-
-            $j_timestamp=mktime (0,0,0,$mois, $i +1 ,$year);
+            $j_timestamp     = mktime(0, 0, 0, $mois, $i + 1, $year);
             $td_second_class = get_td_class_of_the_day_in_the_week($j_timestamp);
 
             if ($i < 0 || $i > $nb_jours_mois || $td_second_class == 'weekend') {
-                $return .= '<td class="'.$td_second_class.'">-</td>';
-            }
-            else {
-                $val_matin='';
-                $val_aprem='';
+                $return .= '<td class="' . $td_second_class . '">-</td>';
+            } else {
+                $val_matin = '';
+                $val_aprem = '';
                 recup_infos_artt_du_jour($user_login, $j_timestamp, $val_matin, $val_aprem, $planningUser);
-                $return .= \utilisateur\Fonctions::affiche_cellule_calendrier_echange_presence_saisie_semaine($val_matin, $val_aprem, $year, $mois, $i+1);
+                $return .= \utilisateur\Fonctions::affiche_cellule_calendrier_echange_presence_saisie_semaine($val_matin, $val_aprem, $year, $mois, $i + 1);
             }
 
-            if ( ($i + $start_nb_day_before ) % 7 == 6)
+            if (($i + $start_nb_day_before) % 7 == 6) {
                 $return .= '<tr>';
+            }
+
         }
 
         $return .= '</tbody>';
@@ -756,55 +772,60 @@ class Fonctions
     }
 
     //affichage du calendrier du mois avec les case à cocher sur les jour d'absence
-    public static function  affiche_calendrier_saisie_jour_absence($user_login, $year, $mois)
+    public static function affiche_calendrier_saisie_jour_absence($user_login, $year, $mois)
     {
-        $return = '';
-        $jour_today                    = date('j');
-        $jour_today_name            = date('D');
+        $return          = '';
+        $jour_today      = date('j');
+        $jour_today_name = date('D');
 
-        $first_jour_mois_timestamp    = mktime(0,0,0,$mois,1,$year);
-        $last_jour_mois_timestamp    = mktime(0,0,0,$mois + 1, 0 ,$year);
+        $first_jour_mois_timestamp = mktime(0, 0, 0, $mois, 1, $year);
+        $last_jour_mois_timestamp  = mktime(0, 0, 0, $mois + 1, 0, $year);
 
-        $mois_name                    = date_fr('F', $first_jour_mois_timestamp);
+        $mois_name = date_fr('F', $first_jour_mois_timestamp);
 
-        $first_jour_mois_rang        = date('w', $first_jour_mois_timestamp);      // jour de la semaine en chiffre (0=dim , 6=sam)
-        $last_jour_mois_rang        = date('w', $last_jour_mois_timestamp);      // jour de la semaine en chiffre (0=dim , 6=sam)
-        $nb_jours_mois                = ( $last_jour_mois_timestamp - $first_jour_mois_timestamp  + 60*60 *12 ) / (24 * 60 * 60);// + 60*60 *12 for fucking DST
+        $first_jour_mois_rang = date('w', $first_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
+        $last_jour_mois_rang  = date('w', $last_jour_mois_timestamp); // jour de la semaine en chiffre (0=dim , 6=sam)
+        $nb_jours_mois        = ($last_jour_mois_timestamp - $first_jour_mois_timestamp + 60 * 60 * 12) / (24 * 60 * 60); // + 60*60 *12 for fucking DST
 
-        if( $first_jour_mois_rang == 0 )
-            $first_jour_mois_rang=7 ;    // jour de la semaine en chiffre (1=lun , 7=dim)
+        if ($first_jour_mois_rang == 0) {
+            $first_jour_mois_rang = 7;
+        }
+        // jour de la semaine en chiffre (1=lun , 7=dim)
 
-        if( $last_jour_mois_rang == 0 )
-            $last_jour_mois_rang=7 ;    // jour de la semaine en chiffre (1=lun , 7=dim)
+        if ($last_jour_mois_rang == 0) {
+            $last_jour_mois_rang = 7;
+        }
+        // jour de la semaine en chiffre (1=lun , 7=dim)
 
         $return .= '<table class="table calendrier_saisie_date">';
-        $return .= '<thead><tr><th colspan="7" class="titre"> '.$mois_name.' '.$year.' </th></tr><tr><th class="cal-saisie2">'. _('lundi_1c') .'</th><th class="cal-saisie2">'. _('mardi_1c') .'</th><th class="cal-saisie2">'. _('mercredi_1c') .'</th><th class="cal-saisie2">'. _('jeudi_1c') .'</th><th class="cal-saisie2">'. _('vendredi_1c') .'</th><th class="cal-saisie2">'. _('samedi_1c') .'</th><th class="cal-saisie2">'. _('dimanche_1c') .'</th></tr></thead>';
+        $return .= '<thead><tr><th colspan="7" class="titre"> ' . $mois_name . ' ' . $year . ' </th></tr><tr><th class="cal-saisie2">' . _('lundi_1c') . '</th><th class="cal-saisie2">' . _('mardi_1c') . '</th><th class="cal-saisie2">' . _('mercredi_1c') . '</th><th class="cal-saisie2">' . _('jeudi_1c') . '</th><th class="cal-saisie2">' . _('vendredi_1c') . '</th><th class="cal-saisie2">' . _('samedi_1c') . '</th><th class="cal-saisie2">' . _('dimanche_1c') . '</th></tr></thead>';
         $return .= '<tbody>';
 
-        $start_nb_day_before = $first_jour_mois_rang -1;
-        $stop_nb_day_before = 7 - $last_jour_mois_rang ;
-        $planningUser = \utilisateur\Fonctions::getUserPlanning($user_login);
+        $start_nb_day_before = $first_jour_mois_rang - 1;
+        $stop_nb_day_before  = 7 - $last_jour_mois_rang;
+        $planningUser        = \utilisateur\Fonctions::getUserPlanning($user_login);
 
-
-        for ( $i = - $start_nb_day_before; $i <= $nb_jours_mois + $stop_nb_day_before; $i ++) {
-            if ( ($i + $start_nb_day_before ) % 7 == 0)
+        for ($i = -$start_nb_day_before; $i <= $nb_jours_mois + $stop_nb_day_before; $i++) {
+            if (($i + $start_nb_day_before) % 7 == 0) {
                 $return .= '<tr>';
+            }
 
-            $j_timestamp=mktime (0,0,0,$mois, $i +1 ,$year);
+            $j_timestamp     = mktime(0, 0, 0, $mois, $i + 1, $year);
             $td_second_class = get_td_class_of_the_day_in_the_week($j_timestamp);
 
             if ($i < 0 || $i > $nb_jours_mois || $td_second_class == 'weekend') {
-                $return .= '<td class="'.$td_second_class.'">-</td>';
-            }
-            else {
-                $val_matin='';
-                $val_aprem='';
+                $return .= '<td class="' . $td_second_class . '">-</td>';
+            } else {
+                $val_matin = '';
+                $val_aprem = '';
                 recup_infos_artt_du_jour($user_login, $j_timestamp, $val_matin, $val_aprem, $planningUser);
-                $return .= \utilisateur\Fonctions::affiche_cellule_calendrier_echange_absence_saisie_semaine($val_matin, $val_aprem, $year, $mois, $i+1);
+                $return .= \utilisateur\Fonctions::affiche_cellule_calendrier_echange_absence_saisie_semaine($val_matin, $val_aprem, $year, $mois, $i + 1);
             }
 
-            if ( ($i + $start_nb_day_before ) % 7 == 6)
+            if (($i + $start_nb_day_before) % 7 == 6) {
                 $return .= '<tr>';
+            }
+
         }
 
         $return .= '</tbody>';
@@ -815,35 +836,35 @@ class Fonctions
 
     public static function affiche_cellule_calendrier_echange_absence_saisie_semaine($val_matin, $val_aprem, $year, $mois, $j)
     {
-        $return = '';
-        $bgcolor=$_SESSION['config']['temps_partiel_bgcolor'];
-        if( $val_matin == 'Y' && $val_aprem == 'Y')
-            $return .= '<td bgcolor='.$bgcolor.' class="cal-saisie">'.$j.'<input type="radio" name="new_debut" value="'.$year.'-'.$mois.'-'.$j.'-j"></td>';
-        elseif( $val_matin == 'Y' && $val_aprem == 'N' )
-            $return .= '<td bgcolor='.$bgcolor.' class="cal-day_semaine_rtt_am_travail_pm_w35">'.$j.'<input type="radio" name="new_debut" value="'.$year.'-'.$mois.'-'.$j.'-a"></td>';
-        elseif( $val_matin == 'N' && $val_aprem == 'Y' )
-            $return .= '<td bgcolor='.$bgcolor.' class="cal-day_semaine_travail_am_rtt_pm_w35">'.$j.'<input type="radio" name="new_debut" value="'.$year.'-'.$mois.'-'.$j.'-p"></td>';
-        else {
-            $bgcolor=$_SESSION['config']['semaine_bgcolor'];
-            $return .= '<td bgcolor='.$bgcolor.' class="cal-saisie">'.$j.'</td>';
+        $return  = '';
+        $bgcolor = $_SESSION['config']['temps_partiel_bgcolor'];
+        if ($val_matin == 'Y' && $val_aprem == 'Y') {
+            $return .= '<td bgcolor=' . $bgcolor . ' class="cal-saisie">' . $j . '<input type="radio" name="new_debut" value="' . $year . '-' . $mois . '-' . $j . '-j"></td>';
+        } elseif ($val_matin == 'Y' && $val_aprem == 'N') {
+            $return .= '<td bgcolor=' . $bgcolor . ' class="cal-day_semaine_rtt_am_travail_pm_w35">' . $j . '<input type="radio" name="new_debut" value="' . $year . '-' . $mois . '-' . $j . '-a"></td>';
+        } elseif ($val_matin == 'N' && $val_aprem == 'Y') {
+            $return .= '<td bgcolor=' . $bgcolor . ' class="cal-day_semaine_travail_am_rtt_pm_w35">' . $j . '<input type="radio" name="new_debut" value="' . $year . '-' . $mois . '-' . $j . '-p"></td>';
+        } else {
+            $bgcolor = $_SESSION['config']['semaine_bgcolor'];
+            $return .= '<td bgcolor=' . $bgcolor . ' class="cal-saisie">' . $j . '</td>';
         }
         return $return;
     }
 
     public static function affiche_cellule_calendrier_echange_presence_saisie_semaine($val_matin, $val_aprem, $year, $mois, $j)
     {
-        $return = '';
+        $return  = '';
         $bgcolor = $_SESSION['config']['temps_partiel_bgcolor'];
-        if( $val_matin == 'Y' && $val_aprem == 'Y' )  // rtt le matin et l'apres midi !
-            $return .= '<td bgcolor='.$bgcolor.' class="cal-saisie">'.$j.'</td>';
-        elseif( $val_matin == 'Y' && $val_aprem == 'N' )
-            $return .= '<td bgcolor='.$bgcolor.' class="cal-day_semaine_rtt_am_travail_pm_w35">'.$j.'<input type="radio" name="new_fin" value="'.$year.'-'.$mois.'-'.$j.'-p"></td>';
-        elseif( $val_matin == 'N' && $val_aprem == 'Y' )
-            $return .= '<td bgcolor='.$bgcolor.' class="cal-day_semaine_travail_am_rtt_pm_w35">'.$j.'<input type="radio" name="new_fin" value="'.$year.'-'.$mois.'-'.$j.'-a"></td>';
-        else
+        if ($val_matin == 'Y' && $val_aprem == 'Y') // rtt le matin et l'apres midi !
         {
+            $return .= '<td bgcolor=' . $bgcolor . ' class="cal-saisie">' . $j . '</td>';
+        } elseif ($val_matin == 'Y' && $val_aprem == 'N') {
+            $return .= '<td bgcolor=' . $bgcolor . ' class="cal-day_semaine_rtt_am_travail_pm_w35">' . $j . '<input type="radio" name="new_fin" value="' . $year . '-' . $mois . '-' . $j . '-p"></td>';
+        } elseif ($val_matin == 'N' && $val_aprem == 'Y') {
+            $return .= '<td bgcolor=' . $bgcolor . ' class="cal-day_semaine_travail_am_rtt_pm_w35">' . $j . '<input type="radio" name="new_fin" value="' . $year . '-' . $mois . '-' . $j . '-a"></td>';
+        } else {
             $bgcolor = $_SESSION['config']['semaine_bgcolor'];
-            $return .= '<td bgcolor='.$bgcolor.' class="cal-saisie">'.$j.'<input type="radio" name="new_fin" value="'.$year.'-'.$mois.'-'.$j.'-j"></td>';
+            $return .= '<td bgcolor=' . $bgcolor . ' class="cal-saisie">' . $j . '<input type="radio" name="new_fin" value="' . $year . '-' . $mois . '-' . $j . '-j"></td>';
         }
 
         return $return;
@@ -854,266 +875,234 @@ class Fonctions
         $return = '';
 
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
+        $session  = session_id();
 
-        $duree_demande_1="";
-        $duree_demande_2="";
-        $valid=TRUE;
+        $duree_demande_1 = "";
+        $duree_demande_2 = "";
+        $valid           = true;
 
         // verif si les dates sont renseignées  (si ce n'est pas le cas, on ne verifie meme pas la suite !)
         // $new_debut et $new_fin sont des string au format : $year-$mois-$jour-X  (avec X = j pour "jour entier", a pour "a" (matin), et p pour "pm" (apres midi) )
-        if( ($new_debut_string=="")||($new_fin_string=="") )
-            $valid=FALSE;
-        else
-        {
-            $date_1=explode("-", $new_debut_string);
-            $year_debut=$date_1[0];
-            $mois_debut=$date_1[1];
-            $jour_debut=$date_1[2];
-            $demi_jour_debut=$date_1[3];
+        if (($new_debut_string == "") || ($new_fin_string == "")) {
+            $valid = false;
+        } else {
+            $date_1          = explode("-", $new_debut_string);
+            $year_debut      = $date_1[0];
+            $mois_debut      = $date_1[1];
+            $jour_debut      = $date_1[2];
+            $demi_jour_debut = $date_1[3];
 
-            $new_debut="$year_debut-$mois_debut-$jour_debut";
+            $new_debut = "$year_debut-$mois_debut-$jour_debut";
 
-            $date_2=explode("-", $new_fin_string);
-            $year_fin=$date_2[0];
-            $mois_fin=$date_2[1];
-            $jour_fin=$date_2[2];
-            $demi_jour_fin=$date_2[3];
+            $date_2        = explode("-", $new_fin_string);
+            $year_fin      = $date_2[0];
+            $mois_fin      = $date_2[1];
+            $jour_fin      = $date_2[2];
+            $demi_jour_fin = $date_2[3];
 
-            $new_fin="$year_fin-$mois_fin-$jour_fin";
-
+            $new_fin = "$year_fin-$mois_fin-$jour_fin";
 
             /********************************************/
             // traitement du jour d'absence à remplacer
 
             // verif de la concordance des demandes avec l'existant, et affectation de valeurs à entrer dans la database
-            if($demi_jour_debut=="j") // on est absent la journee
+            if ($demi_jour_debut == "j") // on est absent la journee
             {
-                if($moment_absence_ordinaire=="j") // on demande à etre present tte la journee
+                if ($moment_absence_ordinaire == "j") // on demande à etre present tte la journee
                 {
-                    $nouvelle_presence_date_1="J";
-                    $nouvelle_absence_date_1="N";
-                    $duree_demande_1="jour";
-                }
-                elseif($moment_absence_ordinaire=="a") // on demande à etre present le matin
+                    $nouvelle_presence_date_1 = "J";
+                    $nouvelle_absence_date_1  = "N";
+                    $duree_demande_1          = "jour";
+                } elseif ($moment_absence_ordinaire == "a") // on demande à etre present le matin
                 {
-                    $nouvelle_presence_date_1="M";
-                    $nouvelle_absence_date_1="A";
-                    $duree_demande_1="demi";
-                }
-                elseif($moment_absence_ordinaire=="p") // on demande à etre present l'aprem
+                    $nouvelle_presence_date_1 = "M";
+                    $nouvelle_absence_date_1  = "A";
+                    $duree_demande_1          = "demi";
+                } elseif ($moment_absence_ordinaire == "p") // on demande à etre present l'aprem
                 {
-                    $nouvelle_presence_date_1="A";
-                    $nouvelle_absence_date_1="M";
-                    $duree_demande_1="demi";
+                    $nouvelle_presence_date_1 = "A";
+                    $nouvelle_absence_date_1  = "M";
+                    $duree_demande_1          = "demi";
                 }
-            }
-            elseif($demi_jour_debut=="a") // on est absent le matin
+            } elseif ($demi_jour_debut == "a") // on est absent le matin
             {
-                if($moment_absence_ordinaire=="j") // on demande à etre present tte la journee
+                if ($moment_absence_ordinaire == "j") // on demande à etre present tte la journee
                 {
-                    $nouvelle_presence_date_1="J";
-                    $nouvelle_absence_date_1="N";
-                    $duree_demande_1="demi";
-                }
-                elseif($moment_absence_ordinaire=="a") // on demande à etre present le matin
+                    $nouvelle_presence_date_1 = "J";
+                    $nouvelle_absence_date_1  = "N";
+                    $duree_demande_1          = "demi";
+                } elseif ($moment_absence_ordinaire == "a") // on demande à etre present le matin
                 {
-                    if($new_debut==$new_fin) // dans ce cas, on veut intervertir 2 demi-journées
+                    if ($new_debut == $new_fin) // dans ce cas, on veut intervertir 2 demi-journées
                     {
-                        $nouvelle_presence_date_1="M";
-                        $nouvelle_absence_date_1="A";
+                        $nouvelle_presence_date_1 = "M";
+                        $nouvelle_absence_date_1  = "A";
+                    } else {
+                        $nouvelle_presence_date_1 = "J";
+                        $nouvelle_absence_date_1  = "N";
                     }
-                    else
-                    {
-                        $nouvelle_presence_date_1="J";
-                        $nouvelle_absence_date_1="N";
-                    }
-                    $duree_demande_1="demi";
-                }
-                elseif($moment_absence_ordinaire=="p") // on demande à etre present l'aprem
+                    $duree_demande_1 = "demi";
+                } elseif ($moment_absence_ordinaire == "p") // on demande à etre present l'aprem
                 {
-                    $valid=FALSE;
+                    $valid = false;
                 }
-            }
-            elseif($demi_jour_debut=="p") // on est absent l'aprem
+            } elseif ($demi_jour_debut == "p") // on est absent l'aprem
             {
-                if($moment_absence_ordinaire=="j") // on demande à etre present tte la journee
+                if ($moment_absence_ordinaire == "j") // on demande à etre present tte la journee
                 {
-                    $nouvelle_presence_date_1="J";
-                    $nouvelle_absence_date_1="N";
-                    $duree_demande_1="demi";
-                }
-                elseif($moment_absence_ordinaire=="a") // on demande à etre present le matin
+                    $nouvelle_presence_date_1 = "J";
+                    $nouvelle_absence_date_1  = "N";
+                    $duree_demande_1          = "demi";
+                } elseif ($moment_absence_ordinaire == "a") // on demande à etre present le matin
                 {
-                    $valid=FALSE;
-                }
-                elseif($moment_absence_ordinaire=="p") // on demande à etre present l'aprem
+                    $valid = false;
+                } elseif ($moment_absence_ordinaire == "p") // on demande à etre present l'aprem
                 {
-                    if($new_debut==$new_fin) // dans ce cas, on veut intervertir 2 demi-journées
+                    if ($new_debut == $new_fin) // dans ce cas, on veut intervertir 2 demi-journées
                     {
-                        $nouvelle_presence_date_1="A";
-                        $nouvelle_absence_date_1="M";
+                        $nouvelle_presence_date_1 = "A";
+                        $nouvelle_absence_date_1  = "M";
+                    } else {
+                        $nouvelle_presence_date_1 = "J";
+                        $nouvelle_absence_date_1  = "N";
                     }
-                    else
-                    {
-                        $nouvelle_presence_date_1="J";
-                        $nouvelle_absence_date_1="N";
-                    }
-                    $duree_demande_1="demi";
+                    $duree_demande_1 = "demi";
                 }
+            } else {
+                $valid = false;
             }
-            else
-                $valid=FALSE;
-
 
             /**********************************************/
             // traitement du jour de présence à remplacer
 
             // verif de la concordance des demandes avec l'existant, et affectation de valeurs à entrer dans la database
-            if($demi_jour_fin=="j") // on est present la journee
+            if ($demi_jour_fin == "j") // on est present la journee
             {
-                if($moment_absence_souhaitee=="j") // on demande à etre absent tte la journee
+                if ($moment_absence_souhaitee == "j") // on demande à etre absent tte la journee
                 {
-                    $nouvelle_presence_date_2="N";
-                    $nouvelle_absence_date_2="J";
-                    $duree_demande_2="jour";
-                }
-                elseif($moment_absence_souhaitee=="a") // on demande à etre absent le matin
+                    $nouvelle_presence_date_2 = "N";
+                    $nouvelle_absence_date_2  = "J";
+                    $duree_demande_2          = "jour";
+                } elseif ($moment_absence_souhaitee == "a") // on demande à etre absent le matin
                 {
-                    $nouvelle_presence_date_2="A";
-                    $nouvelle_absence_date_2="M";
-                    $duree_demande_2="demi";
-                }
-                elseif($moment_absence_souhaitee=="p") // on demande à etre absent l'aprem
+                    $nouvelle_presence_date_2 = "A";
+                    $nouvelle_absence_date_2  = "M";
+                    $duree_demande_2          = "demi";
+                } elseif ($moment_absence_souhaitee == "p") // on demande à etre absent l'aprem
                 {
-                    $nouvelle_presence_date_2="M";
-                    $nouvelle_absence_date_2="A";
-                    $duree_demande_2="demi";
+                    $nouvelle_presence_date_2 = "M";
+                    $nouvelle_absence_date_2  = "A";
+                    $duree_demande_2          = "demi";
                 }
-            }
-            elseif($demi_jour_fin=="a") // on est present le matin
+            } elseif ($demi_jour_fin == "a") // on est present le matin
             {
-                if($moment_absence_souhaitee=="j") // on demande à etre absent tte la journee
+                if ($moment_absence_souhaitee == "j") // on demande à etre absent tte la journee
                 {
-                    $nouvelle_presence_date_2="N";
-                    $nouvelle_absence_date_2="J";
-                    $duree_demande_2="demi";
-                }
-                elseif($moment_absence_souhaitee=="a") // on demande à etre absent le matin
+                    $nouvelle_presence_date_2 = "N";
+                    $nouvelle_absence_date_2  = "J";
+                    $duree_demande_2          = "demi";
+                } elseif ($moment_absence_souhaitee == "a") // on demande à etre absent le matin
                 {
-                    if($new_debut==$new_fin) // dans ce cas, on veut intervertir 2 demi-journées
+                    if ($new_debut == $new_fin) // dans ce cas, on veut intervertir 2 demi-journées
                     {
-                        $nouvelle_presence_date_2="A";
-                        $nouvelle_absence_date_2="M";
+                        $nouvelle_presence_date_2 = "A";
+                        $nouvelle_absence_date_2  = "M";
+                    } else {
+                        $nouvelle_presence_date_2 = "N";
+                        $nouvelle_absence_date_2  = "j";
                     }
-                    else
-                    {
-                        $nouvelle_presence_date_2="N";
-                        $nouvelle_absence_date_2="j";
-                    }
-                    $duree_demande_2="demi";
-                }
-                elseif($moment_absence_souhaitee=="p") // on demande à etre absent l'aprem
+                    $duree_demande_2 = "demi";
+                } elseif ($moment_absence_souhaitee == "p") // on demande à etre absent l'aprem
                 {
-                    $valid=FALSE;
+                    $valid = false;
                 }
-            }
-            elseif($demi_jour_fin=="p") // on est present l'aprem
+            } elseif ($demi_jour_fin == "p") // on est present l'aprem
             {
-                if($moment_absence_souhaitee=="j") // on demande à etre absent tte la journee
+                if ($moment_absence_souhaitee == "j") // on demande à etre absent tte la journee
                 {
-                    $nouvelle_presence_date_2="N";
-                    $nouvelle_absence_date_2="J";
-                    $duree_demande_2="demi";
-                }
-                elseif($moment_absence_souhaitee=="a") // on demande à etre absent le matin
+                    $nouvelle_presence_date_2 = "N";
+                    $nouvelle_absence_date_2  = "J";
+                    $duree_demande_2          = "demi";
+                } elseif ($moment_absence_souhaitee == "a") // on demande à etre absent le matin
                 {
-                    $valid=FALSE;
-                }
-                elseif($moment_absence_souhaitee=="p") // on demande à etre absent l'aprem
+                    $valid = false;
+                } elseif ($moment_absence_souhaitee == "p") // on demande à etre absent l'aprem
                 {
-                    if($new_debut==$new_fin) // dans ce cas, on veut intervertir 2 demi-journées
+                    if ($new_debut == $new_fin) // dans ce cas, on veut intervertir 2 demi-journées
                     {
-                        $nouvelle_presence_date_2="M";
-                        $nouvelle_absence_date_2="A";
+                        $nouvelle_presence_date_2 = "M";
+                        $nouvelle_absence_date_2  = "A";
+                    } else {
+                        $nouvelle_presence_date_2 = "N";
+                        $nouvelle_absence_date_2  = "J";
                     }
-                    else
-                    {
-                        $nouvelle_presence_date_2="N";
-                        $nouvelle_absence_date_2="J";
-                    }
-                    $duree_demande_2="demi";
+                    $duree_demande_2 = "demi";
                 }
+            } else {
+                $valid = false;
             }
-            else
-            {
-                $valid=FALSE;
-            }
-
 
             // verif de la concordance des durée (journée avec journée ou 1/2 journée avec1/2 journée)
-            if( ($duree_demande_1=="") || ($duree_demande_2=="") || ($duree_demande_1!=$duree_demande_2) )
-                $valid=FALSE;
+            if (($duree_demande_1 == "") || ($duree_demande_2 == "") || ($duree_demande_1 != $duree_demande_2)) {
+                $valid = false;
+            }
+
         }
 
-
-
-        if($valid) {
+        if ($valid) {
             $return .= schars($_SESSION['userlogin']) . ' --- ' . schars($new_debut) . ' --- ' . schars($new_fin) . ' --- ' . schars($new_comment) . '<br>';
 
             // insert du jour d'absence ordinaire (qui n'en sera plus un ou qu'a moitie ...)
             // e_presence = N (non) , J (jour entier) , M (matin) ou A (apres-midi)
             // verif si le couple user/date1 existe dans conges_echange_rtt ...
-            $sql_verif_echange1='SELECT e_absence, e_presence from conges_echange_rtt WHERE e_login="'. \includes\SQL::quote($_SESSION['userlogin']).'" AND e_date_jour="'. \includes\SQL::quote($new_debut).'";';
-            $result_verif_echange1 = \includes\SQL::query($sql_verif_echange1) ;
+            $sql_verif_echange1    = 'SELECT e_absence, e_presence from conges_echange_rtt WHERE e_login="' . \includes\SQL::quote($_SESSION['userlogin']) . '" AND e_date_jour="' . \includes\SQL::quote($new_debut) . '";';
+            $result_verif_echange1 = \includes\SQL::query($sql_verif_echange1);
 
-            $count_verif_echange1=$result_verif_echange1->num_rows;
+            $count_verif_echange1 = $result_verif_echange1->num_rows;
 
             // si le couple user/date1 existe dans conges_echange_rtt : on update
-            if($count_verif_echange1!=0) {
-                $new_comment=addslashes($new_comment);
+            if ($count_verif_echange1 != 0) {
+                $new_comment = addslashes($new_comment);
                 //$resultat1=$result_verif_echange1->fetch_array();
                 //if($resultatverif_echange1['e_absence'] == 'N' )
                 $sql1 = 'UPDATE conges_echange_rtt
-                    SET e_absence=\''.$nouvelle_absence_date_1.'\', e_presence=\''.$nouvelle_presence_date_1.'\', e_comment=\''.$new_comment.'\'
-                    WHERE e_login=\''.$_SESSION['userlogin'].'\' AND e_date_jour="'. \includes\SQL::quote($new_debut).'"  ';
-            }
-            else // sinon : on insert
+                    SET e_absence=\'' . $nouvelle_absence_date_1 . '\', e_presence=\'' . $nouvelle_presence_date_1 . '\', e_comment=\'' . $new_comment . '\'
+                    WHERE e_login=\'' . $_SESSION['userlogin'] . '\' AND e_date_jour="' . \includes\SQL::quote($new_debut) . '"  ';
+            } else // sinon : on insert
             {
                 $sql1 = "INSERT into conges_echange_rtt (e_login, e_date_jour, e_absence, e_presence, e_comment)
-                    VALUES ('".$_SESSION['userlogin']."','$new_debut','$nouvelle_absence_date_1', '$nouvelle_presence_date_1', '$new_comment')" ;
+                    VALUES ('" . $_SESSION['userlogin'] . "','$new_debut','$nouvelle_absence_date_1', '$nouvelle_presence_date_1', '$new_comment')";
             }
             $result1 = \includes\SQL::query($sql1);
 
             // insert du jour d'absence souhaité (qui en devient un)
             // e_absence = N (non) , J (jour entier) , M (matin) ou A (apres-midi)
             // verif si le couple user/date2 existe dans conges_echange_rtt ...
-            $sql_verif_echange2='SELECT e_absence, e_presence from conges_echange_rtt WHERE e_login="'.\includes\SQL::quote($_SESSION['userlogin']).'" AND e_date_jour="'. \includes\SQL::quote($new_fin).'";';
+            $sql_verif_echange2    = 'SELECT e_absence, e_presence from conges_echange_rtt WHERE e_login="' . \includes\SQL::quote($_SESSION['userlogin']) . '" AND e_date_jour="' . \includes\SQL::quote($new_fin) . '";';
             $result_verif_echange2 = \includes\SQL::query($sql_verif_echange2);
 
-            $count_verif_echange2=$result_verif_echange2->num_rows;
+            $count_verif_echange2 = $result_verif_echange2->num_rows;
 
             // si le couple user/date2 existe dans conges_echange_rtt : on update
-            if($count_verif_echange2!=0) {
+            if ($count_verif_echange2 != 0) {
                 $sql2 = 'UPDATE conges_echange_rtt
-                    SET e_absence=\''.$nouvelle_absence_date_2.'\', e_presence=\''.$nouvelle_presence_date_2.'\', e_comment=\''.$new_comment.'\'
-                    WHERE e_login=\''.$_SESSION['userlogin'].'\' AND e_date_jour=\''.$new_fin.'\' ';
-            }
-            else // sinon: on insert
+                    SET e_absence=\'' . $nouvelle_absence_date_2 . '\', e_presence=\'' . $nouvelle_presence_date_2 . '\', e_comment=\'' . $new_comment . '\'
+                    WHERE e_login=\'' . $_SESSION['userlogin'] . '\' AND e_date_jour=\'' . $new_fin . '\' ';
+            } else // sinon: on insert
             {
                 $sql2 = "INSERT into conges_echange_rtt (e_login, e_date_jour, e_absence, e_presence, e_comment)
-                    VALUES ('".$_SESSION['userlogin']."','$new_fin','$nouvelle_absence_date_2', '$nouvelle_presence_date_2', '$new_comment')" ;
+                    VALUES ('" . $_SESSION['userlogin'] . "','$new_fin','$nouvelle_absence_date_2', '$nouvelle_presence_date_2', '$new_comment')";
             }
-            $result2 = \includes\SQL::query($sql2) ;
+            $result2 = \includes\SQL::query($sql2);
 
             $comment_log = "echange absence - rtt  ($new_debut_string / $new_fin_string)";
             log_action(0, "", $_SESSION['userlogin'], $comment_log);
 
-
-            if(($result1)&&($result2))
+            if (($result1) && ($result2)) {
                 $return .= 'Changements pris en compte avec succes !<br><br>';
-            else
+            } else {
                 $return .= 'ERREUR ! Une erreur s\'est produite : contactez votre responsable !<br><br>';
+            }
 
         } else {
             $return .= 'ERREUR ! Les valeurs saisies sont invalides ou manquantes  !!!<br><br>';
@@ -1130,15 +1119,19 @@ class Fonctions
     //affiche le formulaire d'échange d'un jour de rtt-temps partiel / jour travaillé
     public static function saisie_echange_rtt($user_login, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $onglet)
     {
-        $return = '';
-        $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
-        $mois_calendrier_saisie_debut_prec=0; $year_calendrier_saisie_debut_prec=0;
-        $mois_calendrier_saisie_debut_suiv=0; $year_calendrier_saisie_debut_suiv=0;
-        $mois_calendrier_saisie_fin_prec=0; $year_calendrier_saisie_fin_prec=0;
-        $mois_calendrier_saisie_fin_suiv=0; $year_calendrier_saisie_fin_suiv=0;
+        $return                            = '';
+        $PHP_SELF                          = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
+        $session                           = session_id();
+        $mois_calendrier_saisie_debut_prec = 0;
+        $year_calendrier_saisie_debut_prec = 0;
+        $mois_calendrier_saisie_debut_suiv = 0;
+        $year_calendrier_saisie_debut_suiv = 0;
+        $mois_calendrier_saisie_fin_prec   = 0;
+        $year_calendrier_saisie_fin_prec   = 0;
+        $mois_calendrier_saisie_fin_suiv   = 0;
+        $year_calendrier_saisie_fin_suiv   = 0;
 
-        $return .= '<form action="'.$PHP_SELF.'?session='.$session.'&&onglet='.$onglet.'" method="POST">' ;
+        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&&onglet=' . $onglet . '" method="POST">';
 
         $return .= '<table class="table table condensed">';
         $return .= '<tr align="center">';
@@ -1148,22 +1141,22 @@ class Fonctions
         $return .= '<table class="table table-bordered table-calendar">';
         $return .= '<tr>';
         init_var_navigation_mois_year($mois_calendrier_saisie_debut, $year_calendrier_saisie_debut,
-                $mois_calendrier_saisie_debut_prec, $year_calendrier_saisie_debut_prec,
-                $mois_calendrier_saisie_debut_suiv, $year_calendrier_saisie_debut_suiv,
-                $mois_calendrier_saisie_fin, $year_calendrier_saisie_fin,
-                $mois_calendrier_saisie_fin_prec, $year_calendrier_saisie_fin_prec,
-                $mois_calendrier_saisie_fin_suiv, $year_calendrier_saisie_fin_suiv );
+            $mois_calendrier_saisie_debut_prec, $year_calendrier_saisie_debut_prec,
+            $mois_calendrier_saisie_debut_suiv, $year_calendrier_saisie_debut_suiv,
+            $mois_calendrier_saisie_fin, $year_calendrier_saisie_fin,
+            $mois_calendrier_saisie_fin_prec, $year_calendrier_saisie_fin_prec,
+            $mois_calendrier_saisie_fin_suiv, $year_calendrier_saisie_fin_suiv);
 
         // affichage des boutons de défilement
         // recul du mois saisie debut
         $return .= '<td align="center">';
-        $return .= '<a href="' . $PHP_SELF . '?session=' . $session . '&year_calendrier_saisie_debut=' . $year_calendrier_saisie_debut_prec . '&mois_calendrier_saisie_debut=' . $mois_calendrier_saisie_debut_prec . '&year_calendrier_saisie_fin=' . $year_calendrier_saisie_fin . '&mois_calendrier_saisie_fin=' . $mois_calendrier_saisie_fin . '&user_login=' . $user_login . '&onglet=' .$onglet . '">';
+        $return .= '<a href="' . $PHP_SELF . '?session=' . $session . '&year_calendrier_saisie_debut=' . $year_calendrier_saisie_debut_prec . '&mois_calendrier_saisie_debut=' . $mois_calendrier_saisie_debut_prec . '&year_calendrier_saisie_fin=' . $year_calendrier_saisie_fin . '&mois_calendrier_saisie_fin=' . $mois_calendrier_saisie_fin . '&user_login=' . $user_login . '&onglet=' . $onglet . '">';
         $return .= '<i class="fa fa-chevron-circle-left"></i>';
         $return .= '</a>';
         $return .= '</td>';
 
         // titre du calendrier de saisie du jour d'absence
-        $return .= '<td align="center">'. _('saisie_echange_titre_calendrier_1') . '</td>';
+        $return .= '<td align="center">' . _('saisie_echange_titre_calendrier_1') . '</td>';
 
         // affichage des boutons de défilement
         // avance du mois saisie debut
@@ -1184,22 +1177,22 @@ class Fonctions
 
         // cellule 2 : boutons radio 1/2 journée ou jour complet
         $return .= '<td class="day-period">';
-        $return .= '<div><input type="radio" name="moment_absence_ordinaire" value="a"><label>'. _('form_am') .'</label><input type="radio" name="moment_absence_souhaitee" value="a"></div>';
-        $return .= '<input type="radio" name="moment_absence_ordinaire" value="p"><label>'. _('form_pm') .'</label><input type="radio" name="moment_absence_souhaitee" value="p"></div>';
-        $return .= '<div><input type="radio" name="moment_absence_ordinaire" value="j" checked><label>'. _('form_day') .'</label><input type="radio" name="moment_absence_souhaitee" value="j" checked></div>';
+        $return .= '<div><input type="radio" name="moment_absence_ordinaire" value="a"><label>' . _('form_am') . '</label><input type="radio" name="moment_absence_souhaitee" value="a"></div>';
+        $return .= '<input type="radio" name="moment_absence_ordinaire" value="p"><label>' . _('form_pm') . '</label><input type="radio" name="moment_absence_souhaitee" value="p"></div>';
+        $return .= '<div><input type="radio" name="moment_absence_ordinaire" value="j" checked><label>' . _('form_day') . '</label><input type="radio" name="moment_absence_souhaitee" value="j" checked></div>';
         $return .= '</td>';
 
         // cellule 3 : calendrier de saisie du jour d'absence
         $return .= '<td class="cell-top">';
         $return .= '<table class="table table-bordered table-calendar">';
         $return .= '<tr>';
-        $mois_calendrier_saisie_fin_prec = $mois_calendrier_saisie_fin==1 ? 12 : $mois_calendrier_saisie_fin-1 ;
-        $mois_calendrier_saisie_fin_suiv = $mois_calendrier_saisie_fin==12 ? 1 : $mois_calendrier_saisie_fin+1 ;
+        $mois_calendrier_saisie_fin_prec = $mois_calendrier_saisie_fin == 1 ? 12 : $mois_calendrier_saisie_fin - 1;
+        $mois_calendrier_saisie_fin_suiv = $mois_calendrier_saisie_fin == 12 ? 1 : $mois_calendrier_saisie_fin + 1;
 
         // affichage des boutons de défilement
         // recul du mois saisie fin
         $return .= '<td align="center">';
-        $return .= '<a href="'.$PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_debut.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_debut.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_fin_prec.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_fin_prec.'&user_login='.$user_login.'&onglet='.$onglet.'">';
+        $return .= '<a href="' . $PHP_SELF . '?session=' . $session . '&year_calendrier_saisie_debut=' . $year_calendrier_saisie_debut . '&mois_calendrier_saisie_debut=' . $mois_calendrier_saisie_debut . '&year_calendrier_saisie_fin=' . $year_calendrier_saisie_fin_prec . '&mois_calendrier_saisie_fin=' . $mois_calendrier_saisie_fin_prec . '&user_login=' . $user_login . '&onglet=' . $onglet . '">';
         $return .= '<i class="fa fa-chevron-circle-left"></i>';
         $return .= '</a>';
         $return .= '</td>';
@@ -1210,7 +1203,7 @@ class Fonctions
         // affichage des boutons de défilement
         // avance du mois saisie fin
         $return .= '<td align="center">';
-        $return .= '<a href="'.$PHP_SELF.'?session='.$session.'&year_calendrier_saisie_debut='.$year_calendrier_saisie_debut.'&mois_calendrier_saisie_debut='.$mois_calendrier_saisie_debut.'&year_calendrier_saisie_fin='.$year_calendrier_saisie_fin_suiv.'&mois_calendrier_saisie_fin='.$mois_calendrier_saisie_fin_suiv.'&user_login='.$user_login.'&onglet='.$onglet.'">';
+        $return .= '<a href="' . $PHP_SELF . '?session=' . $session . '&year_calendrier_saisie_debut=' . $year_calendrier_saisie_debut . '&mois_calendrier_saisie_debut=' . $mois_calendrier_saisie_debut . '&year_calendrier_saisie_fin=' . $year_calendrier_saisie_fin_suiv . '&mois_calendrier_saisie_fin=' . $mois_calendrier_saisie_fin_suiv . '&user_login=' . $user_login . '&onglet=' . $onglet . '">';
         $return .= '<i class="fa fa-chevron-circle-right"></i>';
         $return .= '</a>';
         $return .= '</td>';
@@ -1227,13 +1220,13 @@ class Fonctions
         $return .= '</table>';
         $return .= "<hr/>\n";
         // cellule 1 : champs texte et boutons (valider/cancel)
-        $return .= '<label>'. _('divers_comment_maj_1') .'</label><input class="form-control" type="text" name="new_comment" size="25" maxlength="30" value="">';
+        $return .= '<label>' . _('divers_comment_maj_1') . '</label><input class="form-control" type="text" name="new_comment" size="25" maxlength="30" value="">';
         $return .= "<hr/>\n";
-        $return .= '<input type="hidden" name="user_login" value="'.schars($user_login).'">';
+        $return .= '<input type="hidden" name="user_login" value="' . schars($user_login) . '">';
         $return .= '<input type="hidden" name="new_echange_rtt" value=1>';
-        $return .= '<input class="btn btn-success" type="submit" value="'. _('form_submit') .'">';
-        $return .= "<a class=\"btn\" href=\"$PHP_SELF?session=$session\">". _('form_cancel') ."</a>\n";
-        $return .= '</form>' ;
+        $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
+        $return .= "<a class=\"btn\" href=\"$PHP_SELF?session=$session\">" . _('form_cancel') . "</a>\n";
+        $return .= '</form>';
 
         return $return;
     }
@@ -1252,9 +1245,9 @@ class Fonctions
         $return = '';
         init_tab_jours_feries();
 
-        $new_echange_rtt    = getpost_variable('new_echange_rtt', 0);
+        $new_echange_rtt = getpost_variable('new_echange_rtt', 0);
 
-        if( $new_echange_rtt == 1 && $_SESSION['config']['user_echange_rtt'] ) {
+        if ($new_echange_rtt == 1 && $_SESSION['config']['user_echange_rtt']) {
 
             $new_debut                = getpost_variable('new_debut');
             $new_fin                  = getpost_variable('new_fin');
@@ -1270,7 +1263,7 @@ class Fonctions
             $year_calendrier_saisie_fin   = getpost_variable('year_calendrier_saisie_fin', date('Y'));
             $mois_calendrier_saisie_fin   = getpost_variable('mois_calendrier_saisie_fin', date('m'));
 
-            $return .= '<h1>'. _('user_echange_rtt') .'</h1>';
+            $return .= '<h1>' . _('user_echange_rtt') . '</h1>';
             if (!\utilisateur\Fonctions::hasUserPlanning($_SESSION['userlogin'])) {
                 $return .= '<div class="alert alert-danger">' . _('aucun_planning_associe_utilisateur') . '</div>';
 
@@ -1317,17 +1310,17 @@ class Fonctions
     public static function getUserPlanning($user)
     {
         $dataPlanning = null;
-        $sql = \includes\SQL::singleton();
-        $reqUser = 'SELECT planning.*
+        $sql          = \includes\SQL::singleton();
+        $reqUser      = 'SELECT planning.*
             FROM conges_users
                 INNER JOIN planning USING (planning_id)
             WHERE u_login = "' . $sql->quote($user) . '"
                 AND planning.status = ' . \App\Models\Planning::STATUS_ACTIVE;
         $queryUser = $sql->query($reqUser);
-        $planning = $queryUser->fetch_array();
+        $planning  = $queryUser->fetch_array();
         if (!empty($planning)) {
             $dataPlanning = [];
-            $reqCreneau = 'SELECT *
+            $reqCreneau   = 'SELECT *
                 FROM planning_creneau
                 WHERE planning_id = ' . $planning['planning_id'];
             $queryCreneau = $sql->query($reqCreneau);
@@ -1354,8 +1347,8 @@ class Fonctions
     public static function getRealWeekType(array $planningUser, $weekOfDay)
     {
         $typeSemaineDuJour = ($weekOfDay & 1)
-            ? \App\Models\Planning\Creneau::TYPE_SEMAINE_IMPAIRE
-            : \App\Models\Planning\Creneau::TYPE_SEMAINE_PAIRE;
+        ? \App\Models\Planning\Creneau::TYPE_SEMAINE_IMPAIRE
+        : \App\Models\Planning\Creneau::TYPE_SEMAINE_PAIRE;
         if (isset($planningUser[$typeSemaineDuJour])) {
             return $typeSemaineDuJour;
         } elseif (isset($planningUser[\App\Models\Planning\Creneau::TYPE_SEMAINE_COMMUNE])) {
@@ -1377,7 +1370,7 @@ class Fonctions
     }
 
     /**
-    * Vérifie qu'une matinée est travaillée pour un jour de planning donné
+     * Vérifie qu'une matinée est travaillée pour un jour de planning donné
      *
      * @param array $planningDay
      *
@@ -1442,7 +1435,7 @@ class Fonctions
      */
     public static function getDatePickerJoursFeries()
     {
-        $Jferies      = [];
+        $Jferies = [];
 
         if (is_array($_SESSION["tab_j_feries"])) {
             foreach ($_SESSION["tab_j_feries"] as $date) {
@@ -1462,7 +1455,7 @@ class Fonctions
      */
     public static function getDatePickerFermeture()
     {
-        $Fermeture      = [];
+        $Fermeture = [];
 
         if (isset($_SESSION["tab_j_fermeture"]) && is_array($_SESSION["tab_j_fermeture"])) {
             foreach ($_SESSION["tab_j_fermeture"] as $date) {
@@ -1485,18 +1478,17 @@ class Fonctions
         return ($_SESSION['config']['interdit_saisie_periode_date_passee']) ? 'd' : '';
     }
 
-
     // --------------------------------------
 
     /*
-    * TODO: Où sont passées les heures validées (!= en cours donc) ?
-    */
+     * TODO: Où sont passées les heures validées (!= en cours donc) ?
+     */
 
     public static function getOptionsTypeConges()
     {
         $options = [];
-        $sql = \includes\SQL::singleton();
-        $req = 'SELECT ta_libelle, ta_short_libelle
+        $sql     = \includes\SQL::singleton();
+        $req     = 'SELECT ta_libelle, ta_short_libelle
                 FROM conges_type_absence';
         $res = $sql->query($req);
 

--- a/utilisateur/user_changer_mot_de_passe.php
+++ b/utilisateur/user_changer_mot_de_passe.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \utilisateur\Fonctions::modificationMotDePasseModule($onglet);

--- a/utilisateur/user_echange_jour_absence.php
+++ b/utilisateur/user_echange_jour_absence.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \utilisateur\Fonctions::echangeJourAbsenceModule($onglet);

--- a/utilisateur/user_index.php
+++ b/utilisateur/user_index.php
@@ -3,15 +3,15 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session = (isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()));
 
-include_once ROOT_PATH .'fonctions_conges.php' ;
-include_once INCLUDE_PATH .'fonction.php';
-include_once INCLUDE_PATH .'session.php';
-include_once ROOT_PATH .'fonctions_calcul.php';
+include_once ROOT_PATH . 'fonctions_conges.php';
+include_once INCLUDE_PATH . 'fonction.php';
+include_once INCLUDE_PATH . 'session.php';
+include_once ROOT_PATH . 'fonctions_calcul.php';
 
-if ($_SESSION['config']['where_to_find_user_email']=="ldap") {
-    include CONFIG_PATH .'config_ldap.php';
+if ($_SESSION['config']['where_to_find_user_email'] == "ldap") {
+    include CONFIG_PATH . 'config_ldap.php';
 }
 
 // SERVER
@@ -19,36 +19,35 @@ $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 // GET / POST
 $onglet = getpost_variable('onglet');
 
-
 /*********************************/
 /*   COMPOSITION DES ONGLETS...  */
 /*********************************/
 
 $onglets = array();
 
-if( $_SESSION['config']['user_saisie_demande'] || $_SESSION['config']['user_saisie_mission'] ) {
+if ($_SESSION['config']['user_saisie_demande'] || $_SESSION['config']['user_saisie_mission']) {
     $onglets['nouvelle_absence'] = _('divers_nouvelle_absence');
 }
 
-if( $_SESSION['config']['user_echange_rtt'] ) {
+if ($_SESSION['config']['user_echange_rtt']) {
     $onglets['echange_jour_absence'] = _('user_onglet_echange_abs');
 }
 
 $onglets['liste_conge'] = _('user_liste_conge');
-if( $_SESSION['config']['user_saisie_demande'] || $_SESSION['config']['user_saisie_mission'] ) {
+if ($_SESSION['config']['user_saisie_demande'] || $_SESSION['config']['user_saisie_mission']) {
     $onglets['ajout_heure_repos'] = _('divers_ajout_heure_repos');
 }
 $onglets['liste_heure_repos'] = _('user_liste_heure_repos');
-if( $_SESSION['config']['user_saisie_demande'] || $_SESSION['config']['user_saisie_mission'] ) {
+if ($_SESSION['config']['user_saisie_demande'] || $_SESSION['config']['user_saisie_mission']) {
     $onglets['ajout_heure_additionnelle'] = _('divers_ajout_heure_additionnelle');
 }
 $onglets['liste_heure_additionnelle'] = _('user_liste_heure_additionnelle');
 
-if( $_SESSION['config']['auth'] && $_SESSION['config']['user_ch_passwd'] ) {
+if ($_SESSION['config']['auth'] && $_SESSION['config']['user_ch_passwd']) {
     $onglets['changer_mot_de_passe'] = _('user_onglet_change_passwd');
 }
 
-if ( !isset($onglets[ $onglet ]) && !in_array($onglet, array('modif_demande','suppr_demande','modif_heure_repos', 'modif_heure_additionnelle'))) {
+if (!isset($onglets[$onglet]) && !in_array($onglet, array('modif_demande', 'suppr_demande', 'modif_heure_repos', 'modif_heure_additionnelle'))) {
     $onglet = 'nouvelle_absence';
 }
 
@@ -56,30 +55,28 @@ if ( !isset($onglets[ $onglet ]) && !in_array($onglet, array('modif_demande','su
 /*   COMPOSITION DU HEADER...    */
 /*********************************/
 
-$add_css = '<style>#onglet_menu .onglet{ width: '. (str_replace(',', '.', 100 / count($onglets) )).'% ;}</style>';
-header_menu('','Libertempo : '._('user'),$add_css);
-
+$add_css = '<style>#onglet_menu .onglet{ width: ' . (str_replace(',', '.', 100 / count($onglets))) . '% ;}</style>';
+header_menu('', 'Libertempo : ' . _('user'), $add_css);
 
 /*********************************/
 /*   AFFICHAGE DES ONGLETS...  */
 /*********************************/
 
 echo '<div id="onglet_menu">';
-foreach($onglets as $key => $title) {
-    echo '<div class="onglet '.($onglet == $key ? ' active': '').'" >
-        <a href="'.$PHP_SELF.'?session='.$session.'&onglet='.$key.'">'. $title .'</a>
+foreach ($onglets as $key => $title) {
+    echo '<div class="onglet ' . ($onglet == $key ? ' active' : '') . '" >
+        <a href="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $key . '">' . $title . '</a>
     </div>';
 }
 echo '</div>';
-
 
 /*********************************/
 /*   AFFICHAGE DU RECAP ...    */
 /*********************************/
 
 echo "<div class=\"wrapper\">\n";
-echo '<h3>'._('tableau_recap').'</h3>';
-echo affiche_tableau_bilan_conges_user( $_SESSION['userlogin'] );
+echo '<h3>' . _('tableau_recap') . '</h3>';
+echo affiche_tableau_bilan_conges_user($_SESSION['userlogin']);
 echo "<hr/>\n";
 echo "</div>\n";
 
@@ -87,8 +84,8 @@ echo "</div>\n";
 /*   AFFICHAGE DE L'ONGLET ...    */
 /*********************************/
 
-echo '<div class="'.$onglet.' wrapper">';
-include ROOT_PATH . 'utilisateur/user_'.$onglet.'.php';
+echo '<div class="' . $onglet . ' wrapper">';
+include ROOT_PATH . 'utilisateur/user_' . $onglet . '.php';
 echo '</div>';
 
 /*********************************/

--- a/utilisateur/user_liste_heure_additionnelle.php
+++ b/utilisateur/user_liste_heure_additionnelle.php
@@ -13,7 +13,7 @@ dans un but spécifique. Reportez-vous à la Licence Publique Générale GNU pou
 Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps
 que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation,
 Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, États-Unis.
-*************************************************************************************************
+ *************************************************************************************************
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU General Public License as published by the Free Software Foundation; either
 version 2 of the License, or any later version.
@@ -23,7 +23,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-*************************************************************************************************/
+ *************************************************************************************************/
 defined('_PHP_CONGES') or die('Restricted access');
 $additionnelle = new \App\ProtoControllers\Employe\Heure\Additionnelle();
 echo $additionnelle->getListe();

--- a/utilisateur/user_modif_demande.php
+++ b/utilisateur/user_modif_demande.php
@@ -1,3 +1,3 @@
 <?php
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \utilisateur\Fonctions::modificationAbsenceModule();

--- a/utilisateur/user_modif_heure_additionnelle.php
+++ b/utilisateur/user_modif_heure_additionnelle.php
@@ -13,7 +13,7 @@ dans un but spécifique. Reportez-vous à la Licence Publique Générale GNU pou
 Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps
 que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation,
 Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, États-Unis.
-*************************************************************************************************
+ *************************************************************************************************
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU General Public License as published by the Free Software Foundation; either
 version 2 of the License, or any later version.
@@ -23,7 +23,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-*************************************************************************************************/
+ *************************************************************************************************/
 
 defined('_PHP_CONGES') or die('Restricted access');
 $id = (int) getpost_variable('id');

--- a/utilisateur/user_modif_heure_repos.php
+++ b/utilisateur/user_modif_heure_repos.php
@@ -13,7 +13,7 @@ dans un but spécifique. Reportez-vous à la Licence Publique Générale GNU pou
 Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même temps
 que ce programme ; si ce n'est pas le cas, écrivez à la Free Software Foundation,
 Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, États-Unis.
-*************************************************************************************************
+ *************************************************************************************************
 This program is free software; you can redistribute it and/or modify it under the terms
 of the GNU General Public License as published by the Free Software Foundation; either
 version 2 of the License, or any later version.
@@ -23,7 +23,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-*************************************************************************************************/
+ *************************************************************************************************/
 
 defined('_PHP_CONGES') or die('Restricted access');
 $id    = (int) getpost_variable('id');

--- a/utilisateur/user_nouvelle_absence.php
+++ b/utilisateur/user_nouvelle_absence.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \utilisateur\Fonctions::nouvelleAbsenceModule($onglet);

--- a/utilisateur/user_suppr_demande.php
+++ b/utilisateur/user_suppr_demande.php
@@ -1,4 +1,4 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 echo \utilisateur\Fonctions::suppressionAbsenceModule();

--- a/version.php
+++ b/version.php
@@ -1,9 +1,9 @@
 <?php
 
-defined( '_PHP_CONGES' ) or die( 'Restricted access' );
+defined('_PHP_CONGES') or die('Restricted access');
 
 // site et numero de version de PHP_CONGES
 // ne pas toucher ces variables SVP ;-)
-$config_php_conges_version="1.9";
-$config_url_site_web_php_conges="http://Libertempo.tuxfamily.org";
+$config_php_conges_version      = "1.9";
+$config_url_site_web_php_conges = "http://Libertempo.tuxfamily.org";
 // ne pas toucher ces variables SVP ;-)


### PR DESCRIPTION
Passe de la quasi totalité des fichiers à l'autoformatage grâce à CodeFormatter.
Le formatage permet:
- autoindentation
- suppressions des espaces inutiles
- suppression des doubles lignes sautés
- ajout d'un espace après les virgules
- formatage des variables après = quand il y en a sur plusieurs lignes
... et beaucoup d'autres choses

L'intégralité des corrections php est décrite dans la doc de phpfmt
https://github.com/nanch/phpfmt_stable
Voici les paramètres utilisé pour phpfmt
```
"php55_compat": false, // PHP 5.5 compatible mode
"psr1": false, // Activate PSR1 style
"psr1_naming": false, // Activate PSR1 style - Section 3 and 4.3 - Class and method names case
"psr2": true, // Activate PSR2 style
"indent_with_space": 4, // Use spaces instead of tabs for indentation
"enable_auto_align": true, // Enable auto align of = and =>
"visibility_order": true, // Fixes visibility order for method in classes - PSR-2 4.2
"smart_linebreak_after_curly": true, // Convert multistatement blocks into multiline blocks
```

Les paramètres js
```
"syntaxes": "javascript,json", // Syntax names which must process JS formatter
"format_on_save": false, // Format on save. Either a boolean (true/false) or a string regexp tested on filename. Example : "^((?!.min.|vendor).)*$"
"indent_size": 4, // indentation size
"indent_char": " ", // Indent character
"indent_with_tabs": false, // Indent with one tab (overrides indent_size and indent_char options)
"eol": "\n", // EOL symbol
"preserve_newlines": false, // whether existing line breaks should be preserved,
"max_preserve_newlines": 10, // maximum number of line breaks to be preserved in one chunk
"space_in_paren": false, // Add padding spaces within paren, ie. f( a, b )
"space_in_empty_paren": false, // Add padding spaces within paren if parent empty, ie. f(  )
"e4x": false, // Pass E4X xml literals through untouched
"jslint_happy": false, // if true, then jslint-stricter mode is enforced. Example function () vs function()
"brace_style": "collapse", // "collapse" | "expand" | "end-expand". put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or just put end braces on own line.
"keep_array_indentation": false, // keep array indentation.
"keep_function_indentation": false, // keep function indentation.
"eval_code": false, // eval code
"unescape_strings": false, // Decode printable characters encoded in xNN notation
"wrap_line_length": 0, // Wrap lines at next opportunity after N characters
"break_chained_methods": false, // Break chained method calls across subsequent lines
"end_with_newline": false, // Add new line at end of file
"comma_first": false // Add comma first
```