### PR TITLE
Préparation des session auto : admin, config et HR Fix #108

### DIFF
--- a/admin/Fonctions.php
+++ b/admin/Fonctions.php
@@ -10,7 +10,6 @@ class Fonctions
     public static function modif_resp_groupes($choix_resp, &$checkbox_resp_group, &$checkbox_grd_resp_group)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         $result_insert=TRUE;
@@ -53,7 +52,7 @@ class Fonctions
         log_action(0, "", $choix_resp, $comment_log);
 
         /* APPEL D'UNE AUTRE PAGE */
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group-responsables&choix_gestion_groupes_responsables=resp-group" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=admin-group-responsables&choix_gestion_groupes_responsables=resp-group" method="POST">';
         $return .= '<input type="submit" value="' . _('form_retour') . '">';
         $return .= '</form>';
         return $return;
@@ -63,7 +62,6 @@ class Fonctions
     public static function affiche_gestion_responsable_groupes($choix_resp, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_resp_groupe') . '</h1>';
@@ -111,7 +109,7 @@ class Fonctions
 
         /*****************************************************************************/
 
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=' . $onglet . '" method="POST">';
         $return .= '<div class="row">';
         $return .= '<div class="col-md-6">';
         $return .= '<h3>Responsable</h3>';
@@ -239,7 +237,7 @@ class Fonctions
         $return .= '<input type="hidden" name="change_responsable_group" value="ok">';
         $return .= '<input type="hidden" name="choix_resp" value="' .  $choix_resp . '">';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
-        $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group-responsables&choix_gestion_groupes_responsables=resp-group">' . _('form_annul') . '</a>';
+        $return .= '<a class="btn" href="' . $PHP_SELF . '?onglet=admin-group-responsables&choix_gestion_groupes_responsables=resp-group">' . _('form_annul') . '</a>';
         $return .= '</form>';
         return $return;
     }
@@ -248,7 +246,6 @@ class Fonctions
     public static function affiche_choix_responsable_groupes()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_resp_groupe') . '</h1>';
@@ -285,7 +282,7 @@ class Fonctions
             $sql_nom=$resultat_resp["u_nom"] ;
             $sql_prenom=$resultat_resp["u_prenom"] ;
 
-            $text_choix_resp="<a href=\"$PHP_SELF?session=$session&onglet=admin-group-responsables&choix_resp=$sql_login\"><strong>$sql_nom&nbsp;$sql_prenom</strong></a>" ;
+            $text_choix_resp="<a href=\"$PHP_SELF?onglet=admin-group-responsables&choix_resp=$sql_login\"><strong>$sql_nom&nbsp;$sql_prenom</strong></a>" ;
 
             $childTable .= '<tr class="' . ($i ? 'i' : 'p') . '">';
             $childTable .= '<td>' . $text_choix_resp . '</td>';
@@ -305,7 +302,6 @@ class Fonctions
     public static function modif_group_responsables($choix_group, &$checkbox_group_resp, &$checkbox_group_grd_resp)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         $result_insert=TRUE;
@@ -349,7 +345,7 @@ class Fonctions
         log_action(0, "", "", $comment_log);
 
         /* APPEL D'UNE AUTRE PAGE */
-        $return .= '<form action="' . $PHP_SELF . '?session=' .  $session . '&onglet=admin-group-responsables&choix_gestion_groupes_responsables=group-resp" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=admin-group-responsables&choix_gestion_groupes_responsables=group-resp" method="POST">';
         $return .= '<input type="submit" value="' . _('form_retour') . '">';
         $return .= '</form>';
         return $return;
@@ -359,7 +355,6 @@ class Fonctions
     public static function affiche_gestion_groupes_responsables($choix_group, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_groupe_resp') . '</h1>';
@@ -393,7 +388,7 @@ class Fonctions
             $tab_resp[]=$tab_r;
         }
         /*****************************************************************************/
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=' . $onglet . '" method="POST">';
         $return .= '<div class="row">';
         $return .= '<div class="col-md-6">';
         $return .= '<h3>' . _('admin_gestion_groupe_resp_responsables') . '</h3>';
@@ -522,7 +517,7 @@ class Fonctions
         $return .= '<input type="hidden" name="change_group_responsables" value="ok">';
         $return .= '<input type="hidden" name="choix_group" value="' . $choix_group . ' ">';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
-        $return .= '<a class="btn" href="'  . $PHP_SELF . '?session=' . $session . '&onglet=admin-group-responsables&choix_gestion_groupes_responsables=group-resp">' . _('form_annul') . '</a>';
+        $return .= '<a class="btn" href="'  . $PHP_SELF . '?onglet=admin-group-responsables&choix_gestion_groupes_responsables=group-resp">' . _('form_annul') . '</a>';
         $return .= '</form>';
         return $return;
     }
@@ -531,7 +526,6 @@ class Fonctions
     public static function affiche_choix_groupes_responsables()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         /********************/
@@ -563,7 +557,7 @@ class Fonctions
             $sql_groupename=$resultat_gr["g_groupename"] ;
             $sql_comment=$resultat_gr["g_comment"] ;
 
-            $text_choix_group="<a href=\"$PHP_SELF?session=$session&onglet=admin-group-responsables&choix_group=$sql_gid\"><strong>$sql_groupename</strong></a>" ;
+            $text_choix_group="<a href=\"$PHP_SELF?onglet=admin-group-responsables&choix_group=$sql_gid\"><strong>$sql_groupename</strong></a>" ;
 
             $childTable .= '<tr>';
             $childTable .= '<td>' . $text_choix_group . '</td>';
