### PR TITLE
Harmonisation du chiffrement des mots de passe

### DIFF
--- a/admin/Fonctions.php
+++ b/admin/Fonctions.php
@@ -3393,11 +3393,10 @@ class Fonctions
 
             /*****************************/
             /* INSERT dans conges_users  */
-            if ($_SESSION['config']['how_to_connect_user'] == "dbconges") {
-                $motdepasse = md5($tab_new_user['password1']);
-            } else {
-                $motdepasse = "none";
-            }
+            $motdepasse = ('dbconges' == $_SESSION['config']['how_to_connect_user'])
+                ? $tab_new_user['password1']
+                : 'NIL';
+            $motdepasse = md5($motdepasse);
 
             $sql1 = "INSERT INTO conges_users SET ";
             $sql1=$sql1."u_login='".$tab_new_user['login']."', ";

--- a/admin/Fonctions.php
+++ b/admin/Fonctions.php
@@ -3395,7 +3395,7 @@ class Fonctions
             /* INSERT dans conges_users  */
             $motdepasse = ('dbconges' == $_SESSION['config']['how_to_connect_user'])
                 ? $tab_new_user['password1']
-                : 'NIL';
+                : 'none';
             $motdepasse = md5($motdepasse);
 
             $sql1 = "INSERT INTO conges_users SET ";

--- a/index.php
+++ b/index.php
@@ -52,7 +52,7 @@ else
 		session_destroy();
 
 	// Si CAS alors on utilise le login CAS pour la session
-	if ( $_SESSION['config']['how_to_connect_user'] == "cas" && $_GET['cas'] != "no" )
+	if ( $_SESSION['config']['how_to_connect_user'] == "cas")
 	{
 		//redirection vers l'url d'authentification CAS
 		$usernameCAS = authentification_passwd_conges_CAS();

--- a/install/upgrade_from_v1.9.php
+++ b/install/upgrade_from_v1.9.php
@@ -45,6 +45,10 @@ $sql->query($alterApiUser);
 $addApiToken = 'INSERT IGNORE INTO `conges_appli` VALUES ("token_instance", "")';
 $sql->query($addApiToken);
 
+/* Modification de tous les mots de passe d'utilisateurs non db_conges */
+$updateUserMD5 = 'UPDATE `conges_users` SET u_passwd = "' . md5('none') . '" where u_passwd = "none"';
+$sql->query($updateUserMD5);
+
 $sql->getPdoObj()->commit();
 
 $del_config_db="DELETE FROM conges_config WHERE conf_nom = 'disable_saise_champ_nb_jours_pris';";


### PR DESCRIPTION
L'API a besoin d'un même système de chiffrement pour se connecter et donner le sésame nécessaire aux futurs échanges. Le problème étant que pour les système d'authentification CAS / Kerberos / AD / LDAP, le mot de passe dans la DB n'ayant aucune importance, la décision a été prise de mettre un mot de passe lambda et de ne pas le chiffrer.

Cette PR chiffre donc tous les mots de passe de la même manière, quelle que soit la source de connexion. Elle en profite aussi pour rattraper l'existant, si le besoin était là.

Normalement, ça n'a strictement aucun impact, si ce n'est d'autoriser l'API à se connecter.