### PR TITLE
affichage du solde d'heure. fix #392

### DIFF
--- a/App/ProtoControllers/Utilisateur.php
+++ b/App/ProtoControllers/Utilisateur.php
@@ -183,7 +183,7 @@ class Utilisateur
     public static function getSoldeconge($login, $typeId)
     {
         $sql = \includes\SQL::singleton();
-        $req = 'SELECT su_solde FROM conges_solde_user WHERE su_login = \''.$login.'\'
+        $req = 'SELECT su_solde FROM conges_solde_user WHERE su_login = \'' . \includes\SQL::quote($login) . '\'
                 AND su_abs_id ='. (int) $typeId;
         $query = $sql->query($req);
         $solde = $query->fetch_array()[0];
@@ -202,7 +202,7 @@ class Utilisateur
     public static function getSoldeHeure($login)
     {
         $sql = \includes\SQL::singleton();
-        $req = 'SELECT u_heure_solde FROM conges_users WHERE u_login = \''.$login.'\'';
+        $req = 'SELECT u_heure_solde FROM conges_users WHERE u_login = \'' . \includes\SQL::quote($login) . '\'';
         $query = $sql->query($req);
         $timestamp = $query->fetch_array()[0];
 

--- a/App/ProtoControllers/Utilisateur.php
+++ b/App/ProtoControllers/Utilisateur.php
@@ -190,7 +190,25 @@ class Utilisateur
 
         return $solde;
     }
+    
+     /**
+     * Retourne le solde d'heure au format timestamp d'un utilisateur
+     *
+     * @param string $login
+     * @param int $typeId
+     *
+     * @return int $timestamp
+     */   
+    public static function getSoldeHeure($login)
+    {
+        $sql = \includes\SQL::singleton();
+        $req = 'SELECT u_heure_solde FROM conges_users WHERE u_login = \''.$login.'\'';
+        $query = $sql->query($req);
+        $timestamp = $query->fetch_array()[0];
 
+        return $timestamp;
+    }
+    
     /**
      * Vérifie si l'utilisateur a des sorties en cours
      *

--- a/admin/Fonctions.php
+++ b/admin/Fonctions.php
@@ -1341,9 +1341,14 @@ class Fonctions
         foreach ($tab_type_conges_exceptionnels as $id_type_cong => $libelle) {
             $childTable .= '<th>' . _('divers_solde') . ' ' . $libelle . '</th>';
         }
+
+        if($_SESSION['config']['gestion_heures']){
+            $childTable .= '<th>' . _('divers_solde') . ' ' . _('heures') . '</th>';
+        }
+
         $childTable .= '<th></th>';
         $childTable .= '<th></th>';
-        if($_SESSION['config']['admin_change_passwd']) {
+        if($_SESSION['config']['admin_change_passwd'] && ($_SESSION['config']['how_to_connect_user'] == "dbconges")) {
             $childTable .= '<th></th>';
         }
         $childTable .= '</tr>';
@@ -1414,6 +1419,10 @@ class Fonctions
                 } else {
                     $childTable .= '<td>0</td>';
                 }
+            }
+
+            if($_SESSION['config']['gestion_heures']){
+                $childTable .= '<td>' . \App\Helpers\Formatter::timestamp2Duree($tab_current_infos['solde_heure']) . '</td>';
             }
 
             $childTable .= '<td>' . $admin_modif_user . '</td>';

--- a/fonctions_conges.php
+++ b/fonctions_conges.php
@@ -1831,11 +1831,6 @@ function affiche_tableau_bilan_conges_user($login)
     $sql_quotite=$resultat['u_quotite'];
     $return = '';
 
-    if($_SESSION['config']['gestion_heures']){
-        $timestampSolde = \App\ProtoControllers\Utilisateur::getSoldeHeure($login);
-        $soldeHeure = \App\Helpers\Formatter::timestamp2Duree($timestampSolde);
-    }
-
     // recup dans un tableau de tableaux les nb et soldes de conges d'un user
     $tab_cong_user = recup_tableau_conges_for_user($login, true);
 
@@ -1875,7 +1870,8 @@ function affiche_tableau_bilan_conges_user($login)
         }
     }
     if($_SESSION['config']['gestion_heures']){
-        $return .= '<td class="solde">'. $soldeHeure .'</td>';
+        $timestampSolde = \App\ProtoControllers\Utilisateur::getSoldeHeure($login);
+        $return .= '<td class="solde">'. \App\Helpers\Formatter::timestamp2Duree($timestampSolde) .'</td>';
     }
     $return .= '</tr>';
     $return .= '</tbody>';

--- a/fonctions_conges.php
+++ b/fonctions_conges.php
@@ -1831,6 +1831,11 @@ function affiche_tableau_bilan_conges_user($login)
     $sql_quotite=$resultat['u_quotite'];
     $return = '';
 
+    if($_SESSION['config']['gestion_heures']){
+        $timestampSolde = \App\ProtoControllers\Utilisateur::getSoldeHeure($login);
+        $soldeHeure = \App\Helpers\Formatter::timestamp2Duree($timestampSolde);
+    }
+
     // recup dans un tableau de tableaux les nb et soldes de conges d'un user
     $tab_cong_user = recup_tableau_conges_for_user($login, true);
 
@@ -1841,7 +1846,9 @@ function affiche_tableau_bilan_conges_user($login)
 
     $return .= '<table class="table table-hover table-responsive table-condensed table-bordered">';
     $return .= '<thead>';
-    $return .= '<tr><td></td><td colspan="' . (count($tab_cong_user) * 2 ) . '">SOLDES</td></tr>';
+    $colspan = count($tab_cong_user) * 2 + 1 ;
+    $colspan = $_SESSION['config']['gestion_heures'] ? $colspan + 1 : $colspan;
+    $return .= '<tr><td></td><td colspan="' . $colspan . '">SOLDES</td></tr>';
     $return .= '<tr>';
     $return .= '<th class="titre">'. _('divers_quotite') .'</th>';
 
@@ -1851,6 +1858,9 @@ function affiche_tableau_bilan_conges_user($login)
         } else {
             $return .= '<th class="annuel">' . $id . ' / ' . _('divers_an_maj') . '</th><th class="solde">' . $id . '</th>';
         }
+    }
+    if($_SESSION['config']['gestion_heures']){
+        $return .= '<th class="solde">' . _('heure') . '</th>';
     }
     $return .= '</tr>';
     $return .= '</thead>';
@@ -1863,6 +1873,9 @@ function affiche_tableau_bilan_conges_user($login)
         } else {
             $return .= '<td class="annuel">' . $val['nb_an'] . '</td><td class="solde">' . $val['solde'] . ($val['reliquat'] > 0 ? ' (' . _('dont_reliquat') . ' ' . $val['reliquat'] . ')' : '') . '</td>';
         }
+    }
+    if($_SESSION['config']['gestion_heures']){
+        $return .= '<td class="solde">'. $soldeHeure .'</td>';
     }
     $return .= '</tr>';
     $return .= '</tbody>';


### PR DESCRIPTION
Il manquait le solde des heures dans le tableau récapitulatif d'un employé, cette PR vient ajouter cette information si l'option est activée. 

Cette modification impacte aussi les profils responsable et RH lorsque ces derniers consultent un employé en particulier.