### PR TITLE
Redirection quand demande d'heures add est OK

### DIFF
--- a/App/ProtoControllers/Employe/Heure/Additionnelle.php
+++ b/App/ProtoControllers/Employe/Heure/Additionnelle.php
@@ -164,7 +164,7 @@ class Additionnelle extends \App\ProtoControllers\Employe\AHeure
                 $return = NIL_INT;
             }
         }
-        return NIL_INT;
+        return $return;
     }
 
     /**


### PR DESCRIPTION
Tout est dans le titre. Il y avait une redirection vers la liste pour les heures de repos, pas pour les add. 

Tadaaaam !