### PR TITLE
Ajout des badges pour le RH, les badges sont aussi affichées dans le menu du responsable et du RH

### DIFF
--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -3591,4 +3591,26 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
 
         return $return;
     }
+    public static function getNbDemandesATraiter()
+    {
+        // Récup dans un tableau de tableau des informations de tous les users
+        $tab_all_users=recup_infos_all_users();
+        // si tableau des users n'est pas vide
+        if( count($tab_all_users)!=0 ) {
+            // constitution de la liste (séparé par des virgules) des logins ...
+            $list_users="";
+            foreach($tab_all_users as $current_login => $tab_current_user) {
+                if($list_users=="") {
+                    $list_users= "'$current_login'" ;
+                } else {
+                    $list_users=$list_users.", '$current_login'" ;
+                }
+            }
+            // Récup des demandes en cours pour les users :
+            $sql1 = "SELECT p_num, p_login, p_date_deb, p_demi_jour_deb, p_date_fin, p_demi_jour_fin, p_nb_jours, p_commentaire, p_type, p_date_demande, p_date_traitement FROM conges_periode WHERE p_etat =\"demande\" AND p_login IN ($list_users) ";
+            $ReqLog1 = \includes\SQL::query($sql1);
+            return $ReqLog1->num_rows;
+        }
+        return 0;
+    }
 }

--- a/hr/hr_index.php
+++ b/hr/hr_index.php
@@ -32,8 +32,14 @@ $onglets = array();
 
 $onglets['page_principale'] = _('resp_menu_button_retour_main');
 
-if( $_SESSION['config']['user_saisie_demande'] )
-    $onglets['traitement_demandes'] = _('resp_menu_button_traite_demande');
+if( $_SESSION['config']['user_saisie_demande'] ){
+	$nbBadgeConges = '';
+    $nbDemandes = \hr\Fonctions::getNbDemandesATraiter($_SESSION['userlogin']);
+    if (0 < $nbDemandes) {
+        $nbBadgeConges = ' <span class="badge">' . $nbDemandes . '</span>';
+    }
+    $onglets['traitement_demandes'] = _('resp_menu_button_traite_demande') . $nbBadgeConges;
+}
 
 // if( $_SESSION['config']['resp_ajoute_conges'] )
     $onglets['ajout_conges'] = _('resp_ajout_conges_titre');

--- a/template/reboot/menu_header.php
+++ b/template/reboot/menu_header.php
@@ -62,6 +62,10 @@
                 $mod_toolbar[] = "<a href=\"" . ROOT_PATH . "edition/edit_user.php?session=$session\"><i class=\"fa fa-file-text\"></i><span>"._('button_editions')."</span></a>";
         break;
     }
+    $DemandesConges = new \App\ProtoControllers\Responsable\Traitement\Conge;
+    $nbdemandesResp = $DemandesConges->getNbDemandesATraiter($_SESSION['userlogin']);
+
+    $nbdemandesHR = \hr\Fonctions::getNbDemandesATraiter($_SESSION['userlogin']);
 ?>
 <!DOCTYPE html>
 <html>
@@ -139,6 +143,7 @@
                         <a title="<?= _('button_hr_mode');?>" href="<?= ROOT_PATH ?>hr/hr_index.php?session=<?= $session ?>" <?php print ($tmp == 'hr') ? 'active' : '' ;?>>
                             <i class="fa fa-sitemap fa-2x maxi"></i>
                             <i class="fa fa-sitemap mini"></i>
+                            <?php if (0 < $nbdemandesHR) { echo '<span class="badge" style="position:absolute;">' . $nbdemandesHR . '</span>'; }?>
 						</a>
                     </div>
 					<?php endif; ?>
@@ -147,6 +152,7 @@
                         <a title="<?= _('button_responsable_mode');?>" href="<?= ROOT_PATH ?>responsable/resp_index.php?session=<?= $session ?>" <?php print ($tmp == 'utilisateur') ? 'active' : '' ;?>>
                             <i class="fa fa-users fa-2x maxi"></i>
                             <i class="fa fa-users mini"></i>
+                            <?php if (0 < $nbdemandesResp) { echo '<span class="badge" style="position:absolute;">' . $nbdemandesResp . '</span>'; }?>
 						</a>
                     </div>
 					<?php endif; ?>


### PR DESCRIPTION
Une fonction getNbDemandesATraiter a été créée pour le RH comme c'était déjà le cas pour le responsable.
Cette fonction est désormais utilisée dans le menu du RH pour afficher avec un badge le nombre de demande de congés à traiter sans que le RH n'ai besoin d'afficher la page.
Le système de badge est aussi désormais affiché dans le menu pour que les responsables et les RH aient une vision plus rapide des demandes à traiter.