### PR TITLE
Sauvegarde de la DB avant chaque upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cfg/config_SMTP.php
 .idea/
 /nbproject/
 /dump/*.dump
+/backup/

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ cfg/config_SMTP.php
 .idea/
 /nbproject/
 /dump/*.dump
-/backup/
+/backup/libertempo*

--- a/admin/Fonctions.php
+++ b/admin/Fonctions.php
@@ -1079,8 +1079,8 @@ class Fonctions
     public static function get_nb_users_du_groupe($group_id)
     {
 
-        $sql1='SELECT DISTINCT(cgu.gu_login) FROM conges_groupe_users AS cgu 
-                INNER JOIN conges_users AS cu ON (cu.u_login = cgu.gu_login) 
+        $sql1='SELECT DISTINCT(cgu.gu_login) FROM conges_groupe_users AS cgu
+                INNER JOIN conges_users AS cu ON (cu.u_login = cgu.gu_login)
                 WHERE cgu.gu_gid = '. \includes\SQL::quote($group_id).' AND cu.u_is_active != "N" ORDER BY cgu.gu_login ';
         $ReqLog1 = \includes\SQL::query($sql1);
         $nb_users = $ReqLog1->num_rows;
@@ -1750,7 +1750,7 @@ class Fonctions
     {
         $typeSauvegarde = 'all';
         $contentFile = static::getDataFile($typeSauvegarde);
-        $filename = BACKUP_PATH . 'php_conges_' . $typeSauvegarde .'_' . $previousVersion . '__' . $newVersion . '.sql'; // nom de migration
+        $filename = BACKUP_PATH . 'libertempo_' . $typeSauvegarde .'_' . $previousVersion . '__' . $newVersion . '.sql'; // nom de migration
 
         if (false === file_put_contents($filename, $contentFile)) {
             throw new \Exception('Échec de l\'écriture de la sauvegarde');
@@ -1767,7 +1767,7 @@ class Fonctions
     private static function getDataFile($typeSauvegarde)
     {
         $content = "#\n";
-        $content .= "# PHP_CONGES\n";
+        $content .= "# Libertempo\n";
         $content .= "#\n# DATE : " . date("d-m-Y H:i:s") . "\n";
         $content .= "#\n";
 

--- a/admin/Fonctions.php
+++ b/admin/Fonctions.php
@@ -1618,7 +1618,7 @@ class Fonctions
         // description des champs :
         $req = 'SHOW CREATE TABLE '. \includes\SQL::quote($table);
         $descriptor = \includes\SQL::query($req) ;
-        $resultDescriptor = $ReqLog_champs->fetch_array();
+        $resultDescriptor = $descriptor->fetch_array();
         return $drop . $resultDescriptor['Create Table'] . ";\n#\n";
     }
 

--- a/admin/Fonctions.php
+++ b/admin/Fonctions.php
@@ -1739,7 +1739,12 @@ class Fonctions
     }
 
     /**
+     * Écrit un fichier de sauvegarde de version dans le répertoire de backup
      *
+     * @param string $previousVersion Version de départ (courante)
+     * @param string $newVersion Version visée
+     *
+     * @throws \Exception en cas d'échec d'écriture de fichier
      */
     public static function sauvegardeAsFile($previousVersion, $newVersion)
     {

--- a/backup/.htaccess
+++ b/backup/.htaccess
@@ -1,0 +1,9 @@
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>

--- a/backup/.htaccess
+++ b/backup/.htaccess
@@ -1,6 +1,6 @@
 # Apache 2.2
 <IfModule !mod_authz_core.c>
-    deny from all 
+    deny from all
 </IfModule>
 
 

--- a/backup/.htaccess
+++ b/backup/.htaccess
@@ -3,6 +3,7 @@
     deny from all
 </IfModule>
 
+
 # Apache 2.4
 <IfModule mod_authz_core.c>
     Require all denied

--- a/backup/.htaccess
+++ b/backup/.htaccess
@@ -1,6 +1,6 @@
 # Apache 2.2
 <IfModule !mod_authz_core.c>
-    deny from all
+    deny from all 
 </IfModule>
 
 

--- a/define.php
+++ b/define.php
@@ -23,6 +23,7 @@ if (!defined( 'DEFINE_INCLUDE' )) {
     define('INSTALL_PATH',     ROOT_PATH . 'install/');
     define('LOCALE_PATH',      ROOT_PATH . 'locale/');
     define('DUMP_PATH',        ROOT_PATH . 'dump/');
+    define('BACKUP_PATH',      ROOT_PATH . 'backup' . DS);
     define('TEMPLATE_PATH',    ROOT_PATH . 'template/reboot/');
     define('API_SYSPATH', ABSOLUTE_SYSPATH . 'vendor' . DS . 'Libertempo' . DS . 'libertempo-api' . DS);
     define('API_URL', ROOT_PATH . 'api/');

--- a/install/Fonctions.php
+++ b/install/Fonctions.php
@@ -309,10 +309,6 @@ class Fonctions {
             } elseif($start_version == "1.9") {
                 $file_upgrade = 'upgrade_from_v1.9.php';
                 $new_installed_version = "1.10";
-            } else {
-                $file_upgrade = '';
-                $new_installed_version = $installed_version;
-                $etape = 3;
             }
             try {
                 \admin\Fonctions::sauvegardeAsFile($start_version, $new_installed_version);

--- a/install/Fonctions.php
+++ b/install/Fonctions.php
@@ -295,43 +295,42 @@ class Fonctions {
             {
                     echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$PHP_SELF?etape=2&version=$installed_version&lang=$lang\">";
             }
-        }
-        //*** ETAPE 2
-        elseif($etape==2)
-        {
-                $start_version=$installed_version ;
+        } elseif($etape==2) {
+            $start_version = $installed_version ;
 
-            //on lance l'execution (include) des scripts d'upgrade l'un après l'autre jusqu a la version voulue ($config_php_conges_version) ..
-            if($start_version=="1.7.0") {
-                $file_upgrade='upgrade_from_v1.7.0.php';
-                $new_installed_version="1.8";
-                // execute le script php d'upgrade de la version1.7.0 (vers la suivante (1.8))
-                echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?etape=2&version=$new_installed_version&lang=$lang\">";
-	    } elseif($start_version=="1.8") {
-		$file_upgrade='upgrade_from_v1.8.php';
-		$new_installed_version="1.8.1";
-		// execute le script php d'upgrade de la version1.8 (vers la suivante (1.8.1))
-		echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?etape=2&version=$new_installed_version&lang=$lang\">";
-            } elseif($start_version=="1.8.1") {
-		$file_upgrade='upgrade_from_v1.8.1.php';
-		$new_installed_version="1.9";
-		// execute le script php d'upgrade de la version 1.8.1 (vers la suivante (1.9))
-		echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?etape=2&version=$new_installed_version&lang=$lang\">";
-            } elseif($start_version=="1.9") {
-		$file_upgrade='upgrade_from_v1.9.php';
-		$new_installed_version="1.10";
-		// execute le script php d'upgrade de la version 1.9 (vers la suivante (1.10))
-		echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$file_upgrade?etape=2&version=$new_installed_version&lang=$lang\">";
+            //on lance l'execution (include) des scripts d'upgrade l'un après l'autre jusqu'à la version voulue ($config_php_conges_version) ..
+            if(($start_version == "1.5.0") || ($start_version == "1.5.1")) {
+                $file_upgrade = 'upgrade_from_v1.5.0.php';
+                $new_installed_version = "1.6.0";
+            } elseif($start_version == "1.6.0") {
+                $file_upgrade = 'upgrade_from_v1.6.0.php';
+                $new_installed_version = "1.7.0";
+            } elseif($start_version == "1.7.0") {
+                $file_upgrade = 'upgrade_from_v1.7.0.php';
+                $new_installed_version = "1.8";
+            } elseif($start_version == "1.8") {
+                $file_upgrade = 'upgrade_from_v1.8.php';
+                $new_installed_version = "1.8.1";
+            } elseif($start_version == "1.8.1") {
+                $file_upgrade = 'upgrade_from_v1.8.1.php';
+                $new_installed_version = "1.9";
+            } elseif($start_version == "1.9") {
+                $file_upgrade = 'upgrade_from_v1.9.php';
+                $new_installed_version = "1.10";
             } else {
-                echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=$PHP_SELF?etape=3&version=$installed_version&lang=$lang\">";
+                $file_upgrade = '';
+                $new_installed_version = $installed_version;
+                $etape = 3;
             }
-        }
-        //*** ETAPE 3
-        elseif($etape==3)
-        {
+            try {
+                \admin\Fonctions::sauvegardeAsFile($start_version, $new_installed_version);
+                echo '<META HTTP-EQUIV=REFRESH CONTENT="0; URL=' . $file_upgrade . '?etape=' . $etape . '&version=' . $new_installed_version . '&lang=' . $lang . '>';
+            } catch (\Exception $e) {
+                echo 'Abandon de la mise à jour : ' . $e->getMessage();
+            }
+        } elseif($etape==3) {
             /* Reset du token d'instance à chaque version */
             \includes\SQL::query('UPDATE `conges_appli` SET appli_valeur =  "' . hash('sha256', time() . rand()) . '" WHERE appli_variable = "token_instance"');
-
             // FIN
             // test si fichiers config.php ou config_old.php existent encore (si oui : demande de les effacer !
             if( (\install\Fonctions::test_config_file()) || (\install\Fonctions::test_old_config_file()) )

--- a/install/Fonctions.php
+++ b/install/Fonctions.php
@@ -324,7 +324,7 @@ class Fonctions {
             }
             try {
                 \admin\Fonctions::sauvegardeAsFile($start_version, $new_installed_version);
-                echo '<META HTTP-EQUIV=REFRESH CONTENT="0; URL=' . $file_upgrade . '?etape=' . $etape . '&version=' . $new_installed_version . '&lang=' . $lang . '>';
+                echo '<META HTTP-EQUIV=REFRESH CONTENT="0; URL=' . $file_upgrade . '?etape=' . $etape . '&version=' . $new_installed_version . '&lang=' . $lang . '">';
             } catch (\Exception $e) {
                 echo 'Abandon de la mise à jour : ' . $e->getMessage();
             }

--- a/install/Fonctions.php
+++ b/install/Fonctions.php
@@ -297,14 +297,7 @@ class Fonctions {
         } elseif($etape==2) {
             $start_version = $installed_version ;
 
-            //on lance l'execution (include) des scripts d'upgrade l'un après l'autre jusqu'à la version voulue ($config_php_conges_version) ..
-            if(($start_version == "1.5.0") || ($start_version == "1.5.1")) {
-                $file_upgrade = 'upgrade_from_v1.5.0.php';
-                $new_installed_version = "1.6.0";
-            } elseif($start_version == "1.6.0") {
-                $file_upgrade = 'upgrade_from_v1.6.0.php';
-                $new_installed_version = "1.7.0";
-            } elseif($start_version == "1.7.0") {
+            if($start_version == "1.7.0") {
                 $file_upgrade = 'upgrade_from_v1.7.0.php';
                 $new_installed_version = "1.8";
             } elseif($start_version == "1.8") {
@@ -327,7 +320,7 @@ class Fonctions {
             } catch (\Exception $e) {
                 echo 'Abandon de la mise à jour : ' . $e->getMessage();
             }
-        } elseif($etape==3) {
+        } elseif($etape == 3) {
             /* Reset du token d'instance à chaque version */
             \includes\SQL::query('UPDATE `conges_appli` SET appli_valeur =  "' . hash('sha256', time() . rand()) . '" WHERE appli_variable = "token_instance"');
             // FIN

--- a/install/Fonctions.php
+++ b/install/Fonctions.php
@@ -245,9 +245,8 @@ class Fonctions {
         if($etape==0)
         {
             //avant tout , on conseille une sauvegarde de la database !! (cf vieux index.php)
-            echo "<h3>". _('install_maj_passer_de') ." <font color=\"black\">$installed_version</font> ". _('install_maj_a_version') ." <font color=\"black\">$config_php_conges_version</font> .</h3>\n";
-            echo "<h3><font color=\"red\">". _('install_maj_sauvegardez') ." !!!</font></h3>\n";
-            echo "<h2>....</h2>\n";
+            echo "<h3>". _('install_maj_passer_de') ." <font color=\"black\">$installed_version</font> ". _('install_maj_a_version') ." <font color=\"black\">$config_php_conges_version</font>.</h3>\n";
+            echo "<h3><font color=\"red\">". _('install_maj_cas_echec_backup') .".</font></h3>\n";
             echo "<br>\n";
             echo "<form action=\"$PHP_SELF?lang=$lang\" method=\"POST\">\n";
             echo "<input type=\"hidden\" name=\"etape\" value=\"1\">\n";

--- a/install/Fonctions.php
+++ b/install/Fonctions.php
@@ -309,9 +309,15 @@ class Fonctions {
             } elseif($start_version == "1.9") {
                 $file_upgrade = 'upgrade_from_v1.9.php';
                 $new_installed_version = "1.10";
+            } else {
+                $file_upgrade = '';
+                $new_installed_version = $installed_version;
+                $etape = 3;
             }
             try {
-                \admin\Fonctions::sauvegardeAsFile($start_version, $new_installed_version);
+                if ($new_installed_version !== $start_version) {
+                    \admin\Fonctions::sauvegardeAsFile($start_version, $new_installed_version);
+                }
                 echo '<META HTTP-EQUIV=REFRESH CONTENT="0; URL=' . $file_upgrade . '?etape=' . $etape . '&version=' . $new_installed_version . '&lang=' . $lang . '">';
             } catch (\Exception $e) {
                 echo 'Abandon de la mise à jour : ' . $e->getMessage();

--- a/install/upgrade_from_v1.7.0.php
+++ b/install/upgrade_from_v1.7.0.php
@@ -81,4 +81,4 @@ $alter_solde="ALTER TABLE conges_solde_user MODIFY `su_reliquat` DECIMAL(5,2) NO
 $res_alter_solde=\includes\SQL::query($alter_solde);
 
 // on renvoit à la page mise_a_jour.php (là d'ou on vient)
-echo "<a href=\"mise_a_jour.php?etape=2&version=$version&lang=$lang\">upgrade_from_v1.7.0  OK</a><br>\n";
+echo "Migration depuis v1.7.0 effectuée. <a href=\"mise_a_jour.php?etape=2&version=$version&lang=$lang\">Continuer.</a><br>\n";

--- a/install/upgrade_from_v1.8.1.php
+++ b/install/upgrade_from_v1.8.1.php
@@ -143,4 +143,4 @@ $sql->query($reqInsert);
 $sql->getPdoObj()->commit();
 
 // on renvoit à la page mise_a_jour.php (là d'ou on vient)
-echo "<a href=\"mise_a_jour.php?etape=2&version=$version&lang=$lang\">upgrade_from_v1.8.1  OK</a><br>\n";
+echo "Migration depuis v1.8.1 effectuée. <a href=\"mise_a_jour.php?etape=2&version=$version&lang=$lang\">Continuer.</a><br>\n";

--- a/install/upgrade_from_v1.8.php
+++ b/install/upgrade_from_v1.8.php
@@ -39,4 +39,4 @@ $del_conges_usr="DELETE FROM conges_users WHERE u_login = 'conges';";
 $res_del_conges_usr=\includes\SQL::query($del_conges_usr);
 
 // on renvoit à la page mise_a_jour.php (là d'ou on vient)
-echo "<a href=\"mise_a_jour.php?etape=2&version=$version&lang=$lang\">upgrade_from_v1.8  OK</a><br>\n";
+echo "Migration depuis v1.8 effectuée. <a href=\"mise_a_jour.php?etape=2&version=$version&lang=$lang\">Continuer.</a><br>\n";

--- a/install/upgrade_from_v1.9.php
+++ b/install/upgrade_from_v1.9.php
@@ -51,4 +51,4 @@ $del_config_db="DELETE FROM conges_config WHERE conf_nom = 'disable_saise_champ_
 $res_del_config_from_db=\includes\SQL::query($del_config_db);
 
 // on renvoit à la page mise_a_jour.php (là d'ou on vient)
-echo "<a href=\"mise_a_jour.php?etape=3&version=$version&lang=$lang\">upgrade_from_v1.9  OK</a><br>\n";
+echo "Migration depuis v1.9 effectuée. <a href=\"mise_a_jour.php?etape=2&version=$version&lang=$lang\">Continuer.</a><br>\n";

--- a/install/upgrade_from_v1.9.php
+++ b/install/upgrade_from_v1.9.php
@@ -49,3 +49,6 @@ $sql->getPdoObj()->commit();
 
 $del_config_db="DELETE FROM conges_config WHERE conf_nom = 'disable_saise_champ_nb_jours_pris';";
 $res_del_config_from_db=\includes\SQL::query($del_config_db);
+
+// on renvoit à la page mise_a_jour.php (là d'ou on vient)
+echo "<a href=\"mise_a_jour.php?etape=3&version=$version&lang=$lang\">upgrade_from_v1.9  OK</a><br>\n";


### PR DESCRIPTION
fix #379 

Désormais, avant toute mise à jour, l'appli sauvegarde l'état de la DB dans un répertoire `backup` en nommant bien évidemment les versions concernées. En cas d'échec, la maj est annulée afin de garantir un  maximum la sécurité.
Il m'a fallu faire un petit détour sur le système de sauvegarde et restauration, il sera donc nécessaire de tester ce dernier.

On ne gère pas la destruction, charge au client de supprimer les fichier quand bon lui semble ; j'attends à ce propos votre avis sur la méthodo car je ne sais pas comment communiquer ça.

Hej då !