### PR TITLE
Fix bug PDF d'échappement des caractères dans les headers et footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Libertempo est une application web interactive de gestion des congés du personn
 Libertempo se veut être au plus proche des règles inhérentes aux réglementations françaises tout en restant paramétrable afin de répondre aux particularités et conventions des entreprises et des administrations. 
 
 # Version recommandée
-Vous pouvez télécharger la version stable la plus récente directement depuis [master](https://github.com/wouldsmina/Libertempo/archive/master.zip). ![build_status](https://travis-ci.org/wouldsmina/Libertempo.svg?branch=master)
+Vous pouvez télécharger la version stable la plus récente directement depuis [master](https://github.com/Libertempo/Libertempo-web/archive/master.zip). ![build_status](https://travis-ci.org/wouldsmina/Libertempo.svg?branch=master)
 
-Chaque nouvelle version est mise à disposition sur [github](https://github.com/wouldsmina/Libertempo/releases) et sur [libertempo.tuxfamily.org](http://libertempo.tuxfamily.org/downloads/)
+Chaque nouvelle version est mise à disposition sur [github](https://github.com/Libertempo/Libertempo-web/releases) et sur [libertempo.tuxfamily.org](http://libertempo.tuxfamily.org/downloads/)
 
 # Installation
 Rendez vous sur la [documentation](http://libertempo.tuxfamily.org/Documentation).

--- a/edition/PDF.php
+++ b/edition/PDF.php
@@ -10,7 +10,7 @@ class PDF extends \TCPDF
         /* affichage du texte en haut de page */
         /**************************************/
         $this->SetFont('Times','',10);
-        $this->Cell(0,3, $_SESSION['config']['texte_haut_edition_papier'],0,1,'C');
+        $this->Cell(0,3, html_entity_decode($_SESSION['config']['texte_haut_edition_papier']),0,1,'C');
         $this->Ln(10);
     }
 
@@ -21,7 +21,7 @@ class PDF extends \TCPDF
         /**************************************/
         $this->SetFont('Times','',10);
         //$pdf->Cell(0,6, 'texte_haut_edition_papier',0,1,'C');
-        $this->Cell(0,3, $_SESSION['config']['texte_bas_edition_papier'],0,1,'C');
+        $this->Cell(0,3, html_entity_decode($_SESSION['config']['texte_bas_edition_papier']),0,1,'C');
         $this->Ln(10);
     }
 }


### PR DESCRIPTION
Fix bug PDF d'échappement des caractères dans les headers et footer

Note il y avait aussi le commit de test pour le nouveau dépot ;)