### PR TITLE
Pas de paramètre par défaut avant es6

### DIFF
--- a/Public/Assets/Js/reboot.js
+++ b/Public/Assets/Js/reboot.js
@@ -76,8 +76,9 @@ function compter_jours()
  *
  * @param object opts
  */
-function generateDatePicker(opts, compter = true)
+function generateDatePicker(opts, compter)
 {
+    var compter = (typeof compter !== 'undefined') ? compter : true;
     var defaultOpts = {
         format             : 'dd/mm/yyyy',
         language           : 'fr',
@@ -95,7 +96,7 @@ function generateDatePicker(opts, compter = true)
     }
     $(document).ready(function () {
         $('input.date').datepicker(toApply).on("change", function() {
-            if( compter == true) {
+            if(compter == true) {
                 compter_jours();
             }
         });


### PR DESCRIPTION
fix #405 

Pour les vieux navigateurs n'ayant pas encore implémenté la dernière version de JS, les paramètres par défaut n'existent pas. Dans sa grand bêtise, IE plante silencieusement, n'exécute pas le bout de code et tout ce qui est en dessous n'a aucune existence.

Histoire de vérifier comment ça marche, je propose de livrer ce code sur tuxfamily une fois qu'il sera review. De cette façon, je pourrai le tester lundi.

À livrer dès que possible, via une `1.9.3`