### PR TITLE
Fix un décalage entre les heures du serveur et les heures du client, ce bug apparaissait dans l'utilisation des creneaux

### DIFF
--- a/App/ProtoControllers/HautResponsable/Planning/Creneau.php
+++ b/App/ProtoControllers/HautResponsable/Planning/Creneau.php
@@ -105,8 +105,8 @@ class Creneau
         foreach ($creneaux as $creneau) {
             $jourId      = $creneau['jour_id'];
             $typePeriode = $creneau['type_periode'];
-            $debut       = date('H\:i', $creneau['debut']);
-            $fin         = date('H\:i', $creneau['fin']);
+            $debut       = \App\Helpers\Formatter::timestamp2Duree($creneau['debut']);
+            $fin         = \App\Helpers\Formatter::timestamp2Duree($creneau['fin']);
 
             $grouped[$jourId][$typePeriode][] = [
                 ModelCreneau::TYPE_HEURE_DEBUT => $debut,


### PR DESCRIPTION
Pour reproduire le bug on peut créer un planning en tant qu'administrateur.
Une fois le planning validé il suffit de le visionner pour voir que toutes les heures ont subit une modification +1
Par exemple un créneau 10h -> 12h sera transformé en 11h -> 13h et ainsi de suite