### PR TITLE
Suppression d'un index sql empêche la montée en version

### DIFF
--- a/install/sql/php_conges_v1.8.1.sql
+++ b/install/sql/php_conges_v1.8.1.sql
@@ -317,7 +317,6 @@ CREATE TABLE IF NOT EXISTS `conges_users` (
   `u_email` varchar(100) DEFAULT NULL,
   `u_num_exercice` int(2) NOT NULL DEFAULT '0',
   PRIMARY KEY (`u_login`),
-  KEY `u_login` (`u_login`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 
@@ -452,4 +451,3 @@ INSERT IGNORE INTO `conges_mail` (`mail_nom`, `mail_subject`, `mail_body`) VALUE
 INSERT IGNORE INTO `conges_mail` (`mail_nom`, `mail_subject`, `mail_body`) VALUES ('mail_new_absence_conges', 'APPLI CONGES - Nouvelle absence', ' __SENDER_NAME__ vous informe qu\'il sera absent. Ce type de congés ne necéssite pas de validation. Vous pouvez consulter votre application Libertempo : __URL_ACCUEIL_CONGES__/\r\n\r\n-------------------------------------------------------------------------------------------------------\r\nCeci est un message automatique. ');
 INSERT IGNORE INTO `conges_mail` (`mail_nom`, `mail_subject`, `mail_body`) VALUES ('mail_modif_demande_conges', 'APPLI CONGES - Modification demande', ' __SENDER_NAME__ à modifié une demande non traité. Vous pouvez consulter votre application Libertempo : __URL_ACCUEIL_CONGES__/\r\n\r\n-------------------------------------------------------------------------------------------------------\r\nCeci est un message automatique.');
 INSERT IGNORE INTO `conges_mail` (`mail_nom`, `mail_subject`, `mail_body`) VALUES ('mail_supp_demande_conges', 'APPLI CONGES - Suppression demande', ' __SENDER_NAME__ à supprimé une demande non traité. Vous pouvez consulter votre application Libertempo : __URL_ACCUEIL_CONGES__/\r\n\r\n-------------------------------------------------------------------------------------------------------\r\nCeci est un message automatique.');
-


### PR DESCRIPTION
#390 a remonté un bug dans la montrée en version `1.8.1 -> 1.10`.
Après enquête, la montée en version `1.8 -> 1.8.1` ne donnait pas le même schema SQL que l'installation `1.8.1`, dû à la suppression d'un index dans `conges_users`. C'est désormais corrigé. :shipit: 

---
* Proposition d'amélioration pour que ça ne se reproduise plus : développer #174 