@@ -582,7 +576,6 @@ class Fonctions
     public static function affiche_choix_gestion_groupes_responsables($choix_group, $choix_resp, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         if( $choix_group!="" )    // si un groupe choisi : on affiche la gestion par groupe
@@ -643,7 +636,6 @@ class Fonctions
     public static function modif_user_groups($choix_user, &$checkbox_user_groups)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session='';
         $return = '';
 
         $result_insert= \admin\Fonctions::commit_modif_user_groups($choix_user, $checkbox_user_groups);
@@ -658,7 +650,7 @@ class Fonctions
         log_action(0, "", $choix_user, $comment_log);
 
         /* APPEL D'UNE AUTRE PAGE */
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session. '&onglet=admin-group-users" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=admin-group-users" method="POST">';
         $return .= '<input type="submit" value="' . _('form_retour') . '">';
         $return .= '</form>';
         return $return;
@@ -667,7 +659,6 @@ class Fonctions
     public static function modif_group_users($choix_group, &$checkbox_group_users)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         // on supprime tous les anciens users du groupe puis on ajoute tous ceux qui sont dans le tableau checkbox (si il n'est pas vide)
@@ -694,7 +685,7 @@ class Fonctions
         log_action(0, "", "", $comment_log);
 
         /* APPEL D'UNE AUTRE PAGE */
-        $return .= '<form action="' . $PHP_SELF. '?session=' . $session . '&onglet=admin-group-users" method="POST">';
+        $return .= '<form action="' . $PHP_SELF. '?onglet=admin-group-users" method="POST">';
         $return .= '<input type="submit" value="' . _('form_retour') . '">';
         $return .= '</form>';
         return $return;
@@ -702,7 +693,6 @@ class Fonctions
 
     public static function affiche_gestion_groupes_users($choix_group, $onglet) {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_groupe_user') . '</h1>';
@@ -718,7 +708,7 @@ class Fonctions
         $sql_comment=$resultat_gr["g_comment"] ;
 
 
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=' . $onglet . '" method="POST">';
 
         //AFFICHAGE DU TABLEAU DES USERS DU GROUPE
         $return .= '<h2>' . _('admin_gestion_groupe_users_membres') . ' <strong>' . $sql_group . '</strong>, ' . $sql_comment . '</h2>';
@@ -796,7 +786,7 @@ class Fonctions
         $return .= '<input type="hidden" name="change_group_users" value="ok">';
         $return .= '<input type="hidden" name="choix_group" value="' .  $choix_group . '">';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
-        $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group-users">' . _('form_annul') . '</a>';
+        $return .= '<a class="btn" href="' . $PHP_SELF . '?onglet=admin-group-users">' . _('form_annul') . '</a>';
         $return .= '</form>';
         return $return;
     }
@@ -804,7 +794,6 @@ class Fonctions
     public static function affiche_choix_groupes_users()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_groupe_user') . '</h1>';
@@ -840,7 +829,7 @@ class Fonctions
             $sql_group=$resultat_gr["g_groupename"] ;
             $sql_comment=$resultat_gr["g_comment"] ;
 
-            $choix_group="<a href=\"$PHP_SELF?session=$session&onglet=admin-group-users&choix_group=$sql_gid\"><b>$sql_group</b></a>" ;
+            $choix_group="<a href=\"$PHP_SELF?onglet=admin-group-users&choix_group=$sql_gid\"><b>$sql_group</b></a>" ;
 
             $childTable .= '<tr class="'.($i ? 'i' : 'p').'">';
             $childTable .= '<td><b>' . $choix_group .'</b></td>';
@@ -859,7 +848,6 @@ class Fonctions
     public static function affiche_gestion_user_groupes($choix_user, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_user_groupe') . '</h1>';
@@ -868,7 +856,7 @@ class Fonctions
         /* Affichage Groupes    */
         /************************/
 
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=' . $onglet . '" method="POST">';
 
         $return .= \admin\Fonctions::affiche_tableau_affectation_user_groupes($choix_user);
 
@@ -876,7 +864,7 @@ class Fonctions
         $return .= '<input type="hidden" name="change_user_groups" value="ok">';
         $return .= '<input type="hidden" name="choix_user" value="' . $choix_user . '">';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
-        $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group-users">' . _('form_annul') . '</a>';
+        $return .= '<a class="btn" href="' . $PHP_SELF . '?onglet=admin-group-users">' . _('form_annul') . '</a>';
         $return .= '</form>';
         return $return;
     }
@@ -884,7 +872,6 @@ class Fonctions
     public static function affiche_choix_user_groupes()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_user_groupe') . '</h1>';
@@ -923,7 +910,7 @@ class Fonctions
             $sql_nom=$resultat_user["u_nom"] ;
             $sql_prenom=$resultat_user["u_prenom"] ;
 
-            $choix="<a href=\"$PHP_SELF?session=$session&onglet=admin-group-users&choix_user=$sql_login\"><b>$sql_nom $sql_prenom</b></a>" ;
+            $choix="<a href=\"$PHP_SELF?onglet=admin-group-users&choix_user=$sql_login\"><b>$sql_nom $sql_prenom</b></a>" ;
 
             $childTable .= '<tr class="'.( $i ? 'i' : 'p').'">';
             $childTable .= '<td>' . $choix . '</td>';
@@ -1092,14 +1079,13 @@ class Fonctions
     public static function verif_new_param_group($new_group_name, $new_group_libelle)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         // verif des parametres reçus :
         if(strlen($new_group_name)==0) {
             $return .= '<H3>' . _('admin_verif_param_invalides') . '</H3>';
             $return .= '<new_group_name --- ' . $new_group_libelle . '<br>';
-            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group" method="POST">';
+            $return .= '<form action="' . $PHP_SELF . '?onglet=admin-group" method="POST">';
             $return .= '<input type="hidden" name="new_group_name" value="' . $new_group_name . '">';
             $return .= '<input type="hidden" name="new_group_libelle" value="' . $new_group_libelle . '">';
 
@@ -1115,7 +1101,7 @@ class Fonctions
             $num_verif = $ReqLog_verif->num_rows;
             if ($num_verif!=0) {
                 $return .= '<H3>' . _('admin_verif_groupe_invalide') . '</H3>';
-                $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group" method="POST">';
+                $return .= '<form action="' . $PHP_SELF . '?onglet=admin-group" method="POST">';
                 $return .= '<input type="hidden" name="new_group_name" value="' . $new_group_name . '">';
                 $return .= '<input type="hidden" name="new_group_libelle" value="' . $new_group_libelle . '">';
 
@@ -1133,7 +1119,6 @@ class Fonctions
     public static function ajout_groupe($new_group_name, $new_group_libelle, $new_group_double_valid)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         if(\admin\Fonctions::verif_new_param_group($new_group_name, $new_group_libelle)==0)  // verif si les nouvelles valeurs sont coohérentes et n'existent pas déjà
@@ -1156,7 +1141,7 @@ class Fonctions
             log_action(0, "", "", $comment_log);
 
             /* APPEL D'UNE AUTRE PAGE */
-            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-group" method="POST">';
+            $return .= '<form action="' . $PHP_SELF . '?onglet=admin-group" method="POST">';
             $return .= '<input type="submit" value="' . _('form_retour') . '">';
             $return .= '</form>';
         }
@@ -1166,7 +1151,6 @@ class Fonctions
     public static function affiche_gestion_groupes($new_group_name, $new_group_libelle, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_gestion_groupe') . '</h1>';
@@ -1206,8 +1190,8 @@ class Fonctions
             $sql_double_valid=$resultat_gr["g_double_valid"] ;
             $nb_users_groupe = \admin\Fonctions::get_nb_users_du_groupe($sql_gid);
 
-            $admin_modif_group = '<a href="admin_index.php?onglet=modif_group&session=' . $session . '&group=' . $sql_gid . '" title="' . _('form_modif') . '"><i class="fa fa-pencil"></i></a>';
-            $admin_suppr_group = '<a href="admin_index.php?onglet=suppr_group&session=' . $session . '&group=' . $sql_gid . '" title="' . _('form_supprim') . '"><i class="fa fa-times-circle"></i></a>';
+            $admin_modif_group = '<a href="admin_index.php?onglet=modif_group&group=' . $sql_gid . '" title="' . _('form_modif') . '"><i class="fa fa-pencil"></i></a>';
+            $admin_suppr_group = '<a href="admin_index.php?onglet=suppr_group&group=' . $sql_gid . '" title="' . _('form_supprim') . '"><i class="fa fa-times-circle"></i></a>';
 
             $childTable .= '<tr class="' . ($i ? 'i' : 'p') . '">';
             $childTable .= '<td><b>' . $sql_group .'</b></td>';
@@ -1234,7 +1218,7 @@ class Fonctions
         // TITRE
 
         $return .= '<h2>' . _('admin_groupes_new_groupe') . '</h2>';
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=' . $onglet . '" method="POST">';
         $table = new \App\Libraries\Structure\Table();
         $table->addClasses([
             'table',
@@ -1452,7 +1436,6 @@ class Fonctions
     {
 
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         if( (strlen($new_pwd1)!=0) && (strlen($new_pwd2)!=0) && (strcmp($new_pwd1, $new_pwd2)==0) ) {
@@ -1471,10 +1454,10 @@ class Fonctions
             log_action(0, "", $u_login_to_update, $comment_log);
 
             /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-            $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=admin_index.php?session=' . $session . '&onglet=admin-users">';
+            $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=admin_index.php?onglet=admin-users">';
         } else {
             $return .= '<H3>' . _('admin_verif_param_invalides') . '</H3>';
-            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=chg_pwd_user" method="POST">';
+            $return .= '<form action="' . $PHP_SELF . '?onglet=chg_pwd_user" method="POST">';
             $return .= '<input type="hidden" name="u_login" value="' . $u_login_to_update . '">';
 
             $return .= '<input type="submit" value="' . _('form_redo') . '">';
@@ -1486,14 +1469,13 @@ class Fonctions
     public static function modifier($u_login, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session='';
         $return = '';
 
         /********************/
         /* Etat utilisateur */
         /********************/
         // AFFICHAGE TABLEAU
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '&u_login_to_update=' . $u_login . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=' . $onglet . '&u_login_to_update=' . $u_login . '" method="POST">';
         $table = new \App\Libraries\Structure\Table();
         $table->addClasses(['tablo']);
         $table->addAttribute('width', '80%');
@@ -1529,7 +1511,7 @@ class Fonctions
         $return .= '<input type="submit" value="' . _('form_submit') . '">';
         $return .= '</form>';
 
-        $return .= '<form action="admin_index.php?session=' . $session . '&onglet=admin-users" method="POST">';
+        $return .= '<form action="admin_index.php?onglet=admin-users" method="POST">';
         $return .= '<input type="submit" value="' . _('form_cancel') . '">';
         $return .= '</form>';
         return $return;
@@ -1539,13 +1521,12 @@ class Fonctions
      * Encapsule le comportement du module de gestion des groupes et des responsables
      *
      * @param string $onglet Nom de l'onglet à afficher
-     * @param string $session
      *
      * @return string
      * @access public
      * @static
      */
-    public static function changeMotDePasseUserModule($onglet, $session)
+    public static function changeMotDePasseUserModule($onglet)
     {
         $return = '';
         /*************************************/
@@ -1566,7 +1547,7 @@ class Fonctions
                 $return .= \admin\Fonctions::commit_update($u_login_to_update, $new_pwd1, $new_pwd2);
             } else {
                 // renvoit sur la page principale .
-                redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-users', false);
+                redirect( ROOT_PATH .'admin/admin_index.php?onglet=admin-users', false);
             }
         }
         return $return;
@@ -1623,7 +1604,6 @@ class Fonctions
     public static function restaure($fichier_restaure_name, $fichier_restaure_tmpname, $fichier_restaure_size, $fichier_restaure_error)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         header_popup();
@@ -1634,7 +1614,7 @@ class Fonctions
             //(cf code erreur dans fichier features.file-upload.errors.html de la doc php)
         {
             //message d'erreur et renvoit sur la page précédente (choix fichier)
-            $return.= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+            $return.= '<form action="' . $PHP_SELF . '" method="POST">';
             $table = new \App\Libraries\Structure\Table();
             $childTable = '<tr>';
             $childTable .= '<th>' . _('admin_sauve_db_bad_file') . ' : <br>' . $fichier_restaure_name .'</th>';
@@ -1683,13 +1663,12 @@ class Fonctions
     public static function choix_restaure()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         header_popup();
 
         $return .= '<h1>' . _('admin_sauve_db_titre') . '</h1>';
-        $return .= '<form enctype="multipart/form-data" action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+        $return .= '<form enctype="multipart/form-data" action="' . $PHP_SELF . '" method="POST">';
         $table = new \App\Libraries\Structure\Table();
         $childTable = '<tr>';
         $childTable .= '<th>' . _('admin_sauve_db_restaure') . '<br>' . _('admin_sauve_db_file_to_restore') . ' :</th>';
@@ -1790,16 +1769,15 @@ class Fonctions
     public static function sauve($type_sauvegarde)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
-        redirect(ROOT_PATH .'admin/admin_db_sauve.php?session='.$session.'&choix_action=sauvegarde&type_sauvegarde='.$type_sauvegarde.'&commit=ok', false);
+        redirect(ROOT_PATH .'admin/admin_db_sauve.php?choix_action=sauvegarde&type_sauvegarde='.$type_sauvegarde.'&commit=ok', false);
 
         header_popup();
 
         $return .= '<h1>' . _('admin_sauve_db_titre') . '</h1>';
 
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '" method="POST">';
         $table = new \App\Libraries\Structure\Table();
         $childTable = '<tr>';
         $childTable .= '<th colspan="2">' . _('admin_sauve_db_save_ok') . ' ...</th>';
@@ -1822,7 +1800,6 @@ class Fonctions
     public static function choix_sauvegarde()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
 
@@ -1830,7 +1807,7 @@ class Fonctions
 
         $return .= '<h1>' . _('admin_sauve_db_titre') . '</h1>';
 
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '" method="POST">';
         $table = new \App\Libraries\Structure\Table();
         $childTable = '<tr>';
         $childTable .= '<th colspan="2">' . _('admin_sauve_db_options') . '</th>';
@@ -1870,14 +1847,13 @@ class Fonctions
     public static function choix_save_restore()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         header_popup();
 
         $return .= '<h1>' . _('admin_sauve_db_titre') . '</h1>';
 
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '" method="POST">';
         $table = new \App\Libraries\Structure\Table();
         $childTable = '<tr>';
         $childTable .= '<th colspan="2">' . _('admin_sauve_db_choisissez') . ' :</th>';
@@ -1916,16 +1892,14 @@ class Fonctions
     /**
      * Encapsule le comportement du module de sauvegarde / restauration de bdd
      *
-     * @param string $session
-     *
      * @return void
      * @access public
      * @static
      */
-    public static function saveRestoreModule($session)
+    public static function saveRestoreModule()
     {
         // verif des droits du user à afficher la page
-        verif_droits_user($session, "is_admin");
+        verif_droits_user( "is_admin");
 
 
         /*** initialisation des variables ***/
@@ -1968,14 +1942,13 @@ class Fonctions
                 \admin\Fonctions::restaure($fichier_restaure_name, $fichier_restaure_tmpname, $fichier_restaure_size, $fichier_restaure_error);
         } else {
             /* APPEL D'UNE AUTRE PAGE immediat */
-            echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=admin_index.php?session=$session&onglet=admin-users\">";
+            echo "<META HTTP-EQUIV=REFRESH CONTENT=\"0; URL=admin_index.php?onglet=admin-users\">";
         }
     }
 
     public static function commit_update_groupe($group_to_update, $new_groupname, $new_comment, $new_double_valid)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
         $result   = TRUE;
         $new_comment=addslashes($new_comment);
@@ -1999,7 +1972,7 @@ class Fonctions
         }
 
         /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-        $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=admin_index.php?session=' . $session . '&onglet=admin-group">';
+        $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=admin_index.php?onglet=admin-group">';
         return $return;
     }
 
@@ -2012,7 +1985,7 @@ class Fonctions
         $sql1 = 'SELECT g_groupename, g_comment, g_double_valid FROM conges_groupe WHERE g_gid = "'. \includes\SQL::quote($group).'"';
 
         // AFFICHAGE TABLEAU
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '&group_to_update=' . $group . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=' . $onglet . '&group_to_update=' . $group . '" method="POST">';
         $table = new \App\Libraries\Structure\Table();
         $table->addClasses([
             'table',
@@ -2740,7 +2713,6 @@ class Fonctions
     public static function suppression($u_login_to_delete)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         $sql1 = 'DELETE FROM conges_users WHERE u_login = "'. \includes\SQL::quote($u_login_to_delete).'"';
@@ -2776,14 +2748,13 @@ class Fonctions
     public static function confirmer_suppression($u_login, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         /*****************************/
         /* Etat Utilisateur en cours */
         /*****************************/
         // AFFICHAGE TABLEAU
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '&u_login_to_delete=' . $u_login . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=' . $onglet . '&u_login_to_delete=' . $u_login . '" method="POST">';
         $table = new \App\Libraries\Structure\Table();
         $table->addClasses([
             'table',
@@ -2819,7 +2790,7 @@ class Fonctions
         $return .= ob_get_clean();
         $return .= '<br>';
         $return .= '<input class="btn btn-danger" type="submit" value="' . _('form_supprim') . '">';
-        $return .= '<a class="btn" href="admin_index.php?session=' . $session . '&onglet=admin-users">' . _('form_cancel') . '</a>';
+        $return .= '<a class="btn" href="admin_index.php?onglet=admin-users">' . _('form_cancel') . '</a>';
         $return .= '</form>';
         return $return;
     }
@@ -2993,7 +2964,6 @@ class Fonctions
     public static function affiche_formulaire_ajout_user(&$tab_new_user, &$tab_new_jours_an, &$tab_new_solde, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session='';
         $return = '';
 
         // recup du tableau des types de conges (seulement les conges)
@@ -3011,7 +2981,7 @@ class Fonctions
         // TITRE
         $return .= '<h1>' . _('admin_new_users_titre') . '</h1>';
 
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=' . $onglet . '" method="POST">';
 
         /****************************************/
         // tableau des infos de user
@@ -3218,7 +3188,7 @@ class Fonctions
         $return .= '<hr>';
         $return .= '<input type="hidden" name="saisie_user" value="ok">';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
-        $return .= ' <a class="btn btn-default" href="' . $PHP_SELF . '?session=' . $session . '">' . _('form_cancel') . '</a>';
+        $return .= ' <a class="btn btn-default" href="' . $PHP_SELF . '">' . _('form_cancel') . '</a>';
         $return .= '</form>';
         return $return;
     }
@@ -3226,7 +3196,6 @@ class Fonctions
     public static function verif_new_param(&$tab_new_user, &$tab_new_jours_an, &$tab_new_solde, &$return = null)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
 
         foreach($tab_new_jours_an as $id_cong => $jours_an) {
@@ -3244,7 +3213,7 @@ class Fonctions
                 $return .= $tab_new_jours_an[$id_cong] . '---' . $tab_new_solde[$id_cong] . '<br>';
             }
 
-            $return .= '<form action="' . $PHP_SELF . '?session=' . $session .  '&onglet=ajout-user" method="POST">';
+            $return .= '<form action="' . $PHP_SELF . '?onglet=ajout-user" method="POST">';
             $return .= '<input type="hidden" name="new_login" value="' . $tab_new_user['login'] . '">';
             $return .= '<input type="hidden" name="new_nom" value="' . $tab_new_user['nom'] . '">';
             $return .= '<input type="hidden" name="new_prenom" value="' . $tab_new_user['prenom'] . '">';
@@ -3274,7 +3243,7 @@ class Fonctions
             $num_verif = $ReqLog_verif->num_rows;
             if ($num_verif!=0) {
                 $return .= '<h3><font color="red">' . _('admin_verif_login_exist') . '</font></h3>';
-                $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout-user" method="POST">';
+                $return .= '<form action="' . $PHP_SELF . '?onglet=ajout-user" method="POST">';
                 $return .= '<input type="hidden" name="new_login" value="' . $tab_new_user['login'] . '">';
                 $return .= '<input type="hidden" name="new_nom" value="' . $tab_new_user['nom'] . '">';
                 $return .= '<input type="hidden" name="new_prenom" value="' . $tab_new_user['prenom'] . '">';
@@ -3298,7 +3267,7 @@ class Fonctions
                 return true;
             } elseif($_SESSION['config']['where_to_find_user_email'] == "dbconges" && strrchr($tab_new_user['email'], "@")==FALSE) {
                 $return .= '<h3>' . _('admin_verif_bad_mail') . '</h3>';
-                $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout-user" method="POST">';
+                $return .= '<form action="' . $PHP_SELF . '?onglet=ajout-user" method="POST">';
                 $return .= '<input type="hidden" name="new_login" value="' . $tab_new_user['login'] . '">';
                 $return .= '<input type="hidden" name="new_nom" value="' . $tab_new_user['nom'] . '">';
                 $return .= '<input type="hidden" name="new_prenom" value="' . $tab_new_user['prenom'] . '">';
@@ -3365,7 +3334,6 @@ class Fonctions
     public static function ajout_user(&$tab_new_user, &$tab_new_jours_an, &$tab_new_solde, $checkbox_user_groups)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = '';
         $return   = '';
         $verifFalse = '';
 
@@ -3440,7 +3408,7 @@ class Fonctions
             log_action(0, "", $tab_new_user['login'], $comment_log);
 
             /* APPEL D'UNE AUTRE PAGE */
-            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=admin-users" method="POST">';
+            $return .= '<form action="' . $PHP_SELF . '?onglet=admin-users" method="POST">';
             $return .= '<input type="submit" value="' . _('form_retour') .'">';
             $return .= '</form>';
         } else {

--- a/admin/Fonctions.php
+++ b/admin/Fonctions.php
@@ -10,7 +10,7 @@ class Fonctions
     public static function modif_resp_groupes($choix_resp, &$checkbox_resp_group, &$checkbox_grd_resp_group)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         $result_insert=TRUE;
@@ -63,7 +63,7 @@ class Fonctions
     public static function affiche_gestion_responsable_groupes($choix_resp, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_resp_groupe') . '</h1>';
@@ -248,7 +248,7 @@ class Fonctions
     public static function affiche_choix_responsable_groupes()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_resp_groupe') . '</h1>';
@@ -305,7 +305,7 @@ class Fonctions
     public static function modif_group_responsables($choix_group, &$checkbox_group_resp, &$checkbox_group_grd_resp)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         $result_insert=TRUE;
@@ -359,7 +359,7 @@ class Fonctions
     public static function affiche_gestion_groupes_responsables($choix_group, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_groupe_resp') . '</h1>';
@@ -531,7 +531,7 @@ class Fonctions
     public static function affiche_choix_groupes_responsables()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         /********************/
@@ -582,7 +582,7 @@ class Fonctions
     public static function affiche_choix_gestion_groupes_responsables($choix_group, $choix_resp, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         if( $choix_group!="" )    // si un groupe choisi : on affiche la gestion par groupe
@@ -643,7 +643,7 @@ class Fonctions
     public static function modif_user_groups($choix_user, &$checkbox_user_groups)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
+        $session='';
         $return = '';
 
         $result_insert= \admin\Fonctions::commit_modif_user_groups($choix_user, $checkbox_user_groups);
@@ -667,7 +667,7 @@ class Fonctions
     public static function modif_group_users($choix_group, &$checkbox_group_users)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         // on supprime tous les anciens users du groupe puis on ajoute tous ceux qui sont dans le tableau checkbox (si il n'est pas vide)
@@ -702,7 +702,7 @@ class Fonctions
 
     public static function affiche_gestion_groupes_users($choix_group, $onglet) {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_groupe_user') . '</h1>';
@@ -804,7 +804,7 @@ class Fonctions
     public static function affiche_choix_groupes_users()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_groupe_user') . '</h1>';
@@ -859,7 +859,7 @@ class Fonctions
     public static function affiche_gestion_user_groupes($choix_user, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_user_groupe') . '</h1>';
@@ -884,7 +884,7 @@ class Fonctions
     public static function affiche_choix_user_groupes()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_user_groupe') . '</h1>';
@@ -1092,7 +1092,7 @@ class Fonctions
     public static function verif_new_param_group($new_group_name, $new_group_libelle)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         // verif des parametres reçus :
@@ -1133,7 +1133,7 @@ class Fonctions
     public static function ajout_groupe($new_group_name, $new_group_libelle, $new_group_double_valid)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         if(\admin\Fonctions::verif_new_param_group($new_group_name, $new_group_libelle)==0)  // verif si les nouvelles valeurs sont coohérentes et n'existent pas déjà
@@ -1166,7 +1166,7 @@ class Fonctions
     public static function affiche_gestion_groupes($new_group_name, $new_group_libelle, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         $return .= '<h1>' . _('admin_onglet_gestion_groupe') . '</h1>';
@@ -1297,16 +1297,14 @@ class Fonctions
     /**
      * Encapsule le comportement du module de gestion des utilisateurs
      *
-     * @param string $session
-     *
      * @return string
      * @access public
      * @static
      */
-    public static function userModule($session)
+    public static function userModule()
     {
         $return = '';
-        $return .= '<a href="' . ROOT_PATH . 'admin/admin_index.php?session='. session_id().'&amp;onglet=ajout-user" style="float:right" class="btn btn-success">' . _('admin_onglet_add_user') . '</a>';
+        $return .= '<a href="' . ROOT_PATH . 'admin/admin_index.php?onglet=ajout-user" style="float:right" class="btn btn-success">' . _('admin_onglet_add_user') . '</a>';
         $return .= '<h1>' . _('admin_onglet_gestion_user') . '</h1>';
 
         /*********************/
@@ -1370,9 +1368,9 @@ class Fonctions
         uasort($tab_info_users, "sortParActif");
         $i = true;
         foreach ($tab_info_users as $current_login => $tab_current_infos) {
-            $admin_modif_user= '<a href="admin_index.php?onglet=modif_user&session=' . $session . '&u_login=' . $current_login . '" title="' . _('form_modif') . '"><i class="fa fa-pencil"></i></a>';
-            $admin_suppr_user = '<a href="admin_index.php?onglet=suppr_user&session=' . $session . '&u_login=' . $current_login . '" title="' . _('form_supprim') . '"><i class="fa fa-times-circle"></i></a>';
-            $admin_chg_pwd_user = '<a href="admin_index.php?onglet=chg_pwd_user&session=' . $session . '&u_login=' . $current_login . '" title="' . _('form_password') . '"><i class="fa fa-key"></i></a>';
+            $admin_modif_user= '<a href="admin_index.php?onglet=modif_user&u_login=' . $current_login . '" title="' . _('form_modif') . '"><i class="fa fa-pencil"></i></a>';
+            $admin_suppr_user = '<a href="admin_index.php?onglet=suppr_user&u_login=' . $current_login . '" title="' . _('form_supprim') . '"><i class="fa fa-times-circle"></i></a>';
+            $admin_chg_pwd_user = '<a href="admin_index.php?onglet=chg_pwd_user&u_login=' . $current_login . '" title="' . _('form_password') . '"><i class="fa fa-key"></i></a>';
 
 
             $childTable .= '<tr class="' . (($tab_current_infos['is_active']=='Y') ? 'actif' : 'inactif') . '">';
@@ -1454,7 +1452,7 @@ class Fonctions
     {
 
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         if( (strlen($new_pwd1)!=0) && (strlen($new_pwd2)!=0) && (strcmp($new_pwd1, $new_pwd2)==0) ) {
@@ -1488,7 +1486,7 @@ class Fonctions
     public static function modifier($u_login, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
+        $session='';
         $return = '';
 
         /********************/
@@ -1625,7 +1623,7 @@ class Fonctions
     public static function restaure($fichier_restaure_name, $fichier_restaure_tmpname, $fichier_restaure_size, $fichier_restaure_error)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         header_popup();
@@ -1685,7 +1683,7 @@ class Fonctions
     public static function choix_restaure()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         header_popup();
@@ -1792,7 +1790,7 @@ class Fonctions
     public static function sauve($type_sauvegarde)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         redirect(ROOT_PATH .'admin/admin_db_sauve.php?session='.$session.'&choix_action=sauvegarde&type_sauvegarde='.$type_sauvegarde.'&commit=ok', false);
@@ -1824,7 +1822,7 @@ class Fonctions
     public static function choix_sauvegarde()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
 
@@ -1872,7 +1870,7 @@ class Fonctions
     public static function choix_save_restore()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         header_popup();
@@ -1977,7 +1975,7 @@ class Fonctions
     public static function commit_update_groupe($group_to_update, $new_groupname, $new_comment, $new_double_valid)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
         $result   = TRUE;
         $new_comment=addslashes($new_comment);
@@ -2008,7 +2006,6 @@ class Fonctions
     public static function modifier_groupe($group, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
         $return   = '';
 
         // Récupération des informations
@@ -2077,7 +2074,7 @@ class Fonctions
         $return .= ob_get_clean();
         $return .= '<hr/>';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_submit') . '">';
-        $return .= '<a class="btn" href="admin_index.php?session=' . $session . '&onglet=admin-group">' . _('form_cancel') . '</a>';
+        $return .= '<a class="btn" href="admin_index.php?onglet=admin-group">' . _('form_cancel') . '</a>';
         $return .= '</form>';
         return $return;
     }
@@ -2085,14 +2082,13 @@ class Fonctions
     /**
      * Encapsule le comportement du module de modif des groupes
      *
-     * @param string $session
      * @param mixed  $onglet
      *
      * @return void
      * @access public
      * @static
      */
-    public static function modifGroupeModule($session, $onglet)
+    public static function modifGroupeModule($onglet)
     {
         /*************************************/
         // recup des parametres reçus :
@@ -2114,7 +2110,7 @@ class Fonctions
             $return .= \admin\Fonctions::commit_update_groupe($group_to_update, $new_groupname, $new_comment, $new_double_valid);
         } else {
             // renvoit sur la page principale .
-            redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-group', false);
+            redirect( ROOT_PATH .'admin/admin_index.php?onglet=admin-group', false);
         }
         return $return;
     }
@@ -2123,7 +2119,6 @@ class Fonctions
     {
         $dataUser = \App\ProtoControllers\Utilisateur::getDonneesUtilisateur($u_login_to_update);
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
         $erreurs = [];
 
         $result=true;
@@ -2272,7 +2267,7 @@ class Fonctions
                     $errors .= '<li>' . $erreur . '</li>';
                 }
             }
-            $return .= '<div class="alert alert-danger">' . _('erreur_recommencer') . ' :<ul>' . $errors . '</ul><br /><a href="admin_index.php?onglet=modif_user&session=' . $session . '&u_login=' . $u_login_to_update . '">' . _('form_retour') . '</a></div>';
+            $return .= '<div class="alert alert-danger">' . _('erreur_recommencer') . ' :<ul>' . $errors . '</ul><br /><a href="admin_index.php?onglet=modif_user&u_login=' . $u_login_to_update . '">' . _('form_retour') . '</a></div>';
 
             return false;
         }
@@ -2281,7 +2276,6 @@ class Fonctions
     public static function modifier_user($u_login, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
         $return   = '';
         $soldeHeureId = uniqid();
 
@@ -2300,7 +2294,7 @@ class Fonctions
         /********************/
         /* Etat utilisateur */
         /********************/
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet . '&u_login_to_update=' . $u_login . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=' . $onglet . '&u_login_to_update=' . $u_login . '" method="POST">';
         // AFFICHAGE TABLEAU DES INFOS
         $table = new \App\Libraries\Structure\Table();
         $table->addClasses([
@@ -2553,7 +2547,7 @@ class Fonctions
         $return .= '<div>' . $planningName . '</div>';
 
         $return .= '<hr /><input class="btn btn-success" type="submit" value="' . _('form_submit') . '"> ';
-        $return .= '<a class="btn btn-default" href="admin_index.php?session=' . $session . '&onglet=admin-users">' . _('form_cancel') . '</a>';
+        $return .= '<a class="btn btn-default" href="admin_index.php?onglet=admin-users">' . _('form_cancel') . '</a>';
         $return .= '</form>';
         return $return;
     }
@@ -2561,14 +2555,13 @@ class Fonctions
     /**
      * Encapsule le comportement du module de modification d'utilisateurs
      *
-     * @param string $session
      * @param string $onglet Nom de l'onglet à afficher
      *
      * @return string
      * @access public
      * @static
      */
-    public static function modifUserModule($session, $onglet)
+    public static function modifUserModule($onglet)
     {
         $u_login              = htmlentities(getpost_variable('u_login'));
         $u_login_to_update    = htmlentities(getpost_variable('u_login_to_update')) ;
@@ -2614,14 +2607,14 @@ class Fonctions
 
             $ok = \admin\Fonctions::commit_update_user($u_login_to_update, $tab_new_user, $tab_new_jours_an, $tab_new_solde, $tab_new_reliquat, $echo);
             if ($ok) {
-                redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-users', false);
+                redirect( ROOT_PATH .'admin/admin_index.php?onglet=admin-users', false);
                 exit;
             } else {
                 $return .= $echo;
             }
         } else {
             // renvoit sur la page principale .
-            redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-users', false);
+            redirect( ROOT_PATH .'admin/admin_index.php?onglet=admin-users', false);
             exit;
         }
         return $return;
@@ -2630,7 +2623,6 @@ class Fonctions
     public static function suppression_group($group_to_delete)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         $sql1 = 'DELETE FROM conges_groupe WHERE g_gid = '.\includes\SQL::quote($group_to_delete);
@@ -2657,14 +2649,13 @@ class Fonctions
         }
 
         /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-        $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=admin_index.php?session=' . $session . '&onglet=admin-group">';
+        $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=admin_index.php?onglet=admin-group">';
         return $return;
     }
 
     public static function confirmer($group, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
         $return   = '';
 
         /*******************/
@@ -2676,7 +2667,7 @@ class Fonctions
 
         // AFFICHAGE TABLEAU
 
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=' . $onglet.'&group_to_delete=' . $group . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=' . $onglet.'&group_to_delete=' . $group . '" method="POST">';
         $table = new \App\Libraries\Structure\Table();
         $table->addClasses([
             'table',
@@ -2710,7 +2701,7 @@ class Fonctions
         $return .= ob_get_clean();
         $return .= '<hr/>';
         $return .= '<input class="btn btn-danger" type="submit" value="' . _('form_supprim') . '">';
-        $return .= '<a class="btn" href="admin_index.php?session=' . $session . '&onglet=admin-group">' . _('form_cancel') . '</a>';
+        $return .= '<a class="btn" href="admin_index.php?onglet=admin-group">' . _('form_cancel') . '</a>';
         $return .= '</form>';
 
         return $return;
@@ -2719,14 +2710,13 @@ class Fonctions
     /**
      * Encapsule le comportement du module de suppression des groupes
      *
-     * @param string $session
      * @param string $onglet Nom de l'onglet à afficher
      *
      * @return void
      * @access public
      * @static
      */
-    public static function supprimerGroupeModule($session, $onglet)
+    public static function supprimerGroupeModule($onglet)
     {
         $group = getpost_variable('group');
         $group_to_delete = getpost_variable('group_to_delete');
@@ -2742,7 +2732,7 @@ class Fonctions
             $return .= \admin\Fonctions::suppression_group($group_to_delete);
         } else {
             // renvoit sur la page principale .
-            redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-group', false);
+            redirect( ROOT_PATH .'admin/admin_index.php?onglet=admin-group', false);
         }
         return $return;
     }
@@ -2750,7 +2740,7 @@ class Fonctions
     public static function suppression($u_login_to_delete)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         $sql1 = 'DELETE FROM conges_users WHERE u_login = "'. \includes\SQL::quote($u_login_to_delete).'"';
@@ -2786,7 +2776,7 @@ class Fonctions
     public static function confirmer_suppression($u_login, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         /*****************************/
@@ -2837,14 +2827,13 @@ class Fonctions
     /**
      * Encapsule le comportement du module de suppression des utilisateurs
      *
-     * @param string $session
      * @param string $onglet
      *
      * @return string
      * @access public
      * @static
      */
-    public static function supprimerUtilisateurModule($session, $onglet)
+    public static function supprimerUtilisateurModule($onglet)
     {
         $return = '';
         /*************************************/
@@ -2868,11 +2857,11 @@ class Fonctions
             $return .= \admin\Fonctions::confirmer_suppression($u_login, $onglet);
         } elseif($u_login_to_delete!="") {
             echo \admin\Fonctions::suppression($u_login_to_delete);
-            redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-users', false);
+            redirect( ROOT_PATH .'admin/admin_index.php?onglet=admin-users', false);
             exit;
         } else {
             // renvoit sur la page principale .
-            redirect( ROOT_PATH .'admin/admin_index.php?session='.$session.'&onglet=admin-users', false);
+            redirect( ROOT_PATH .'admin/admin_index.php?onglet=admin-users', false);
             exit;
         }
         return $return;
@@ -3004,7 +2993,7 @@ class Fonctions
     public static function affiche_formulaire_ajout_user(&$tab_new_user, &$tab_new_jours_an, &$tab_new_solde, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
+        $session='';
         $return = '';
 
         // recup du tableau des types de conges (seulement les conges)
@@ -3237,7 +3226,7 @@ class Fonctions
     public static function verif_new_param(&$tab_new_user, &$tab_new_jours_an, &$tab_new_solde, &$return = null)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
 
         foreach($tab_new_jours_an as $id_cong => $jours_an) {
@@ -3376,7 +3365,7 @@ class Fonctions
     public static function ajout_user(&$tab_new_user, &$tab_new_jours_an, &$tab_new_solde, $checkbox_user_groups)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session  = session_id();
+        $session  = '';
         $return   = '';
         $verifFalse = '';
 

--- a/admin/admin_admin-users.php
+++ b/admin/admin_admin-users.php
@@ -1,4 +1,4 @@
 <?php
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-echo \admin\Fonctions::userModule($session);
+echo \admin\Fonctions::userModule();

--- a/admin/admin_chg_pwd_user.php
+++ b/admin/admin_chg_pwd_user.php
@@ -1,4 +1,4 @@
 <?php
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-echo \admin\Fonctions::changeMotDePasseUserModule($onglet, $session);
+echo \admin\Fonctions::changeMotDePasseUserModule($onglet);

--- a/admin/admin_db_sauve.php
+++ b/admin/admin_db_sauve.php
@@ -3,10 +3,8 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
-
 include_once ROOT_PATH .'fonctions_conges.php' ;
 include_once INCLUDE_PATH .'fonction.php';
 include_once INCLUDE_PATH .'session.php';
 
-\admin\Fonctions::saveRestoreModule($session);
+\admin\Fonctions::saveRestoreModule();

--- a/admin/admin_index.php
+++ b/admin/admin_index.php
@@ -11,7 +11,7 @@ include_once INCLUDE_PATH .'session.php';
 include_once ROOT_PATH .'fonctions_calcul.php';
 
 // verif des droits du user à afficher la page
-verif_droits_user($session, 'is_admin');
+verif_droits_user('is_admin');
 
 
 
@@ -58,7 +58,7 @@ header_menu('', 'Libertempo : '._('button_admin_mode'),$add_css);
 echo '<div id="onglet_menu">';
 foreach($onglets as $key => $title) {
     echo '<div class="onglet '.($onglet == $key ? ' active': '').'" >
-        <a href="'.$PHP_SELF.'?&onglet='.$key.'">'. $title .'</a>
+        <a href="'.$PHP_SELF.'?onglet='.$key.'">'. $title .'</a>
     </div>';
 }
 echo '</div>';

--- a/admin/admin_index.php
+++ b/admin/admin_index.php
@@ -3,8 +3,6 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-$session='';
-
 include_once ROOT_PATH .'fonctions_conges.php' ;
 include_once INCLUDE_PATH .'fonction.php';
 include_once INCLUDE_PATH .'session.php';

--- a/admin/admin_index.php
+++ b/admin/admin_index.php
@@ -3,7 +3,7 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
+$session='';
 
 include_once ROOT_PATH .'fonctions_conges.php' ;
 include_once INCLUDE_PATH .'fonction.php';
@@ -58,7 +58,7 @@ header_menu('', 'Libertempo : '._('button_admin_mode'),$add_css);
 echo '<div id="onglet_menu">';
 foreach($onglets as $key => $title) {
     echo '<div class="onglet '.($onglet == $key ? ' active': '').'" >
-        <a href="'.$PHP_SELF.'?session='.$session.'&onglet='.$key.'">'. $title .'</a>
+        <a href="'.$PHP_SELF.'?&onglet='.$key.'">'. $title .'</a>
     </div>';
 }
 echo '</div>';

--- a/admin/admin_modif_group.php
+++ b/admin/admin_modif_group.php
@@ -1,4 +1,4 @@
 <?php
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-echo \admin\Fonctions::modifGroupeModule($session, $onglet);
+echo \admin\Fonctions::modifGroupeModule($onglet);

--- a/admin/admin_modif_user.php
+++ b/admin/admin_modif_user.php
@@ -1,4 +1,4 @@
 <?php
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-echo \admin\Fonctions::modifUserModule($session, $onglet);
+echo \admin\Fonctions::modifUserModule($onglet);

--- a/admin/admin_suppr_group.php
+++ b/admin/admin_suppr_group.php
@@ -1,4 +1,4 @@
 <?php
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-echo \admin\Fonctions::supprimerGroupeModule($session, $onglet);
+echo \admin\Fonctions::supprimerGroupeModule($onglet);

--- a/admin/admin_suppr_user.php
+++ b/admin/admin_suppr_user.php
@@ -1,4 +1,4 @@
 <?php
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-echo \admin\Fonctions::supprimerUtilisateurModule($session, $onglet);
+echo \admin\Fonctions::supprimerUtilisateurModule($onglet);

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -133,7 +133,7 @@ class Fonctions
     public static function logModule($session)
     {
         // verif des droits du user à afficher la page
-        verif_droits_user($session, "is_admin");
+        verif_droits_user("is_admin");
         $return = '';
 
         /*** initialisation des variables ***/
@@ -308,7 +308,7 @@ class Fonctions
     public static function mailModule($session)
     {
         // verif des droits du user à afficher la page
-        verif_droits_user($session, "is_admin");
+        verif_droits_user("is_admin");
         $return = '';
 
 
@@ -800,7 +800,7 @@ class Fonctions
         include_once INCLUDE_PATH .'session.php';
 
         // verif des droits du user à afficher la page
-        verif_droits_user($session, "is_admin");
+        verif_droits_user( "is_admin");
 
 
 
@@ -1097,7 +1097,7 @@ class Fonctions
     public static function configurationModule($session)
     {
         // verif des droits du user à afficher la page
-        verif_droits_user($session, "is_admin");
+        verif_droits_user("is_admin");
         $return = '';
 
         /*** initialisation des variables ***/

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -7,7 +7,7 @@ namespace config;
  */
 class Fonctions
 {
-    public static function commit_vider_table_logs($session)
+    public static function commit_vider_table_logs()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -20,32 +20,27 @@ class Fonctions
         log_action(0, "", "", $comment_log);
 
         $return .= '<span class="messages">' . _('form_modif_ok') . '</span><br>';
-        if($session=="") {
-            redirect( ROOT_PATH . 'config/index.php?onglet=logs');
-        }
-        else {
-            redirect( ROOT_PATH . 'config/index.php?session=' . $session . '&onglet=logs');
-        }
+        redirect( ROOT_PATH . 'config/index.php?onglet=logs');
     }
 
-    public static function confirmer_vider_table_logs($session)
+    public static function confirmer_vider_table_logs()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
         $return .= '<center>';
         $return .= '<br><h2>' . _('confirm_vider_logs') . '</h2><br>';
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=logs" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=logs" method="POST">';
         $return .= '<input type="hidden" name="action" value="commit_suppr_logs">';
         $return .= '<input type="submit" value="' . _('form_delete_logs') . '">';
         $return .= '</form>';
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=logs" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=logs" method="POST">';
         $return .= '<input type="submit" value="' . _('form_cancel') . '"">';
         $return .= '</form></center>';
         return $return;
     }
 
-    public static function affichage($login_par, $session)
+    public static function affichage($login_par)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -71,7 +66,7 @@ class Fonctions
 
             $childTable = '<tr><td class="histo" colspan="5">' . _('voir_les_logs_par') . '</td>';
             if($login_par!="") {
-                $childTable .= '<tr><td class="histo" colspan="5">' . _('voir_tous_les_logs') . '<a href="' . $PHP_SELF . '?session=' . $session . '&onglet=logs">' . _('voir_tous_les_logs') . '</a></td>';
+                $childTable .= '<tr><td class="histo" colspan="5">' . _('voir_tous_les_logs') . '<a href="' . $PHP_SELF . '?onglet=logs">' . _('voir_tous_les_logs') . '</a></td>';
             }
             $childTable .= '<tr><td class="histo" colspan="5">&nbsp;</td>';
 
@@ -94,7 +89,7 @@ class Fonctions
 
                 $childTable .= '<tr>';
                 $childTable .= '<td>' . $log_log_date . '</td>';
-                $childTable .= '<td><a href="' . $PHP_SELF . '?session=' . $session . '&onglet=logs&login_par=' . $log_login_par . '"><b>' . $log_login_par . '</b></a></td>';
+                $childTable .= '<td><a href="' . $PHP_SELF . '?onglet=logs&login_par=' . $log_login_par . '"><b>' . $log_login_par . '</b></a></td>';
                 $childTable .= '<td>' . $log_login_pour . '</td>';
                 $childTable .= '<td>' . $log_log_comment . '</td>';
                 $childTable .= '<td>' . $log_log_etat . '</td>';
@@ -105,11 +100,7 @@ class Fonctions
             ob_start();
             $table->render();
             $return .= ob_get_clean();
-            if($session=="") {
-                $return .= '<form action="' . $PHP_SELF . '?onglet=logs" method="POST">';
-            } else {
-                $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=logs" method="POST">';
-            }
+            $return .= '<form action="' . $PHP_SELF . '?onglet=logs" method="POST">';
 
             // affichage du bouton pour vider les logs
             $return .= '<input type="hidden" name="action" value="suppr_logs">';
@@ -124,13 +115,11 @@ class Fonctions
     /**
      * Encapsule le comportement du module d'affichage des logs
      *
-     * @param string $session
-     *
      * @return void
      * @access public
      * @static
      */
-    public static function logModule($session)
+    public static function logModule()
     {
         // verif des droits du user à afficher la page
         verif_droits_user("is_admin");
@@ -153,26 +142,22 @@ class Fonctions
 
 
         if($action=="suppr_logs") {
-            $return .= \config\Fonctions::confirmer_vider_table_logs($session);
+            $return .= \config\Fonctions::confirmer_vider_table_logs();
         } elseif($action=="commit_suppr_logs") {
-            \config\Fonctions::commit_vider_table_logs($session);
+            \config\Fonctions::commit_vider_table_logs();
         } else {
-            $return .= \config\Fonctions::affichage($login_par, $session);
+            $return .= \config\Fonctions::affichage($login_par);
         }
         // bottom();
         return $return;
     }
 
-    public static function commit_modif($tab_new_values, $session)
+    public static function commit_modif($tab_new_values)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
-        if($session=="") {
-            $URL = "$PHP_SELF?onglet=mail";
-        } else {
-            $URL = "$PHP_SELF?session=$session&onglet=mail";
-        }
+        $URL = "$PHP_SELF?onglet=mail";
 
 
         // update de la table
@@ -191,16 +176,12 @@ class Fonctions
         return $return;
     }
 
-    public static function test_config($tab_new_values, $session)
+    public static function test_config($tab_new_values)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
-        if($session=="") {
-            $URL = "$PHP_SELF?onglet=mail";
-        } else {
-            $URL = "$PHP_SELF?session=$session&onglet=mail";
-        }
+        $URL = "$PHP_SELF?onglet=mail";
 
         // update de la table
         $mail_array             = find_email_adress_for_user($_SESSION['userlogin']);
@@ -218,16 +199,12 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage_config_mail($tab_new_values, $session)
+    public static function affichage_config_mail($tab_new_values)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
-        if($session=="") {
-            $URL = "$PHP_SELF?onglet=mail";
-        } else {
-            $URL = "$PHP_SELF?session=$session&onglet=mail";
-        }
+        $URL = "$PHP_SELF?onglet=mail";
 
         /**************************************/
         // affichage du titre
@@ -299,13 +276,11 @@ class Fonctions
     /**
      * Encapsule le comportement du module d'affichage des logs
      *
-     * @param string $session
-     *
      * @return void
      * @access public
      * @static
      */
-    public static function mailModule($session)
+    public static function mailModule()
     {
         // verif des droits du user à afficher la page
         verif_droits_user("is_admin");
@@ -323,13 +298,13 @@ class Fonctions
         /*********************************/
 
         if($action=="modif") {
-            $return .= \config\Fonctions::commit_modif($tab_new_values, $session);
+            $return .= \config\Fonctions::commit_modif($tab_new_values);
         }
         if($action=="test") {
-            $return .= \config\Fonctions::test_config($tab_new_values, $session);
+            $return .= \config\Fonctions::test_config($tab_new_values);
         }
 
-        $return .= \config\Fonctions::affichage_config_mail($tab_new_values, $session);
+        $return .= \config\Fonctions::affichage_config_mail($tab_new_values);
 
         return $return;
     }
@@ -374,16 +349,12 @@ class Fonctions
         return $tab;
     }
 
-    public static function commit_ajout(&$tab_new_values, $session)
+    public static function commit_ajout(&$tab_new_values)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
-        if($session=="") {
-            $URL = "$PHP_SELF?onglet=type_absence";
-        } else {
-            $URL = "$PHP_SELF?session=$session&onglet=type_absence";
-        }
+        $URL = "$PHP_SELF?onglet=type_absence";
         $tab_new_values['libelle'] = htmlentities($tab_new_values['libelle'], ENT_QUOTES | ENT_HTML401);
         $tab_new_values['short_libelle'] = htmlentities($tab_new_values['short_libelle']);
         $tab_new_values['type'] = htmlentities($tab_new_values['type'], ENT_QUOTES | ENT_HTML401);
@@ -447,16 +418,12 @@ class Fonctions
         return $return;
     }
 
-    public static function commit_suppr($session, $id_to_update)
+    public static function commit_suppr($id_to_update)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
-        if($session=="") {
-            $URL = "$PHP_SELF?onglet=type_absence";
-        } else {
-            $URL = "$PHP_SELF?session=$session&onglet=type_absence";
-        }
+        $URL = "$PHP_SELF?onglet=type_absence";
 
         // delete dans la table conges_type_absence
         $req_delete1='DELETE FROM conges_type_absence WHERE ta_id='. \includes\SQL::quote($id_to_update);
@@ -475,16 +442,12 @@ class Fonctions
         return $return;
     }
 
-    public static function supprimer($session, $id_to_update)
+    public static function supprimer($id_to_update)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
-        if($session=="") {
-            $URL = "$PHP_SELF?onglet=type_absence";
-        } else {
-            $URL = "$PHP_SELF?session=$session&onglet=type_absence";
-        }
+        $URL = "$PHP_SELF?onglet=type_absence";
 
 
         // verif si pas de periode de ce type de conges !!!
@@ -528,16 +491,12 @@ class Fonctions
         return $return;
     }
 
-    public static function commit_modif_absence(&$tab_new_values, $session, $id_to_update)
+    public static function commit_modif_absence(&$tab_new_values, $id_to_update)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
-        if($session=="") {
-            $URL = "$PHP_SELF";
-        } else {
-            $URL = "$PHP_SELF?session=$session";
-        }
+        $URL = "$PHP_SELF";
 
 
         // verif de la saisie
@@ -555,11 +514,7 @@ class Fonctions
 
         if($erreur) {
             $return .= '<br>';
-            if($session=="") {
-                $return .= '<form action="' . $PHP_SELF . '?onglet=type_absence" method="POST">';
-            } else {
-                $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=type_absence" method="POST">';
-            }
+            $return .= '<form action="' . $PHP_SELF . '?onglet=type_absence" method="POST">';
             $return .= '<input type="hidden" name="action" value="modif">';
             $return .= '<input type="hidden" name="id_to_update" value="' . $id_to_update .'">';
             $return .= '<input type="hidden" name="tab_new_values[libelle]" value="' . $tab_new_values['libelle'] . '">';
@@ -581,16 +536,12 @@ class Fonctions
         return $return;
     }
 
-    public static function modifier(&$tab_new_values, $session, $id_to_update)
+    public static function modifier(&$tab_new_values, $id_to_update)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
-        if($session=="") {
-            $URL = "$PHP_SELF?onglet=type_absence";
-        } else {
-            $URL = "$PHP_SELF?session=$session&onglet=type_absence";
-        }
+        $URL = "$PHP_SELF?onglet=type_absence";
 
         /**************************************/
         // affichage du titre
@@ -644,24 +595,17 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage_absence($tab_new_values,$session)
+    public static function affichage_absence($tab_new_values)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
-        if($session=="") {
-            $URL = "$PHP_SELF?onglet=type_absence";
-        } else {
-            $URL = "$PHP_SELF?session=$session&onglet=type_absence";
-        }
+        $URL = "$PHP_SELF?onglet=type_absence";
 
         /**************************************/
         // affichage du titre
         $return .= '<h1>' . _('config_abs_titre') . '</h1>';
         /**************************************/
-
-        // affiche_bouton_retour($session);
-
 
         // affichage de la liste des type d'absence existants
 
@@ -703,13 +647,8 @@ class Fonctions
                         $ta_libelle = $data['ta_libelle'];
                         $ta_short_libelle = $data['ta_short_libelle'];
 
-                        if($session=="") {
-                            $text_modif="<a href=\"$PHP_SELF?action=modif&id_to_update=$ta_id&onglet=type_absence\" title=\"". _('form_modif') ."\"><i class=\"fa fa-pencil\"></i></a>";
-                            $text_suppr="<a href=\"$PHP_SELF?action=suppr&id_to_update=$ta_id&onglet=type_absence\" title=\"". _('form_supprim') ."\"><i class=\"fa fa-times-circle\"></i></a>";
-                        } else {
-                            $text_modif="<a href=\"$PHP_SELF?session=$session&action=modif&id_to_update=$ta_id&onglet=type_absence\" title=\"". _('form_modif') ."\"><i class=\"fa fa-pencil\"></i></a>";
-                            $text_suppr="<a href=\"$PHP_SELF?session=$session&action=suppr&id_to_update=$ta_id&onglet=type_absence\" title=\"". _('form_supprim') ."\"><i class=\"fa fa-times-circle\"></i></a>";
-                        }
+                        $text_modif="<a href=\"$PHP_SELF?action=modif&id_to_update=$ta_id&onglet=type_absence\" title=\"". _('form_modif') ."\"><i class=\"fa fa-pencil\"></i></a>";
+                        $text_suppr="<a href=\"$PHP_SELF?action=suppr&id_to_update=$ta_id&onglet=type_absence\" title=\"". _('form_supprim') ."\"><i class=\"fa fa-times-circle\"></i></a>";
 
                         $childTable .= '<tr><td><strong>' . $ta_libelle . '</strong></td><td>' . $ta_short_libelle . '</td><td class="action">' . $text_modif . '&nbsp;' . $text_suppr . '</td></tr>';
                     }
@@ -785,7 +724,6 @@ class Fonctions
      */
     public static function typeAbsenceModule()
     {
-        $session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : "") ) ;
         $return = '';
 
         if (file_exists(CONFIG_PATH .'config_ldap.php')) {
@@ -817,32 +755,28 @@ class Fonctions
         /*********************************/
 
         if($action=="new") {
-            $return .= \config\Fonctions::commit_ajout($tab_new_values,$session);
+            $return .= \config\Fonctions::commit_ajout($tab_new_values);
         } elseif($action=="modif") {
-            $return .= \config\Fonctions::modifier($tab_new_values, $session, $id_to_update);
+            $return .= \config\Fonctions::modifier($tab_new_values, $id_to_update);
         } elseif($action=="commit_modif") {
-            $return .= \config\Fonctions::commit_modif_absence($tab_new_values, $session, $id_to_update);
+            $return .= \config\Fonctions::commit_modif_absence($tab_new_values, $id_to_update);
         } elseif($action=="suppr") {
-            $return .= \config\Fonctions::supprimer($session, $id_to_update);
+            $return .= \config\Fonctions::supprimer($id_to_update);
         } elseif($action=="commit_suppr") {
-            $return .= \config\Fonctions::commit_suppr($session, $id_to_update);
+            $return .= \config\Fonctions::commit_suppr($id_to_update);
         } else {
-            $return .= \config\Fonctions::affichage_absence($tab_new_values, $session);
+            $return .= \config\Fonctions::affichage_absence($tab_new_values);
         }
 
         return $return;
     }
 
-    public static function commit_saisie(&$tab_new_values, $session)
+    public static function commit_saisie(&$tab_new_values)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
-        if($session=="") {
-            $URL = "$PHP_SELF";
-        } else {
-            $URL = "$PHP_SELF?session=$session";
-        }
+        $URL = "$PHP_SELF";
 
         $timeout=2 ;  // temps d'attente pour rafraichir l'écran après l'update !
 
@@ -911,21 +845,14 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage_configuration($session)
+    public static function affichage_configuration()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
 
-        // affiche_bouton_retour($session);
-
-
         // affichage de la liste des variables
 
-        if($session=="") {
-            $return .= '<form action="' . $PHP_SELF . '" method="POST">';
-        } else {
-            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
-        }
+        $return .= '<form action="' . $PHP_SELF . '" method="POST">';
         $return .= '<input type="hidden" name="action" value="commit">';
 
         //requête qui récupère les informations de config
@@ -1088,13 +1015,11 @@ class Fonctions
     /**
      * Encapsule le comportement du module d'affichage des logs
      *
-     * @param string $session
-     *
      * @return void
      * @access public
      * @static
      */
-    public static function configurationModule($session)
+    public static function configurationModule()
     {
         // verif des droits du user à afficher la page
         verif_droits_user("is_admin");
@@ -1116,10 +1041,10 @@ class Fonctions
         /*************************************/
 
         if($action=="commit") {
-            $return .= \config\Fonctions::commit_saisie($tab_new_values, $session);
+            $return .= \config\Fonctions::commit_saisie($tab_new_values);
         } else {
             $return .= '<div class="wrapper configure">';
-            $return .= \config\Fonctions::affichage_configuration($session);
+            $return .= \config\Fonctions::affichage_configuration();
             $return .= '<div>';
         }
         return $return;

--- a/config/config_logs.php
+++ b/config/config_logs.php
@@ -1,4 +1,4 @@
 <?php
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-echo \config\Fonctions::logModule($session);
+echo \config\Fonctions::logModule();

--- a/config/config_mail.php
+++ b/config/config_mail.php
@@ -1,3 +1,3 @@
 <?php
 
-echo \config\Fonctions::mailModule($session);
+echo \config\Fonctions::mailModule();

--- a/config/configure.php
+++ b/config/configure.php
@@ -1,2 +1,2 @@
 <?php
-echo \config\Fonctions::configurationModule($session);
+echo \config\Fonctions::configurationModule();

--- a/config/index.php
+++ b/config/index.php
@@ -21,7 +21,7 @@ $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
 $session=session_id();
 
 // verif des droits du user à afficher la page
-verif_droits_user($session, "is_admin");
+verif_droits_user("is_admin");
 
 $_SESSION['from_config']=TRUE;  // initialise ce flag pour changer le bouton de retour des popup
 

--- a/config/index.php
+++ b/config/index.php
@@ -4,9 +4,7 @@ define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 include_once INCLUDE_PATH . 'fonction.php';
 
-$session =(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
-
-if (empty($session)) {
+if (empty(session_id())) {
 	redirect(ROOT_PATH . 'index.php?return_url=config/index.php');
 }
 
@@ -17,8 +15,6 @@ $_SESSION['config']=init_config_tab();      // on initialise le tableau des vari
 include_once INCLUDE_PATH .'session.php';
 
 $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-
-$session=session_id();
 
 // verif des droits du user à afficher la page
 verif_droits_user("is_admin");
@@ -73,14 +69,14 @@ $_SESSION['from_config']=TRUE;  // initialise ce flag pour changer le bouton de 
 	echo '<div id="onglet_menu">';
 	foreach($onglets as $key => $title) {
 		echo '<div class="onglet '.($onglet == $key ? ' active': '').'" >
-			<a href="'.$PHP_SELF.'?session='.$session.'&onglet='.$key.'">'. $title .'</a>
+			<a href="'.$PHP_SELF.'?onglet='.$key.'">'. $title .'</a>
 		</div>';
 	}
 	echo '</div>';
 
 	echo '<div class="'.$onglet.' wrapper">';
 
-		echo '<a href="' . ROOT_PATH . "admin/admin_index.php?session=$session\" class=\"admin-back\"><i class=\"fa fa-arrow-circle-o-left\"></i>". _('form_retour')."</a>\n";
+		echo '<a href="' . ROOT_PATH . "admin/admin_index.php\" class=\"admin-back\"><i class=\"fa fa-arrow-circle-o-left\"></i>". _('form_retour')."</a>\n";
 
 		if($onglet == 'general') {
 			include_once ROOT_PATH . 'config/configure.php';

--- a/deconnexion.php
+++ b/deconnexion.php
@@ -23,7 +23,7 @@ if($how_to_connect_user=="cas")
     deconnexion_CAS($URL_ACCUEIL_CONGES);
 }
 
-session_delete($session);
+session_delete();
 
 $session="";
 $session_username="";

--- a/define.php
+++ b/define.php
@@ -82,6 +82,8 @@ if (!defined( 'DEFINE_INCLUDE' )) {
             });
             break;
     }
+    session_start();
+
 
     /* Définition de headers de sécurité */
     header('X-XSS-Protection: 1; mode=block');

--- a/fonctions_conges.php
+++ b/fonctions_conges.php
@@ -1757,7 +1757,7 @@ function execute_sql_file($file)
 
 // verif des droits du user à afficher la page qu'il demande (pour éviter les hacks par bricolage d'URL)
 
-function verif_droits_user($session, $niveau_droits)
+function verif_droits_user($niveau_droits)
 {
     $niveau_droits = strtolower($niveau_droits);
 
@@ -1772,7 +1772,7 @@ function verif_droits_user($session, $niveau_droits)
         $lang_divers_vous_authentifier    =  _('divers_vous_authentifier') ;
 
         // on delete la session et on renvoit sur l'authentification (page d'accueil)
-        session_delete($session);
+        session_delete();
 
         // message d'erreur !
         echo "<center>\n";

--- a/fonctions_conges.php
+++ b/fonctions_conges.php
@@ -286,13 +286,13 @@ function verif_saisie_new_demande($new_debut, $new_demi_jour_deb, $new_fin, $new
         echo '<br>'. _('demande_heure_chevauche_demande') .'<br>';
         $verif = false;
     }
-    
+
     $tab_periode_calcul = make_tab_demi_jours_periode($new_debut, $new_fin, $new_demi_jour_deb, $new_demi_jour_fin);
     if(verif_periode_chevauche_periode_user($new_debut, $new_fin, $_SESSION['userlogin'], "", $tab_periode_calcul, $new_comment)){
         echo '<br>'._('calcul_nb_jours_commentaire') .'<br>';
         $verif = false;
     }
-    
+
     $new_comment = htmlentities($new_comment, ENT_QUOTES | ENT_HTML401);
 
     return $verif;

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -141,7 +141,7 @@ class Fonctions
                 }
                 $childTable .= '</tr>';
             }
-        
+
         }
 
         $childTable .= '</tbody>';
@@ -1048,7 +1048,7 @@ class Fonctions
             'startDate'          => $startDate,
         ];
         $return .= '<script>generateDatePicker(' . json_encode($datePickerOpts) . ');</script>';
-            
+
         // si les mois et année ne sont pas renseignés, on prend ceux du jour
         if($year_calendrier_saisie_debut==0) {
             $year_calendrier_saisie_debut=date("Y");
@@ -1954,7 +1954,7 @@ class Fonctions
     public static function pageJoursChomesModule($session)
     {
         // verif des droits du user à afficher la page
-        verif_droits_user($session, "is_hr");
+        verif_droits_user( "is_hr");
         $return = '';
         /*** initialisation des variables ***/
         /*************************************/
@@ -3084,7 +3084,7 @@ class Fonctions
     public static function pageJoursFermetureModule($session)
     {
         // verif des droits du user à afficher la page
-        verif_droits_user($session, "is_hr");
+        verif_droits_user("is_hr");
         $return = '';
 
         /*** initialisation des variables ***/

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -12,13 +12,12 @@ class Fonctions
      *
      * @param array  $tab_type_cong
      * @param array  $tab_type_conges_exceptionnels
-     * @param string $session
      *
      * @return void
      * @access public
      * @static
      */
-    public static function pagePrincipaleModule(array $tab_type_cong, array $tab_type_conges_exceptionnels, $session)
+    public static function pagePrincipaleModule(array $tab_type_cong, array $tab_type_conges_exceptionnels)
     {
         /***********************************/
         // AFFICHAGE ETAT CONGES TOUS USERS
@@ -80,7 +79,7 @@ class Fonctions
             asort($tab_info_users);
             uasort($tab_info_users, "sortParActif");
             foreach ($tab_info_users as $current_login => $tab_current_infos) {
-                $text_affich_user="<a href=\"hr_index.php?session=$session&onglet=traite_user&user_login=$current_login\" title=\""._('resp_etat_users_afficher')."\"><i class=\"fa fa-eye\"></i></a>" ;
+                $text_affich_user="<a href=\"hr_index.php?onglet=traite_user&user_login=$current_login\" title=\""._('resp_etat_users_afficher')."\"><i class=\"fa fa-eye\"></i></a>" ;
 
                 $childTable .= '<tr class="' . (($tab_current_infos['is_active']=='Y') ? 'actif' : 'inactif') . '">';
                 $childTable .= '<td class="utilisateur"><strong>' . $tab_current_infos['nom'] . ' ' . $tab_current_infos['prenom'] . '</strong>';
@@ -136,7 +135,7 @@ class Fonctions
 
                 $childTable .= '<td>' . $text_affich_user . '</td>';
                 if($_SESSION['config']['editions_papier']) {
-                    $text_edit_papier="<a href=\"../edition/edit_user.php?session=$session&user_login=$current_login\" target=\"_blank\" title=\""._('resp_etat_users_imprim')."\"><i class=\"fa fa-file-text\"></i></a>";
+                    $text_edit_papier="<a href=\"../edition/edit_user.php?user_login=$current_login\" target=\"_blank\" title=\""._('resp_etat_users_imprim')."\"><i class=\"fa fa-file-text\"></i></a>";
                     $childTable .= '<td>' . $text_edit_papier . '</td>';
                 }
                 $childTable .= '</tr>';
@@ -156,7 +155,6 @@ class Fonctions
     public static function traite_all_demande_en_cours($tab_bt_radio, $tab_text_refus)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         while($elem_tableau = each($tab_bt_radio)) {
@@ -212,7 +210,7 @@ class Fonctions
 
         $return .= _('form_modif_ok') . '<br><br>';
         /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-        $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?session=' . $session . '&onglet=traitement_demandes">';
+        $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?onglet=traitement_demandes">';
         return $return;
     }
 
@@ -220,7 +218,6 @@ class Fonctions
     {
         $return = '';
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
         $count1=0;
         $count2=0;
 
@@ -254,7 +251,7 @@ class Fonctions
 
         /*********************************/
 
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=traitement_demandes" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=traitement_demandes" method="POST">';
 
         /*********************************/
         /* TABLEAU DES DEMANDES DES USERS*/
@@ -387,13 +384,12 @@ class Fonctions
      *
      * @param array  $tab_type_cong
      * @param string $onglet
-     * @param string $session
      *
      * @return void
      * @access public
      * @static
      */
-    public static function pageTraitementDemandeModule(array $tab_type_cong, $onglet, $session)
+    public static function pageTraitementDemandeModule(array $tab_type_cong, $onglet)
     {
         $return = '';
 
@@ -410,7 +406,7 @@ class Fonctions
         } else {
             $return .= \hr\Fonctions::traite_all_demande_en_cours($tab_bt_radio, $tab_text_refus);
             echo $return;
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session.'&onglet='.$onglet, false);
+            redirect( ROOT_PATH .'hr/hr_index.php?onglet='.$onglet, false);
             exit;
         }
         return $return;
@@ -419,7 +415,6 @@ class Fonctions
     public static function new_conges($user_login, $numero_int, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         $new_debut = convert_date($new_debut);
@@ -462,7 +457,7 @@ class Fonctions
         }
 
         /* APPEL D'UNE AUTRE PAGE */
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user&user_login=' . $user_login . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=traite_user&user_login=' . $user_login . '" method="POST">';
         $return .= '<input type="submit" value="' . _('form_retour') . '">';
         $return .= '</form>';
         return $return;
@@ -471,7 +466,6 @@ class Fonctions
     public static function traite_demandes($user_login, $tab_radio_traite_demande, $tab_text_refus)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id();
         $return = '';
 
         // recup dans un tableau de tableau les infos des types de conges et absences
@@ -549,14 +543,13 @@ class Fonctions
         }
         $return .= _('form_modif_ok') . '<br><br>';
         /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-        $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?session=' . $session . '&user_login=' . $user_login . '">';
+        $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?user_login=' . $user_login . '">';
         return $return;
     }
 
     public static function annule_conges($user_login, $tab_checkbox_annule, $tab_text_annul)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id() ;
         $return = '';
 
         // recup dans un tableau de tableau les infos des types de conges et absences
@@ -598,7 +591,7 @@ class Fonctions
 
         $return .= _('form_modif_ok') . '<br><br>';
         /* APPEL D'UNE AUTRE PAGE au bout d'une tempo de 2secondes */
-        $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?session=' . $session . '&user_login=' . $user_login . '">';
+        $return .= '<META HTTP-EQUIV=REFRESH CONTENT="2; URL=' . $PHP_SELF . '?user_login=' . $user_login . '">';
         return $return;
     }
 
@@ -606,7 +599,6 @@ class Fonctions
     public static function affiche_etat_conges_user_for_resp($user_login, $year_affichage, $tri_date)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id() ;
         $return = '';
 
         // affichage de l'année et des boutons de défilement
@@ -614,9 +606,9 @@ class Fonctions
         $year_affichage_suiv = $year_affichage+1 ;
 
         $return .= '<b>';
-        $return .= '<a href="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user&user_login=' . $user_login . '&year_affichage=' . $year_affichage_prec . '"><<</a>';
+        $return .= '<a href="' . $PHP_SELF . '?onglet=traite_user&user_login=' . $user_login . '&year_affichage=' . $year_affichage_prec . '"><<</a>';
         $return .= '&nbsp&nbsp&nbsp ' . $year_affichage . '&nbsp&nbsp&nbsp';
-        $return .= '<a href="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user&user_login=' . $user_login . '&year_affichage=' . $year_affichage_suiv . '">>></a>';
+        $return .= '<a href="' . $PHP_SELF . '?onglet=traite_user&user_login=' . $user_login . '&year_affichage=' . $year_affichage_suiv . '">>></a>';
         $return .= '</b><br><br>';
 
 
@@ -641,14 +633,14 @@ class Fonctions
             $tab_types_abs = recup_tableau_tout_types_abs() ;
 
             // AFFICHAGE TABLEAU
-            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user" method="POST">';
+            $return .= '<form action="' . $PHP_SELF . '?onglet=traite_user" method="POST">';
             $return .= '<table cellpadding="2" class="tablo">';
             $return .= '<thead>';
             $return .= '<tr>';
             $return .= '<th>';
-            $return .= '<a href="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user&user_login=' . $user_login . '&tri_date=descendant"><img src="' . IMG_PATH . '1downarrow-16x16.png" width="16" height="16" border="0" title="trier"></a>';
+            $return .= '<a href="' . $PHP_SELF . '?onglet=traite_user&user_login=' . $user_login . '&tri_date=descendant"><img src="' . IMG_PATH . '1downarrow-16x16.png" width="16" height="16" border="0" title="trier"></a>';
             $return .= _('divers_debut_maj_1');
-            $return .= '<a href="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user&user_login=' . $user_login . '&tri_date=ascendant"><img src="' . IMG_PATH . '1uparrow-16x16.png" width="16" height="16" border="0" title="trier"></a>';
+            $return .= '<a href="' . $PHP_SELF . '?onglet=traite_user&user_login=' . $user_login . '&tri_date=ascendant"><img src="' . IMG_PATH . '1uparrow-16x16.png" width="16" height="16" border="0" title="trier"></a>';
             $return .= '</th>';
             $return .= '<th>' . _('divers_fin_maj_1') . '</th>';
             $return .= '<th>' . _('divers_nb_jours_pris_maj_1') . '</th>';
@@ -754,7 +746,6 @@ class Fonctions
     public static function affiche_etat_demande_2_valid_user_for_resp($user_login)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id() ;
         $return = '';
 
         // Récupération des informations
@@ -771,7 +762,7 @@ class Fonctions
             $tab_type_all_abs = recup_tableau_tout_types_abs();
 
             // AFFICHAGE TABLEAU
-            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user" method="POST">';
+            $return .= '<form action="' . $PHP_SELF . '?onglet=traite_user" method="POST">';
             $return .= '<table cellpadding="2" class="tablo">';
             $return .= '<thead>';
             $return .= '<tr>';
@@ -845,7 +836,7 @@ class Fonctions
 
             $return .= '<input type="hidden" name="user_login" value="' . $user_login . '">';
             $return .= '<br><input class="btn btn-success" type="submit" value="' . _('form_submit') . '">  &nbsp;&nbsp;&nbsp;&nbsp; <input type="reset" value="' . _('form_cancel') . '">';
-            $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '">' . _('form_cancel') . '</a>';
+            $return .= '<a class="btn" href="' . $PHP_SELF . '">' . _('form_cancel') . '</a>';
             $return .= '</form>';
         }
         return $return;
@@ -855,7 +846,6 @@ class Fonctions
     public static function affiche_etat_demande_user_for_resp($user_login, $tab_user, $tab_grd_resp)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id() ;
         $return = '';
 
         // Récupération des informations
@@ -873,7 +863,7 @@ class Fonctions
             $tab_type_all_abs = recup_tableau_tout_types_abs();
 
             // AFFICHAGE TABLEAU
-            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=traite_user" method="POST">';
+            $return .= '<form action="' . $PHP_SELF . '?onglet=traite_user" method="POST">';
             $return .= '<table cellpadding="2" class="tablo">';
             $return .= '<thead>';
             $return .= '<tr>';
@@ -966,7 +956,7 @@ class Fonctions
 
             $return .= '<input type="hidden" name="user_login" value="' . $user_login . '">';
             $return .= '<br><input class="btn btn-success" type="submit" value="' . _('form_submit') . '">  &nbsp;&nbsp;&nbsp;&nbsp;  <input type="reset" value="' . _('form_cancel') . '">';
-            $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '">' . _('form_cancel') . '</a>';
+            $return .= '<a class="btn" href="' . $PHP_SELF . '">' . _('form_cancel') . '</a>';
             $return .= '</form>';
         }
         return $return;
@@ -975,7 +965,6 @@ class Fonctions
     public static function affichage($user_login,  $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date, $onglet)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
-        $session=session_id();
         $return = '';
 
         // on initialise le tableau global des jours fériés s'il ne l'est pas déjà :
@@ -1201,7 +1190,6 @@ class Fonctions
     public static function ajout_global_groupe($choix_groupe, $tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
 
         // recup de la liste des users d'un groupe donné
         $list_users = get_list_users_du_groupe($choix_groupe);
@@ -1257,7 +1245,6 @@ class Fonctions
     public static function ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
         $return = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
@@ -1311,7 +1298,6 @@ class Fonctions
     public static function ajout_conges($tab_champ_saisie, $tab_commentaire_saisie)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         foreach($tab_champ_saisie as $user_name => $tab_conges)   // tab_champ_saisie[$current_login][$id_conges]=valeur du nb de jours ajouté saisi
@@ -1338,7 +1324,6 @@ class Fonctions
     public static function affichage_saisie_globale_groupe($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
         $return = '';
 
         /***********************************************************************/
@@ -1350,7 +1335,7 @@ class Fonctions
         if($list_group!="") //si la liste n'est pas vide ( serait le cas si n'est responsable d'aucun groupe)
         {
             $return .= '<h2>' . _('resp_ajout_conges_ajout_groupe') . '</h2>';
-            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout_conges" method="POST">';
+            $return .= '<form action="' . $PHP_SELF . '?onglet=ajout_conges" method="POST">';
             $return .= '<fieldset class="cal_saisie">';
             $return .= '<div class="table-responsive"><table class="table table-hover table-condensed table-striped">';
             $return .= '<tr>';
@@ -1387,7 +1372,6 @@ class Fonctions
             $return .= '<input class="btn" type="submit" value="' . _('form_valid_groupe') . '">';
             $return .= '</fieldset>';
             $return .= '<input type="hidden" name="ajout_groupe" value="TRUE">';
-            $return .= '<input type="hidden" name="session" value="' . $session . '">';
             $return .= '</form>';
         }
         return $return;
@@ -1396,13 +1380,12 @@ class Fonctions
     public static function affichage_saisie_globale_pour_tous($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
         $return = '';
 
         /************************************************************/
         /* SAISIE GLOBALE pour tous les utilisateurs du responsable */
         $return .= '<h2>' . _('resp_ajout_conges_ajout_all') . '</h2>';
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout_conges" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=ajout_conges" method="POST">';
         $return .= '<fieldset class="cal_saisie">';
         $return .= '<div class="table-responsive"><table class="table table-hover table-condensed table-striped">';
         $return .= '<thead>';
@@ -1427,7 +1410,6 @@ class Fonctions
         $return .= '<input class="btn" type="submit" value="' . _('form_valid_global') . '">';
         $return .= '</fieldset>';
         $return .= '<input type="hidden" name="ajout_global" value="TRUE">';
-        $return .= '<input type="hidden" name="session" value="' . $session . '">';
         $return .= '</form>';
         return $return;
     }
@@ -1435,13 +1417,12 @@ class Fonctions
     public static function affichage_saisie_user_par_user($tab_type_conges, $tab_type_conges_exceptionnels, $tab_all_users_du_hr, $tab_all_users_du_grand_resp)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
         $return = '';
 
         /************************************************************/
         /* SAISIE USER PAR USER pour tous les utilisateurs du responsable */
         $return .= '<h2>Ajout par utilisateur</h2>';
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=ajout_conges" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=ajout_conges" method="POST">';
 
         if( (count($tab_all_users_du_hr)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
             // AFFICHAGE TITRES TABLEAU
@@ -1509,7 +1490,6 @@ class Fonctions
             $return .= '</table>';
 
             $return .= '<input type="hidden" name="ajout_conges" value="TRUE">';
-            $return .= '<input type="hidden" name="session" value="' . $session . '">';
             $return .= '<input class="btn" type="submit" value="' . _('form_submit') . '">';
             $return .= ' </form>';
         }
@@ -1559,7 +1539,6 @@ class Fonctions
     public static function saisie_ajout( $tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
         $return = '';
 
         // recup du tableau des types de conges (seulement les congesexceptionnels )
@@ -1603,13 +1582,12 @@ class Fonctions
      * Encapsule le comportement du module d'ajout de congés
      *
      * @param array  $tab_type_cong
-     * @param string $session
      *
      * @return void
      * @access public
      * @static
      */
-    public static function pageAjoutCongesModule($tab_type_cong, $session)
+    public static function pageAjoutCongesModule($tab_type_cong)
     {
         //var pour resp_ajout_conges_all.php
         $ajout_conges = getpost_variable('ajout_conges');
@@ -1626,7 +1604,7 @@ class Fonctions
             $tab_commentaire_saisie        = getpost_variable('tab_commentaire_saisie');
 
             $return .= \hr\Fonctions::ajout_conges($tab_champ_saisie, $tab_commentaire_saisie);
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
+            redirect( ROOT_PATH .'hr/hr_index.php', false);
             exit;
         } elseif( $ajout_global == "TRUE" ) {
 
@@ -1635,7 +1613,7 @@ class Fonctions
             $tab_new_comment_all         = getpost_variable('tab_new_comment_all');
 
             $return .= \hr\Fonctions::ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all);
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
+            redirect( ROOT_PATH .'hr/hr_index.php', false);
             exit;
         } elseif( $ajout_groupe == "TRUE" ) {
 
@@ -1645,7 +1623,7 @@ class Fonctions
             $choix_groupe                = getpost_variable('choix_groupe');
 
             \hr\Fonctions::ajout_global_groupe($choix_groupe, $tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all);
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
+            redirect( ROOT_PATH .'hr/hr_index.php', false);
             exit;
         } else {
             $return .= \hr\Fonctions::saisie_ajout($tab_type_cong);
@@ -1722,7 +1700,6 @@ class Fonctions
     public static function commit_saisie($tab_checkbox_j_chome)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         // si l'année est déja renseignée dans la database, on efface ttes les dates de l'année
@@ -1753,13 +1730,12 @@ class Fonctions
     public static function confirm_saisie($tab_checkbox_j_chome)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         header_popup();
 
         $return .= '<h1>' . _('admin_jours_chomes_titre') . '</h1>';
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=jours_chomes" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=jours_chomes" method="POST">';
         $return .= '<table>';
         $return .= '<tr>';
         $return .= '<td align="center">';
@@ -1892,7 +1868,6 @@ class Fonctions
     public static function saisie($year_calendrier_saisie)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         // si l'année n'est pas renseignée, on prend celle du jour
@@ -1912,7 +1887,7 @@ class Fonctions
                     $tab_year[] = $value;
             }
         }
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=jours_chomes&year_calendrier_saisie=' . $year_calendrier_saisie . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=jours_chomes&year_calendrier_saisie=' . $year_calendrier_saisie . '" method="POST">';
         $return .= '<div class="calendar">';
         $months = array('01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12');
 
@@ -1945,13 +1920,11 @@ class Fonctions
     /**
      * Encapsule le comportement du module des jours chomés
      *
-     * @param string $session
-     *
      * @return void
      * @access public
      * @static
      */
-    public static function pageJoursChomesModule($session)
+    public static function pageJoursChomesModule()
     {
         // verif des droits du user à afficher la page
         verif_droits_user( "is_hr");
@@ -1980,8 +1953,8 @@ class Fonctions
         $return .= '<div class="pager">';
         $return .= '<div class="onglet calendar-nav">';
         // navigation
-        $prev_link = "$PHP_SELF?session=$session&onglet=jours_chomes&year_calendrier_saisie=". ($year_calendrier_saisie - 1);
-        $next_link = "$PHP_SELF?session=$session&onglet=jours_chomes&year_calendrier_saisie=". ($year_calendrier_saisie + 1);
+        $prev_link = "$PHP_SELF?onglet=jours_chomes&year_calendrier_saisie=". ($year_calendrier_saisie - 1);
+        $next_link = "$PHP_SELF?onglet=jours_chomes&year_calendrier_saisie=". ($year_calendrier_saisie + 1);
         $return .= '<ul>';
         $return .= '<li><a href="' . $prev_link . '" class="calendar-prev"><i class="fa fa-chevron-left"></i><span>année précédente</span></a></li>';
         $return .= '&nbsp;<li class="current-year">' . $year_calendrier_saisie . '</li>';
@@ -2024,7 +1997,6 @@ class Fonctions
     public static function cloture_globale_groupe($group_id, $tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         // recup de la liste de TOUS les users du groupe
@@ -2044,7 +2016,6 @@ class Fonctions
     public static function cloture_globale($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
@@ -2165,7 +2136,6 @@ class Fonctions
     public static function cloture_users($tab_type_conges, $tab_cloture_users, $tab_commentaire_saisie)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
@@ -2189,7 +2159,6 @@ class Fonctions
     public static function affichage_cloture_globale_groupe($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
         $return = '';
 
         /***********************************************************************/
@@ -2237,7 +2206,6 @@ class Fonctions
 
             $return .= '<input type="hidden" name="onglet" value="cloture_exercice">';
             $return .= '<input type="hidden" name="cloture_groupe" value="TRUE">';
-            $return .= '<input type="hidden" name="session" value="' . $session . '">';
             $return .= '</form>';
         }
 
@@ -2247,13 +2215,12 @@ class Fonctions
     public static function affichage_cloture_globale_pour_tous($tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
         $return = '';
 
         /************************************************************/
         /* CLOTURE EXERCICE GLOBALE pour tous les utilisateurs du responsable */
 
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=cloture_year" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '?onglet=cloture_year" method="POST">';
         $return .= '<table>';
         $return .= '<tr><td align="center">';
         $return .= '<fieldset class="cal_saisie">';
@@ -2271,7 +2238,6 @@ class Fonctions
         $return .= '</td></tr>';
         $return .= '</table>';
         $return .= '<input type="hidden" name="cloture_globale" value="TRUE">';
-        $return .= '<input type="hidden" name="session" value="' . $session . '">';
         $return .= '</form>';
         return $return;
     }
@@ -2313,14 +2279,13 @@ class Fonctions
     public static function affichage_cloture_user_par_user($tab_type_conges, $tab_all_users_du_hr, $tab_all_users_du_grand_resp)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
         $return = '';
 
         /************************************************************/
         /* CLOTURE EXERCICE USER PAR USER pour tous les utilisateurs du responsable */
 
         if( (count($tab_all_users_du_hr)!=0) || (count($tab_all_users_du_grand_resp)!=0) ) {
-            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '&onglet=cloture_year" method="POST">';
+            $return .= '<form action="' . $PHP_SELF . '?onglet=cloture_year" method="POST">';
             $return .= '<table>';
             $return .= '<tr>';
             $return .= '<td align="center">';
@@ -2369,7 +2334,6 @@ class Fonctions
             $return .= '</td></tr>';
             $return .= '</table>';
             $return .= '<input type="hidden" name="cloture_users" value="TRUE">';
-            $return .= '<input type="hidden" name="session" value="' . $session . '">';
             $return .= '</form>';
         }
 
@@ -2379,7 +2343,6 @@ class Fonctions
     public static function saisie_cloture( $tab_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id() ;
         $return = '';
 
         // recup de la liste de TOUS les users dont $resp_login est responsable
@@ -2414,13 +2377,11 @@ class Fonctions
     /**
      * Encapsule le comportement du module de cloture d'exercice
      *
-     * @param string $session
-     *
      * @return void
      * @access public
      * @static
      */
-    public static function pageClotureYearModule($session)
+    public static function pageClotureYearModule()
     {
         /*************************************/
         // recup des parametres reçus :
@@ -2444,18 +2405,18 @@ class Fonctions
             $tab_commentaire_saisie       = getpost_variable('tab_commentaire_saisie'); //a vérifier
             $return .= \hr\Fonctions::cloture_users($tab_type_cong, $tab_cloture_users, $tab_commentaire_saisie);
 
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
+            redirect( ROOT_PATH .'hr/hr_index.php', false);
             exit;
         } elseif($cloture_globale=="TRUE") {
             \hr\Fonctions::cloture_globale($tab_type_cong);
 
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
+            redirect( ROOT_PATH .'hr/hr_index.php', false);
             exit;
         } elseif($cloture_groupe=="TRUE") {
             $choix_groupe            = getpost_variable('choix_groupe');
             $return .= \hr\Fonctions::cloture_globale_groupe($choix_groupe, $tab_type_cong);
 
-            redirect( ROOT_PATH .'hr/hr_index.php?session='.$session, false);
+            redirect( ROOT_PATH .'hr/hr_index.php', false);
             exit;
         } else {
             $return .= \hr\Fonctions::saisie_cloture($tab_type_cong);
@@ -2696,7 +2657,6 @@ class Fonctions
     public static function commit_annul_fermeture($fermeture_id, $groupe_id)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         /*****************************/
@@ -2760,7 +2720,7 @@ class Fonctions
         }
         log_action(0, "", "", $comment_log);
 
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '" method="POST">';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_ok') . '">';
         $return .= '</form>';
         $return .= '</div>';
@@ -2770,7 +2730,6 @@ class Fonctions
     public static function commit_new_fermeture($new_date_debut, $new_date_fin, $groupe_id, $id_type_conges)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         // on transforme les formats des dates
@@ -2849,7 +2808,7 @@ class Fonctions
 
         $comment_log = "saisie des jours de fermeture de $date_debut a $date_fin" ;
         log_action(0, "", "", $comment_log);
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '" method="POST">';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_ok') . '">';
         $return .= '</form>';
         $return .= '</div>';
@@ -2859,11 +2818,10 @@ class Fonctions
     public static function confirm_annul_fermeture($fermeture_id, $groupe_id, $fermeture_date_debut, $fermeture_date_fin)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         $return .= '<div class="wrapper">';
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '" method="POST">';
         $return .= _('divers_fermeture_du') . '<b>' . $fermeture_date_debut . '</b>' . _('divers_au') . '<b>' . $fermeture_date_fin . '</b>.';
         $return .= '<b>' . _('admin_annul_fermeture_confirm') . '</b>.<br>';
         $return .= '<input type="hidden" name="fermeture_id" value="' . $fermeture_id . '">';
@@ -2872,7 +2830,7 @@ class Fonctions
         $return .= '<input type="hidden" name="groupe_id" value="' . $groupe_id . '">';
         $return .= '<input type="hidden" name="choix_action" value="commit_annul_fermeture">';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('form_continuer') . '">';
-        $return .= '<a class="btn" href="' . $PHP_SELF . '?session=' . $session . '">' . _('form_cancel') . '</a>';
+        $return .= '<a class="btn" href="' . $PHP_SELF . '">' . _('form_cancel') . '</a>';
         $return .= '</form>';
         $return .= '</div>';
         return $return;
@@ -2946,7 +2904,6 @@ class Fonctions
     public static function saisie_dates_fermeture($year, $groupe_id, $new_date_debut, $new_date_fin, $code_erreur)
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         $tab_date_debut=explode("/",$new_date_debut);   // date au format d/m/Y
@@ -2961,7 +2918,7 @@ class Fonctions
         $tab_year=array();
         \hr\Fonctions::get_tableau_jour_fermeture($year, $tab_year,  $groupe_id);
 
-        $return .= '<form id="form-fermeture" class="form-inline" role="form" action="' . $PHP_SELF . '?session=' . $session . '&year=' . $year . '" method="POST">';
+        $return .= '<form id="form-fermeture" class="form-inline" role="form" action="' . $PHP_SELF . '?year=' . $year . '" method="POST">';
         $return .= '<div class="form-group">';
         $return .= '<label for="new_date_debut">' . _('divers_date_debut') . '</label><input type="text" class="form-control date" name="new_date_debut" value="' . $new_date_debut . '">';
         $return .= '</div>';
@@ -2985,7 +2942,6 @@ class Fonctions
     public static function saisie_groupe_fermeture()
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
-        $session=session_id();
         $return = '';
 
         $return .= '<div class="row">';
@@ -2995,7 +2951,7 @@ class Fonctions
         /********************/
 
         // AFFICHAGE TABLEAU
-        $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" method="POST">';
+        $return .= '<form action="' . $PHP_SELF . '" method="POST">';
         $return .= '<input type="hidden" name="groupe_id" value="0">';
         $return .= '<input type="hidden" name="choix_action" value="saisie_dates">';
         $return .= '<input class="btn btn-success" type="submit" value="' . _('admin_jours_fermeture_fermeture_pour_tous') . ' !">';
@@ -3011,7 +2967,7 @@ class Fonctions
 
             // AFFICHAGE TABLEAU
             $return .= '<div class="col-md-6">';
-            $return .= '<form action="' . $PHP_SELF . '?session=' . $session . '" class="form-inline" method="POST">';
+            $return .= '<form action="' . $PHP_SELF . '" class="form-inline" method="POST">';
             $return .= '<div class="form-group" style="margin-right: 10px;">';
             $ReqLog_gr = \includes\SQL::query($sql_gr);
             $return .= '<select class="form-control" name="groupe_id">';
@@ -3060,7 +3016,7 @@ class Fonctions
                 $return .= _('divers_du') . ' <b>'. $date_affiche_1 . '</b> ' . _('divers_au') . ' <b>' . $date_affiche_2 . '</b>  (id ' . $fermeture_id . ')</b> ' . $groupe_name;
                 $return .= '</td>';
                 $return .= '<td>';
-                $return .= '<a href="' . $PHP_SELF . '?session=' . $session . '&choix_action=annul_fermeture&fermeture_id=' . $fermeture_id . '&groupe_id=' . $groupe_id . '&fermeture_date_debut=' . $date_affiche_1 . '&fermeture_date_fin=' . $date_affiche_2 . '">' . _('admin_annuler_fermeture') . '</a>';
+                $return .= '<a href="' . $PHP_SELF . '?choix_action=annul_fermeture&fermeture_id=' . $fermeture_id . '&groupe_id=' . $groupe_id . '&fermeture_date_debut=' . $date_affiche_1 . '&fermeture_date_fin=' . $date_affiche_2 . '">' . _('admin_annuler_fermeture') . '</a>';
                 $return .= '</td>';
                 $return .= '</tr>';
             }
@@ -3068,20 +3024,18 @@ class Fonctions
         }
         $return .= '</div>';
         $return .= '<hr>';
-        $return .= '<a class="btn" href="'.ROOT_PATH.'/hr/hr_index.php?session=' . $session . '">' . _('form_cancel') . '</a>';
+        $return .= '<a class="btn" href="'.ROOT_PATH.'/hr/hr_index.php">' . _('form_cancel') . '</a>';
         return $return;
     }
 
     /**
      * Encapsule le comportement du module de jours de fermeture
-     *
-     * @param string $session
-     *
+          *
      * @return void
      * @access public
      * @static
      */
-    public static function pageJoursFermetureModule($session)
+    public static function pageJoursFermetureModule()
     {
         // verif des droits du user à afficher la page
         verif_droits_user("is_hr");
@@ -3173,8 +3127,8 @@ class Fonctions
         foreach($onglets as $key => $title) {
             if($key == 'year_nav') {
                 // navigation
-                $prev_link = "$PHP_SELF?session=$session&onglet=$onglet&year=". ($year - 1) . "&groupe_id=$groupe_id";
-                $next_link = "$PHP_SELF?session=$session&onglet=$onglet&year=". ($year + 1) . "&groupe_id=$groupe_id";
+                $prev_link = "$PHP_SELF?onglet=$onglet&year=". ($year - 1) . "&groupe_id=$groupe_id";
+                $next_link = "$PHP_SELF?onglet=$onglet&year=". ($year + 1) . "&groupe_id=$groupe_id";
                 $return .= '<div class="onglet calendar-nav">';
                 $return .= '<ul>';
                 $return .= '<li><a href="' . $prev_link . '" class="calendar-prev"><i class="fa fa-chevron-left"></i><span>année précédente</span></a></li>';
@@ -3183,7 +3137,7 @@ class Fonctions
                 $return .= '</ul>';
                 $return .= '</div>';
             } else {
-                $return .= '<div class="onglet ' . ($onglet == $key ? ' active' : '') . '" ><a href="' . $PHP_SELF . '?session=' . $session . '&year=' . $year . '&onglet=' . $key . '">' . $title . '</a></div>';
+                $return .= '<div class="onglet ' . ($onglet == $key ? ' active' : '') . '" ><a href="' . $PHP_SELF . '?year=' . $year . '&onglet=' . $key . '">' . $title . '</a></div>';
             }
         }
         $return .= '</div>';
@@ -3259,13 +3213,13 @@ class Fonctions
             }
 
             $return .= '<div class="wrapper">';
-            $return .= '<a href="' . ROOT_PATH . 'hr/hr_index.php?session=' . $session . '" class="admin-back"><i class="fa fa-arrow-circle-o-left"></i>Retour mode rh</a>';
+            $return .= '<a href="' . ROOT_PATH . 'hr/hr_index.php" class="admin-back"><i class="fa fa-arrow-circle-o-left"></i>Retour mode rh</a>';
             if($onglet == 'saisie') {
                 $return .= \hr\Fonctions::saisie_dates_fermeture($year, $groupe_id, $new_date_debut, $new_date_fin, $code_erreur);
             }
         } elseif($choix_action=="saisie_groupe") {
             $return .= '<div class="wrapper">';
-            $return .= '<a href="' . ROOT_PATH . 'hr/hr_index.php?session=' . $session . '" class="admin-back"><i class="fa fa-arrow-circle-o-left"></i>Retour mode rh</a>';
+            $return .= '<a href="' . ROOT_PATH . 'hr/hr_index.php" class="admin-back"><i class="fa fa-arrow-circle-o-left"></i>Retour mode rh</a>';
             $return .= \hr\Fonctions::saisie_groupe_fermeture();
             $return .= '</div>';
         } elseif($choix_action=="commit_new_fermeture") {
@@ -3307,7 +3261,7 @@ class Fonctions
 enctype="application/x-www-form-urlencoded"><input type="hidden" name="planning_id" value="' . $_POST['planning_id'] . '" /><input type="hidden" name="status" value="' . \App\Models\Planning::STATUS_ACTIVE . '" /><input type="hidden" name="_METHOD" value="PATCH" /><div class="alert alert-info">' .  $notice . '. <button type="submit" class="btn btn-link alert-link">' . _('Annuler') . '</button></div></form>';
             } else {
                 log_action(0, '', '', 'Récupération du planning ' . $_POST['planning_id']);
-                redirect(ROOT_PATH . 'hr/hr_index.php?session='. session_id() . '&onglet=liste_planning', false);
+                redirect(ROOT_PATH . 'hr/hr_index.php?onglet=liste_planning', false);
             }
         }
 
@@ -3315,10 +3269,9 @@ enctype="application/x-www-form-urlencoded"><input type="hidden" name="planning_
         $listPlanningId = \App\ProtoControllers\HautResponsable\Planning::getListPlanningId();
 
         $return = '';
-        $return .= '<a href="' . ROOT_PATH . 'hr/hr_index.php?session='. session_id().'&amp;onglet=ajout_planning" style="float:right" class="btn btn-success">' . _('hr_ajout_planning') . '</a>';
+        $return .= '<a href="' . ROOT_PATH . 'hr/hr_index.php?onglet=ajout_planning" style="float:right" class="btn btn-success">' . _('hr_ajout_planning') . '</a>';
         $return .= '<h1>' . _('hr_affichage_liste_planning_titre') . '</h1>';
         $return .= $message;
-        $session = session_id();
         $table = new \App\Libraries\Structure\Table();
         $table->addClasses([
             'table',
@@ -3337,7 +3290,7 @@ enctype="application/x-www-form-urlencoded"><input type="hidden" name="planning_
                 $childTable .= '<tr><td>' . $planning['name'] . '</td>';
                 $childTable .= '<td><form action="" method="post" accept-charset="UTF-8"
 enctype="application/x-www-form-urlencoded"><a  title="' . _('form_modif') . '" href="hr_index.php?onglet=modif_planning&id=' . $planning['planning_id'] .
-                '&session=' . $session . '"><i class="fa fa-pencil"></i></a>&nbsp;&nbsp;';
+                '"><i class="fa fa-pencil"></i></a>&nbsp;&nbsp;';
                 if (in_array($planning['planning_id'], $listIdUsed)) {
                     $childTable .= '<button title="' . _('planning_used') . '" type="button" class="btn btn-link disabled"><i class="fa fa-times-circle"></i></button>';
                 } else {
@@ -3372,7 +3325,7 @@ enctype="application/x-www-form-urlencoded"><a  title="' . _('form_modif') . '" 
         if (!empty($_POST)) {
             if (0 < (int) \App\ProtoControllers\HautResponsable\Planning::postPlanning($_POST, $errorsLst, $notice)) {
                 log_action(0, '', '', 'Édition du planning ' . $_POST['name']);
-                redirect(ROOT_PATH . 'hr/hr_index.php?session='. session_id() . '&onglet=liste_planning', false);
+                redirect(ROOT_PATH . 'hr/hr_index.php?onglet=liste_planning', false);
             } else {
                 if (!empty($errorsLst)) {
                     $errors = '';

--- a/hr/hr_ajout_conges.php
+++ b/hr/hr_ajout_conges.php
@@ -1,4 +1,4 @@
 <?php
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-echo \hr\Fonctions::pageAjoutCongesModule($tab_type_cong, $session);
+echo \hr\Fonctions::pageAjoutCongesModule($tab_type_cong);

--- a/hr/hr_cloture_year.php
+++ b/hr/hr_cloture_year.php
@@ -1,4 +1,4 @@
 <?php
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-echo \hr\Fonctions::pageClotureYearModule($session);
+echo \hr\Fonctions::pageClotureYearModule();

--- a/hr/hr_index.php
+++ b/hr/hr_index.php
@@ -4,8 +4,6 @@ define('ROOT_PATH', '../');
 require ROOT_PATH . 'define.php';
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
-
 include_once ROOT_PATH .'fonctions_conges.php' ;
 include_once INCLUDE_PATH .'fonction.php';
 include_once INCLUDE_PATH .'session.php';
@@ -60,7 +58,7 @@ header_menu('', 'Libertempo : '._('resp_menu_button_mode_hr'),$add_css);
 echo '<div id="onglet_menu">';
 foreach($onglets as $key => $title) {
     echo '<div class="onglet '.($onglet == $key ? ' active': '').'" >
-        <a href="'.$PHP_SELF.'?session='.$session.'&onglet='.$key.'">'. $title .'</a>
+        <a href="'.$PHP_SELF.'?onglet='.$key.'">'. $title .'</a>
     </div>';
 }
 echo '</div>';

--- a/hr/hr_index.php
+++ b/hr/hr_index.php
@@ -12,7 +12,7 @@ include_once INCLUDE_PATH .'session.php';
 include_once ROOT_PATH .'fonctions_calcul.php';
 
 // verif des droits du user à afficher la page
-verif_droits_user($session, "is_hr");
+verif_droits_user("is_hr");
 
 
 /*************************************/

--- a/hr/hr_jours_chomes.php
+++ b/hr/hr_jours_chomes.php
@@ -2,9 +2,7 @@
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
-
 if (file_exists(CONFIG_PATH .'config_ldap.php'))
     include CONFIG_PATH .'config_ldap.php';
 
-echo \hr\Fonctions::pageJoursChomesModule($session);
+echo \hr\Fonctions::pageJoursChomesModule();

--- a/hr/hr_jours_fermeture.php
+++ b/hr/hr_jours_fermeture.php
@@ -3,8 +3,6 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'define.php';
 
-$session=(isset($_GET['session']) ? $_GET['session'] : ((isset($_POST['session'])) ? $_POST['session'] : session_id()) ) ;
-
 if (file_exists(CONFIG_PATH .'config_ldap.php')) {
     include_once CONFIG_PATH .'config_ldap.php';
 }
@@ -15,5 +13,5 @@ include_once INCLUDE_PATH .'fonction.php';
 include_once INCLUDE_PATH .'session.php';
 include_once ROOT_PATH .'fonctions_calcul.php';
 
-echo \hr\Fonctions::pageJoursFermetureModule($session);
+echo \hr\Fonctions::pageJoursFermetureModule();
 bottom();

--- a/hr/hr_page_principale.php
+++ b/hr/hr_page_principale.php
@@ -1,4 +1,4 @@
 <?php
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-echo \hr\Fonctions::pagePrincipaleModule($tab_type_cong, $tab_type_conges_exceptionnels, $session);
+echo \hr\Fonctions::pagePrincipaleModule($tab_type_cong, $tab_type_conges_exceptionnels);

--- a/hr/hr_traitement_demandes.php
+++ b/hr/hr_traitement_demandes.php
@@ -1,4 +1,4 @@
 <?php
 
 defined( '_PHP_CONGES' ) or die( 'Restricted access' );
-echo \hr\Fonctions::pageTraitementDemandeModule($tab_type_cong, $onglet, $session);
+echo \hr\Fonctions::pageTraitementDemandeModule($tab_type_cong, $onglet);

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -181,7 +181,6 @@ function session_is_valid($session)
    // ATTENTION:  on fixe l'id de session comme nom de session pour que , sur un meme pc, on puisse se loguer sous 2 users à la fois
    if (session_id() == "")
    {
-      session_name($session);
       session_start();
    }
 
@@ -189,7 +188,7 @@ function session_is_valid($session)
     {
         $difference = time() - $_SESSION['timestamp_last'];
 
-        if ( ($session==session_id()) && ($difference < $_SESSION['config']['duree_session']) )
+        if ( ($difference < $_SESSION['config']['duree_session']) )
             return true;
     }
 
@@ -205,8 +204,6 @@ function session_create($username)
     {
         if(isset($_SESSION)) unset($_SESSION);
         $session = "phpconges".md5(uniqid(rand()));
-        session_name($session);
-        session_id($session);
 
         session_start();
         $_SESSION['userlogin']=$username;
@@ -228,7 +225,7 @@ function session_create($username)
     $comment_log = 'Connexion de '.$username;
     log_action(0, "", $username, $comment_log);
 
-    return   $session;
+    return $session;
 }
 
 //

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -242,10 +242,8 @@ function session_update($session)
 //
 // destruction d'une session
 //
-function session_delete($session)
+function session_delete()
 {
-   if ($session != "")
-   {
      unset($_SESSION['userlogin']);
      unset($_SESSION['timestamp_start']);
      unset($_SESSION['timestamp_last']);
@@ -253,7 +251,6 @@ function session_delete($session)
      unset($_SESSION['config']);
      unset($_SESSION['lang']);
      session_destroy();
-   }
 }
 
 

--- a/includes/session.php
+++ b/includes/session.php
@@ -20,7 +20,7 @@ if (session_id() == '' || !isset($_SESSION)) {
     if(session_is_valid($session) )
     session_update($session);
     else {
-        session_delete($session);
+        session_delete();
         $session_username="";
         $session_password="";
         $_SESSION['config']=init_config_tab();  // on recrée le tableau de config pour l'url du lien

--- a/includes/session.php
+++ b/includes/session.php
@@ -12,23 +12,19 @@ $session_password="";
 
 //
 // recup du num  de session (mais on ne sais pas s'il est passé en GET ou POST
-$session=(isset($_REQUEST['session']) ? $_REQUEST['session'] : '' );
+$session='';
 
-if ($session != "") //  UNE SESSION EXISTE
-{
-	if(session_is_valid($session) )
-		session_update($session);
-	else {
-		session_delete($session);
-		$session="";
-		$session_username="";
-		$session_password="";
-		$_SESSION['config']=init_config_tab();  // on recrée le tableau de config pour l'url du lien
-		
-		redirect(ROOT_PATH . 'index.php?error=session-invalid');
-	}
+if (session_id() == '' || !isset($_SESSION)) {
+    redirect(ROOT_PATH . 'index.php');
+} else {
+    if(session_is_valid($session) )
+    session_update($session);
+    else {
+        session_delete($session);
+        $session_username="";
+        $session_password="";
+        $_SESSION['config']=init_config_tab();  // on recrée le tableau de config pour l'url du lien
+
+        redirect(ROOT_PATH . 'index.php?error=session-invalid');
+    }
 }
-else    //  PAS DE SESSION   ($session == "")
-	redirect(ROOT_PATH . 'index.php');
-
-

--- a/index.php
+++ b/index.php
@@ -7,7 +7,6 @@ if (!is_readable( CONFIG_PATH .'dbconnect.php'))
 {
 	header("Location:". ROOT_PATH .'install/');
 }
-
 include_once INCLUDE_PATH .'fonction.php';
 include_once ROOT_PATH .'fonctions_conges.php'; // for init_config_tab()
 $_SESSION['config']=init_config_tab();      // on initialise le tableau des variables de config
@@ -16,7 +15,6 @@ $_SESSION['config']=init_config_tab();      // on initialise le tableau des vari
 
 /*** initialisation des variables ***/
 /************************************/
-
 if($_SESSION['config']['auth'] == FALSE)    // si pas d'autentification (cf config de php_conges)
 {
 	$login = getpost_variable('login');
@@ -171,7 +169,7 @@ if(isset($_SESSION['userlogin']))
 	}
 	else
 	{
-		$session=session_id();
+		$session='';
 		$row = $rs->fetch_array();
 		$NOM=$row["u_nom"];
 		$PRENOM=$row["u_prenom"];

--- a/responsable/resp_index.php
+++ b/responsable/resp_index.php
@@ -12,7 +12,7 @@ include_once INCLUDE_PATH . 'session.php';
 include_once ROOT_PATH . 'fonctions_calcul.php';
 
 // verif des droits du user à afficher la page
-verif_droits_user($session, "is_resp");
+verif_droits_user("is_resp");
 
 /*************************************/
 // recup des parametres reçus :


### PR DESCRIPTION
Cf. #108 

Pour que la review se passe bien, et que le contexte de l'objet de la PR se diffuse doucement, je tente une petite expérience : faire des PR de moins de 500kloc et les découper au besoin. Mon but à terme est de séparer les PR de review et les PR de test. L'effet notable est que ça va me forcer à imaginer le design en une fois, pour voir tout l'arbre des changements immédiatement, ou prendre des décisions sur les points incertains. Mais bref.

Cette liste de PR se penche sur l'utilisation des sessions au sein de LT. Auparavant, nous forcions l'id de session et nous le passions partout ; je n'ai jamais compris le besoin, en plus d'être sujet au bug. Aussi, nous allons utiliser les sessions automatiquement, parce que ça marche bien, et ça rend possible l'API, ce qui ne gâte rien.

Cette première PR s'attarde sur les modules admin, configuration, hr, et pose bien évidemment la logique de base aux sessions auto. Dans la PR, ce qui mérite le plus d'attention est `includes/*` et `index.php`, le reste est accessoire et relativement chiant.

:taco: 