### PR TITLE
Ne pas proposer le changement de mot de passe si le connecteur est tierce

### DIFF
--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -783,6 +783,11 @@ class Fonctions
 
         foreach($tab_new_values as $key => $value ) {
             $value = htmlentities($value, ENT_QUOTES | ENT_HTML401);
+            /* Contrôle de cohérence entre config. */
+            if ('how_to_connect_user' === $key && 'dbconges' !== $value) {
+                $tab_new_values['user_ch_passwd'] = 'FALSE';
+            }
+
             // CONTROLE gestion_conges_exceptionnels
             // si désactivation les conges exceptionnels, on verif s'il y a des conges exceptionnels enregistres ! si oui : changement impossible !
             if(($key=="gestion_conges_exceptionnels") && ($value=="FALSE") ) {

--- a/config/Fonctions.php
+++ b/config/Fonctions.php
@@ -784,8 +784,8 @@ class Fonctions
         foreach($tab_new_values as $key => $value ) {
             $value = htmlentities($value, ENT_QUOTES | ENT_HTML401);
             /* Contrôle de cohérence entre config. */
-            if ('how_to_connect_user' === $key && 'dbconges' !== $value) {
-                $tab_new_values['user_ch_passwd'] = 'FALSE';
+            if ('user_ch_passwd' === $key && 'dbconges' !== $tab_new_values['how_to_connect_user'] ) {
+                $value = 'FALSE';
             }
 
             // CONTROLE gestion_conges_exceptionnels


### PR DESCRIPTION
fix #446 

Il s'agit de réaliser une dépendance entre la configuration du connecteur à celle du changement de mot de passe. En d'autres termes, si le connecteur est tierce, alors l'autorisation du changement de mot de passe est forcée à non.

En attente du merge de https://github.com/Libertempo/libertempo-docker/pull/22