### PR TITLE
Mute notice etc.

### DIFF
--- a/define.php
+++ b/define.php
@@ -39,6 +39,10 @@ if (!defined( 'DEFINE_INCLUDE' )) {
     \Kint::enabled(false);
     \Kint::$theme = 'solarized-dark';
     switch (ENV) {
+        case ENV_PROD:
+            error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);
+            ini_set("display_errors", 0);
+            break;
         case ENV_DEV:
             error_reporting(-1);
             // no break;


### PR DESCRIPTION
Fix #471 (entre autres)

Le mode prod force désormais, côté applicatif, une version du compilateur plus souple et muette. Il n'affichera plus aucun message, même si le serveur en a décidé autrement.