### PR TITLE
[notification] correction erreur variable lors du traitement des heures additionnelles

### DIFF
--- a/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
+++ b/App/ProtoControllers/Responsable/Traitement/Additionnelle.php
@@ -102,7 +102,7 @@ class Additionnelle extends \App\ProtoControllers\Responsable\ATraitement
             $return = NIL_INT;
         }
         if( 0 < $return) {
-            $notif = new \App\Libraries\Notification\Additionnelle($id);
+            $notif = new \App\Libraries\Notification\Additionnelle($id_heure);
             if (!$notif->send()) {
                 $localError[] = _('erreur_envoi_mail') . ': ' . $infoDemande['login'];
                 $return = NIL_INT;

--- a/App/ProtoControllers/Responsable/Traitement/Repos.php
+++ b/App/ProtoControllers/Responsable/Traitement/Repos.php
@@ -104,7 +104,7 @@ class Repos extends \App\ProtoControllers\Responsable\ATraitement
         }
         
         if( 0 < $return) {
-            $notif = new \App\Libraries\Notification\Repos($id);
+            $notif = new \App\Libraries\Notification\Repos($id_heure);
             $send = $notif->send();
 
             if (false === $send) {


### PR DESCRIPTION
une erreur de variable provoquait une erreur (non bloquante) lors du traitement. Cela avait aussi pour effet de ne pas transmettre la notification.