### PR TITLE
Ajout de la date de dernier accès api

### DIFF
--- a/admin/Fonctions.php
+++ b/admin/Fonctions.php
@@ -2007,6 +2007,7 @@ class Fonctions
             $sql1=$sql1."u_passwd='$motdepasse', ";
             $sql1=$sql1."u_quotite=".$tab_new_user['quotite'].",";
             $sql1=$sql1."u_heure_solde=".  \App\Helpers\Formatter::hour2Time($tab_new_user['solde_heure']).",";
+            $sql1 .= 'date_inscription = "' . date('Y-m-d H:i') . '" ,';
             $sql1=$sql1." u_email='".$tab_new_user['email']."' ";
             $result1 = \includes\SQL::query($sql1);
 

--- a/install/sql/php_conges_v1.10.sql
+++ b/install/sql/php_conges_v1.10.sql
@@ -279,7 +279,7 @@ CREATE TABLE IF NOT EXISTS `conges_users` (
   `u_heure_solde` int(11) NOT NULL DEFAULT '0',
   `date_inscription` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `token` VARCHAR(100) NOT NULL DEFAULT '',
-  `last_access` TIMESTAMP NOT NULL,
+  `date_last_access` TIMESTAMP NOT NULL,
   PRIMARY KEY (`u_login`),
   KEY `planning_id` (`planning_id`),
   KEY `token` (`token`)

--- a/install/sql/php_conges_v1.10.sql
+++ b/install/sql/php_conges_v1.10.sql
@@ -279,6 +279,7 @@ CREATE TABLE IF NOT EXISTS `conges_users` (
   `u_heure_solde` int(11) NOT NULL DEFAULT '0',
   `date_inscription` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `token` VARCHAR(100) NOT NULL DEFAULT '',
+  `last_access` TIMESTAMP NOT NULL,
   PRIMARY KEY (`u_login`),
   KEY `planning_id` (`planning_id`),
   KEY `token` (`token`)
@@ -358,7 +359,7 @@ INSERT IGNORE INTO `conges_appli` VALUES ('token_instance', '');
 # Contenu de la table `conges_users`
 #
 
-INSERT IGNORE INTO `conges_users` VALUES ('admin', 'Libertempo', 'admin', 'N', 'admin', 'Y', 'N','Y','N', '636d61cf9094a62a81836f3737d9c0da', 100, NULL, 0, 0, 0, null, '');
+INSERT IGNORE INTO `conges_users` VALUES ('admin', 'Libertempo', 'admin', 'N', 'admin', 'Y', 'N','Y','N', '636d61cf9094a62a81836f3737d9c0da', 100, NULL, 0, 0, 0, null, '', null);
 
 #
 # Contenu de la table `conges_config`

--- a/install/sql/php_conges_v1.10.sql
+++ b/install/sql/php_conges_v1.10.sql
@@ -277,9 +277,9 @@ CREATE TABLE IF NOT EXISTS `conges_users` (
   `u_num_exercice` int(2) NOT NULL DEFAULT '0',
   `planning_id` int(11) UNSIGNED NOT NULL,
   `u_heure_solde` int(11) NOT NULL DEFAULT '0',
-  `date_inscription` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `date_inscription` DATETIME NOT NULL DEFAULT NOW(),
   `token` VARCHAR(100) NOT NULL DEFAULT '',
-  `date_last_access` TIMESTAMP NOT NULL,
+  `date_last_access` DATETIME NOT NULL,
   PRIMARY KEY (`u_login`),
   KEY `planning_id` (`planning_id`),
   KEY `token` (`token`)

--- a/install/upgrade_from_v1.9.php
+++ b/install/upgrade_from_v1.9.php
@@ -40,9 +40,9 @@ $res_del_config_from_db=\includes\SQL::query($del_config_db);
 
 /* Ajout des champs de l'utilisateur requis pour l'API */
 $alterApiUser = 'ALTER TABLE `conges_users`
-    ADD `date_inscription` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ADD `date_inscription` DATETIME NOT NULL DEFAULT NOW(),
     ADD `token` VARCHAR(100) NOT NULL DEFAULT "",
-    ADD `date_last_access` TIMESTAMP NOT NULL,
+    ADD `date_last_access` DATETIME NOT NULL,
     ADD INDEX `token` (`token`)';
 $sql->query($alterApiUser);
 

--- a/install/upgrade_from_v1.9.php
+++ b/install/upgrade_from_v1.9.php
@@ -42,6 +42,7 @@ $res_del_config_from_db=\includes\SQL::query($del_config_db);
 $alterApiUser = 'ALTER TABLE `conges_users`
     ADD `date_inscription` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     ADD `token` VARCHAR(100) NOT NULL DEFAULT "",
+    ADD `last_access` TIMESTAMP NOT NULL,
     ADD INDEX `token` (`token`)';
 $sql->query($alterApiUser);
 

--- a/install/upgrade_from_v1.9.php
+++ b/install/upgrade_from_v1.9.php
@@ -42,7 +42,7 @@ $res_del_config_from_db=\includes\SQL::query($del_config_db);
 $alterApiUser = 'ALTER TABLE `conges_users`
     ADD `date_inscription` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     ADD `token` VARCHAR(100) NOT NULL DEFAULT "",
-    ADD `last_access` TIMESTAMP NOT NULL,
+    ADD `date_last_access` TIMESTAMP NOT NULL,
     ADD INDEX `token` (`token`)';
 $sql->query($alterApiUser);
 


### PR DESCRIPTION
Cf. #361 

On va y arriver à force ! Je stocke la date de dernier accès pour que côté API, les échanges aient une durée de péremption qui se repousse à chaque nouvel accès du client. Fonctionne pour tout type de connexion (c'est à ça qu'il sert).