### PR TITLE
Tout le monde a la vue admin pour le calendrier

### DIFF
--- a/App/ProtoControllers/Calendrier.php
+++ b/App/ProtoControllers/Calendrier.php
@@ -169,12 +169,16 @@ final class Calendrier
         }
         $form .= '</select></div></div>';
         if($_SESSION['config']['gestion_groupes']) {
+            $groupesVisiblesUtilisateur = \App\ProtoControllers\Utilisateur::getListeGroupesVisibles($_SESSION['userlogin']);
             $form .= '<div class="form-group col-md-4 col-sm-5">
             <label class="control-label col-md-3 col-sm-3" for="groupe">Groupe&nbsp;:</label>
             <div class="col-md-8 col-sm-8"><select class="form-control" name="search[groupe]" id="groupe">';
             $form .= '<option value="' . NIL_INT . '">Tous</option>';
 
             foreach (\App\ProtoControllers\Groupe::getOptions() as $id => $groupe) {
+                if (!in_array($id, $groupesVisiblesUtilisateur)) {
+                    continue;
+                }
                 $selected = ($id ===  $this->idGroupe)
                     ? 'selected="selected"'
                     : '';

--- a/App/ProtoControllers/Utilisateur.php
+++ b/App/ProtoControllers/Utilisateur.php
@@ -48,7 +48,7 @@ class Utilisateur
             || \App\ProtoControllers\Utilisateur::isAdmin($utilisateur)
         ) {
             $groupesVisibles = \App\ProtoControllers\Groupe::getListeId();
-        } elseif (\App\ProtoControllers\Utilisateur::isResponsable()) {
+        } elseif (\App\ProtoControllers\Utilisateur::isResponsable($utilisateur)) {
             $groupesResponsable = \App\ProtoControllers\Responsable::getIdGroupeResp($utilisateur);
             $groupesGrandResponsable = \App\ProtoControllers\Responsable::getIdGroupeGrandResponsable($utilisateur);
             $groupesEmploye = \App\ProtoControllers\Utilisateur::getGroupesId($utilisateur);
@@ -73,7 +73,7 @@ class Utilisateur
         $donneesUtilisateur = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($utilisateur);
 
         return (!empty($donneesUtilisateur))
-            ? $donneesUtilisateur['u_is_hr']
+            ? 'Y' === $donneesUtilisateur['u_is_hr']
             : false;
     }
 
@@ -90,7 +90,7 @@ class Utilisateur
         $donneesUtilisateur = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($utilisateur);
 
         return (!empty($donneesUtilisateur))
-            ? $donneesUtilisateur['u_is_admin']
+            ? 'Y' === $donneesUtilisateur['u_is_admin']
             : false;
     }
 
@@ -107,7 +107,7 @@ class Utilisateur
         $donneesUtilisateur = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($utilisateur);
 
         return (!empty($donneesUtilisateur))
-            ? $donneesUtilisateur['u_is_resp']
+            ? 'Y' === $donneesUtilisateur['u_is_resp']
             : false;
     }
 
@@ -130,13 +130,13 @@ class Utilisateur
         return $donnees;
     }
 
-     /**
-      * Retourne la liste des utilisateurs associés à un planning
-      *
-      * @param int $planningId
-      *
-      * @return array
-      */
+    /**
+     * Retourne la liste des utilisateurs associés à un planning
+     *
+     * @param int $planningId
+     *
+     * @return array
+     */
     public static function getListByPlanning($planningId)
     {
         $planningId = (int) $planningId;
@@ -190,7 +190,7 @@ class Utilisateur
 
         return $solde;
     }
-    
+
      /**
      * Retourne le solde d'heure au format timestamp d'un utilisateur
      *
@@ -198,7 +198,7 @@ class Utilisateur
      * @param int $typeId
      *
      * @return int $timestamp
-     */   
+     */
     public static function getSoldeHeure($login)
     {
         $sql = \includes\SQL::singleton();
@@ -208,7 +208,7 @@ class Utilisateur
 
         return $timestamp;
     }
-    
+
     /**
      * Vérifie si l'utilisateur a des sorties en cours
      *
@@ -226,17 +226,17 @@ class Utilisateur
 
     /**
      * Récupère l'adresse email de l'utilisateur
-     * 
+     *
      * @todo En attendant l'objet ldap utilisation de find_email_adress_for_user
-     * 
+     *
      * @param string $login
      * @return string $mail
-     */    
+     */
     public static function getEmailUtilisateur($login)  {
         require_once ROOT_PATH.'fonctions_conges.php';
         return find_email_adress_for_user($login)[1];
     }
-    
+
     /**
      * Vérifie si l'utilisateur a des congés en cours
      *


### PR DESCRIPTION
Suite au typage faible de PHP, une erreur de booléen est passée au travers du code, et rendait toujours « oui » quand on posait la question « puis-je voir la vue admin du calendrier ? »

J'en ai profité pour fix #391

Mérite une livraison immédiate (et une communication pour le déploiement), probablement dans le même livrable `1.9.3` que #430 