### PR TITLE
[LOG] les validations de congés étaient tracés 2 fois

### DIFF
--- a/App/ProtoControllers/Responsable/Traitement/Conge.php
+++ b/App/ProtoControllers/Responsable/Traitement/Conge.php
@@ -284,7 +284,6 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
         } else {
             $id = $this->updateSoldeUser($demande['p_login'], $demande['p_nb_jours'], $demande['p_type']);
             $this->updateStatutValidationFinale($demande['p_num']);
-            log_action($demande['p_num'],"ok", $demande['p_login'], 'traitement demande ' . $demande['p_num'] . ' (' . $demande['p_login'] . ') (' . $demande['p_nb_jours'] . ' jours) : OK');
         }
     }
 


### PR DESCRIPTION
Une petite PR facile et rapide pour retirer un log_action() de trop lors de la validation finale.