### PR TITLE
Versionner les assets

### DIFF
--- a/Public/template/error_header.php
+++ b/Public/template/error_header.php
@@ -29,13 +29,13 @@ include TEMPLATE_PATH . 'template_define.php';
         <meta name="msapplication-TileImage" content="<?= IMG_PATH ?>Favicons/mstile-144x144.png">
         <meta name="theme-color" content="#ffffff">
         <?php /* JQUERY */ ?>
-        <link type="text/css" href="<?= ASSETS_PATH ?>jquery/css/custom-theme/jquery-ui-1.8.17.custom.css" rel="stylesheet" />
+        <link type="text/css" href="<?= ASSETS_PATH ?>jquery/css/custom-theme/jquery-ui-1.8.17.custom.css?v=<?= $config_php_conges_version ?>" rel="stylesheet" />
         <?php /* BOOTSTRAP */?>
-        <link type="text/css" href="<?= ASSETS_PATH ?>bootstrap/css/bootstrap.min.css" rel="stylesheet" media="screen">
+        <link type="text/css" href="<?= ASSETS_PATH ?>bootstrap/css/bootstrap.min.css?v=<?= $config_php_conges_version ?>" rel="stylesheet" media="screen">
         <?php /* FONT AWESOME */ ?>
-        <link href="<?= ASSETS_PATH ?>font-awesome/css/font-awesome.css" rel="stylesheet">
+        <link href="<?= ASSETS_PATH ?>font-awesome/css/font-awesome.css?v=<?= $config_php_conges_version ?>" rel="stylesheet">
         <?php /* REBOOT STYLE */ ?>
-        <link type="text/css" href="<?= CSS_PATH ?>reboot.css" rel="stylesheet" media="screen">
+        <link type="text/css" href="<?= CSS_PATH ?>reboot.css?v=<?= $config_php_conges_version ?>" rel="stylesheet" media="screen">
         <?php /* SCRIPTS */ ?>
         <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-1.7.1.min.js?v=<?= $config_php_conges_version ?>"></script>
         <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-ui-1.8.17.custom.min.js?v=<?= $config_php_conges_version ?>"></script>

--- a/Public/template/error_header.php
+++ b/Public/template/error_header.php
@@ -12,7 +12,7 @@ include TEMPLATE_PATH . 'template_define.php';
         <link rel="apple-touch-icon" href="<?= IMG_PATH ?>Favicons/apple-touch-icon.png">
         <link rel="apple-touch-icon" sizes="57x57" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-57x57.png">
         <link rel="apple-touch-icon" sizes="60x60" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-60x60.png">
-        <link rel="apple-touch-icon" sizes="72x72" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-72x72.png">    
+        <link rel="apple-touch-icon" sizes="72x72" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-72x72.png">
         <link rel="apple-touch-icon" sizes="76x76" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-76x76.png">
         <link rel="apple-touch-icon" sizes="114x114" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-114x114.png">
         <link rel="apple-touch-icon" sizes="120x120" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-120x120.png">
@@ -37,10 +37,10 @@ include TEMPLATE_PATH . 'template_define.php';
         <?php /* REBOOT STYLE */ ?>
         <link type="text/css" href="<?= CSS_PATH ?>reboot.css" rel="stylesheet" media="screen">
         <?php /* SCRIPTS */ ?>
-        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-1.7.1.min.js"></script>
-        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-ui-1.8.17.custom.min.js"></script>
-        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery.tablesorter.min.js"></script>
-        <script type="text/javascript" src="<?= JS_PATH ?>reboot.js"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-1.7.1.min.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-ui-1.8.17.custom.min.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery.tablesorter.min.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= JS_PATH ?>reboot.js?v=<?= $config_php_conges_version ?>"></script>
         <?= $additional_head; ?>
     </head>
     <body class="error">

--- a/Public/template/login_header.php
+++ b/Public/template/login_header.php
@@ -29,13 +29,13 @@ include TEMPLATE_PATH . 'template_define.php';
         <meta name="msapplication-TileImage" content="<?= IMG_PATH ?>Favicons/mstile-144x144.png">
         <meta name="theme-color" content="#ffffff">
         <?php /* JQUERY */ ?>
-        <link type="text/css" href="<?= ASSETS_PATH ?>jquery/css/custom-theme/jquery-ui-1.8.17.custom.css" rel="stylesheet" />
+        <link type="text/css" href="<?= ASSETS_PATH ?>jquery/css/custom-theme/jquery-ui-1.8.17.custom.css?v=<?= $config_php_conges_version ?>" rel="stylesheet" />
         <?php /* BOOTSTRAP */?>
-        <link type="text/css" href="<?= ASSETS_PATH ?>bootstrap/css/bootstrap.min.css" rel="stylesheet" media="screen">
+        <link type="text/css" href="<?= ASSETS_PATH ?>bootstrap/css/bootstrap.min.css?v=<?= $config_php_conges_version ?>" rel="stylesheet" media="screen">
         <?php /* FONT AWESOME */ ?>
-        <link href="<?= ASSETS_PATH ?>font-awesome/css/font-awesome.css" rel="stylesheet">
+        <link href="<?= ASSETS_PATH ?>font-awesome/css/font-awesome.css?v=<?= $config_php_conges_version ?>" rel="stylesheet">
         <?php /* REBOOT STYLE */ ?>
-        <link type="text/css" href="<?= CSS_PATH ?>reboot.css" rel="stylesheet" media="screen">
+        <link type="text/css" href="<?= CSS_PATH ?>reboot.css?v=<?= $config_php_conges_version ?>" rel="stylesheet" media="screen">
         <?php /* SCRIPTS */ ?>
         <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-1.7.1.min.js?v=<?= $config_php_conges_version ?>"></script>
         <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-ui-1.8.17.custom.min.js?v=<?= $config_php_conges_version ?>"></script>

--- a/Public/template/login_header.php
+++ b/Public/template/login_header.php
@@ -37,10 +37,10 @@ include TEMPLATE_PATH . 'template_define.php';
         <?php /* REBOOT STYLE */ ?>
         <link type="text/css" href="<?= CSS_PATH ?>reboot.css" rel="stylesheet" media="screen">
         <?php /* SCRIPTS */ ?>
-        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-1.7.1.min.js"></script>
-        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-ui-1.8.17.custom.min.js"></script>
-        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery.tablesorter.min.js"></script>
-        <script type="text/javascript" src="<?= JS_PATH ?>reboot.js"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-1.7.1.min.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-ui-1.8.17.custom.min.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery.tablesorter.min.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= JS_PATH ?>reboot.js?v=<?= $config_php_conges_version ?>"></script>
         <?= $additional_head ?>
     </head>
     <body class="login">

--- a/Public/template/menu_header.php
+++ b/Public/template/menu_header.php
@@ -164,12 +164,12 @@ function sousmenuEmploye()
         <?php /* REBOOT STYLE */ ?>
         <link type="text/css" href="<?= CSS_PATH ?>reboot.css" rel="stylesheet" media="screen,print">
         <?php /* JQUERY */ ?>
-        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-1.7.1.min.js"></script>
-        <script type="text/javascript" src="<?= ASSETS_PATH  ?>bootstrap/js/bootstrap.min.js"></script>
-        <script type="text/javascript" src="<?= ASSETS_PATH ?>bootstrap-datepicker/bootstrap-datepicker.js"></script>
-        <script type="text/javascript" src="<?= ASSETS_PATH ?>bootstrap-datepicker/locales/bootstrap-datepicker.fr.js"></script>
-        <script type="text/javascript" src="<?= ASSETS_PATH ?>bootstrap-timepicker/js/bootstrap-timepicker.min.js"></script>
-        <script type="text/javascript" src="<?= JS_PATH ?>reboot.js"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-1.7.1.min.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH  ?>bootstrap/js/bootstrap.min.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH ?>bootstrap-datepicker/bootstrap-datepicker.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH ?>bootstrap-datepicker/locales/bootstrap-datepicker.fr.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH ?>bootstrap-timepicker/js/bootstrap-timepicker.min.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= JS_PATH ?>reboot.js?v=<?= $config_php_conges_version ?>"></script>
         <?= $additional_head ?>
     </head>
     <body id="top" class="connected <?= ($printable) ? 'printable' : '' ?>">

--- a/Public/template/menu_header.php
+++ b/Public/template/menu_header.php
@@ -156,13 +156,13 @@ function sousmenuEmploye()
         <meta name="msapplication-TileImage" content="<?= IMG_PATH ?>Favicons/mstile-144x144.png">
         <meta name="theme-color" content="#ffffff">
         <?php /* BOOTSTRAP */?>
-        <link type="text/css" href="<?= ASSETS_PATH ?>bootstrap/css/bootstrap.min.css" rel="stylesheet" media="screen,print">
-        <link type="text/css" href="<?= CSS_PATH ?>datepicker.css" rel="stylesheet" media="screen">
-        <link type="text/css" href="<?= ASSETS_PATH ?>bootstrap-timepicker/css/bootstrap-timepicker.min.css" rel="stylesheet" media="screen" />
+        <link type="text/css" href="<?= ASSETS_PATH ?>bootstrap/css/bootstrap.min.css?v=<?= $config_php_conges_version ?>" rel="stylesheet" media="screen,print">
+        <link type="text/css" href="<?= CSS_PATH ?>datepicker.css?v=<?= $config_php_conges_version ?>" rel="stylesheet" media="screen">
+        <link type="text/css" href="<?= ASSETS_PATH ?>bootstrap-timepicker/css/bootstrap-timepicker.min.css?v=<?= $config_php_conges_version ?>" rel="stylesheet" media="screen" />
         <?php /* FONT AWESOME */ ?>
-        <link href="<?= ASSETS_PATH ?>font-awesome/css/font-awesome.css" rel="stylesheet">
+        <link href="<?= ASSETS_PATH ?>font-awesome/css/font-awesome.css?v=<?= $config_php_conges_version ?>" rel="stylesheet">
         <?php /* REBOOT STYLE */ ?>
-        <link type="text/css" href="<?= CSS_PATH ?>reboot.css" rel="stylesheet" media="screen,print">
+        <link type="text/css" href="<?= CSS_PATH ?>reboot.css?v=<?= $config_php_conges_version ?>" rel="stylesheet" media="screen,print">
         <?php /* JQUERY */ ?>
         <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-1.7.1.min.js?v=<?= $config_php_conges_version ?>"></script>
         <script type="text/javascript" src="<?= ASSETS_PATH  ?>bootstrap/js/bootstrap.min.js?v=<?= $config_php_conges_version ?>"></script>

--- a/Public/template/popup_header.php
+++ b/Public/template/popup_header.php
@@ -30,13 +30,13 @@ include TEMPLATE_PATH . 'template_define.php';
         <meta name="msapplication-TileImage" content="<?= IMG_PATH ?>Favicons/mstile-144x144.png">
         <meta name="theme-color" content="#ffffff">
         <?php /* JQUERY */ ?>
-        <link type="text/css" href="<?= ASSETS_PATH ?>jquery/css/custom-theme/jquery-ui-1.8.17.custom.css" rel="stylesheet" />
+        <link type="text/css" href="<?= ASSETS_PATH ?>jquery/css/custom-theme/jquery-ui-1.8.17.custom.css?v=<?= $config_php_conges_version ?>" rel="stylesheet" />
         <?php /* BOOTSTRAP */?>
-        <link type="text/css" href="<?= ASSETS_PATH ?>bootstrap/css/bootstrap.min.css" rel="stylesheet" media="screen">
+        <link type="text/css" href="<?= ASSETS_PATH ?>bootstrap/css/bootstrap.min.css?v=<?= $config_php_conges_version ?>" rel="stylesheet" media="screen">
         <?php /* FONT AWESOME */ ?>
-        <link href="<?= ASSETS_PATH ?>font-awesome/css/font-awesome.css" rel="stylesheet">
+        <link href="<?= ASSETS_PATH ?>font-awesome/css/font-awesome.css?v=<?= $config_php_conges_version ?>" rel="stylesheet">
         <?php /* REBOOT STYLE */ ?>
-        <link type="text/css" href="<?= CSS_PATH ?>reboot.css" rel="stylesheet" media="screen">
+        <link type="text/css" href="<?= CSS_PATH ?>reboot.css?v=<?= $config_php_conges_version ?>" rel="stylesheet" media="screen">
         <?php /* SCRIPTS */ ?>
         <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-1.7.1.min.js?v=<?= $config_php_conges_version ?>"></script>
         <script type="text/javascript" src="<?= ASSETS_PATH; ?>jquery/js/jquery-ui-1.8.17.custom.min.js?v=<?= $config_php_conges_version ?>"></script>

--- a/Public/template/popup_header.php
+++ b/Public/template/popup_header.php
@@ -13,7 +13,7 @@ include TEMPLATE_PATH . 'template_define.php';
         <link rel="apple-touch-icon" href="<?= IMG_PATH ?>Favicons/apple-touch-icon.png">
         <link rel="apple-touch-icon" sizes="57x57" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-57x57.png">
         <link rel="apple-touch-icon" sizes="60x60" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-60x60.png">
-        <link rel="apple-touch-icon" sizes="72x72" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-72x72.png">    
+        <link rel="apple-touch-icon" sizes="72x72" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-72x72.png">
         <link rel="apple-touch-icon" sizes="76x76" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-76x76.png">
         <link rel="apple-touch-icon" sizes="114x114" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-114x114.png">
         <link rel="apple-touch-icon" sizes="120x120" href="<?= IMG_PATH ?>Favicons/apple-touch-icon-120x120.png">
@@ -38,10 +38,10 @@ include TEMPLATE_PATH . 'template_define.php';
         <?php /* REBOOT STYLE */ ?>
         <link type="text/css" href="<?= CSS_PATH ?>reboot.css" rel="stylesheet" media="screen">
         <?php /* SCRIPTS */ ?>
-        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-1.7.1.min.js"></script>
-        <script type="text/javascript" src="<?= ASSETS_PATH; ?>jquery/js/jquery-ui-1.8.17.custom.min.js"></script>
-        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery.tablesorter.min.js"></script>
-        <script type="text/javascript" src="<?= JS_PATH ?>reboot.js"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery-1.7.1.min.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH; ?>jquery/js/jquery-ui-1.8.17.custom.min.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= ASSETS_PATH ?>jquery/js/jquery.tablesorter.min.js?v=<?= $config_php_conges_version ?>"></script>
+        <script type="text/javascript" src="<?= JS_PATH ?>reboot.js?v=<?= $config_php_conges_version ?>"></script>
         <?= $additional_head ?>
     </head>
     <body class="popup">

--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -57,6 +57,7 @@ function header_popup($title = '' , $additional_head = '' ) {
     if (empty($title))
         $title = 'Libertempo';
 
+    include ROOT_PATH .'version.php';
     include_once TEMPLATE_PATH . 'popup_header.php';
 }
 
@@ -74,11 +75,13 @@ function header_error($title = '' , $additional_head = '' ) {
     if (empty($title))
         $title = 'Libertempo';
 
+    include ROOT_PATH .'version.php';
     include_once TEMPLATE_PATH . 'error_header.php';
 }
 
 function header_login($title = '' , $additional_head = '' ) {
     global $type_bottom;
+    require_once ROOT_PATH . 'version.php';
 
     static $last_use = '';
     if ($last_use == '') {
@@ -108,6 +111,7 @@ function header_menu( $info ,$title = '' , $additional_head = '' ) {
     if (empty($title))
         $title = 'Libertempo';
 
+    include ROOT_PATH .'version.php';
     include_once TEMPLATE_PATH . 'menu_header.php';
 }
 


### PR DESCRIPTION
Fix #406 

À plusieurs reprises, suite à des mises à jour, des utilisateurs se sont plaints d'un mauvais rendu, la faute à un JS ou un CSS mis à jour dans le code, mais pas dans le navigateur. Pour corriger cela, il suffit de lui transmettre quelques chose qui varierai au changement de version pour que le cache du navigateur bascule sur la nouvelle version.

J'ai tout bêtement mis la version en cours.

Le test frise le ridicule. Il y a en tout 4 headers : au login / aux erreurs de login / aux popup / dans le reste de l'appli. Pour tous ces headers, le testeur devrait se balader dans l'appli avec la console navigateur ouverte pour observer la mise en cache. Puis, en changeant la valeur sur une ressource, cette dernière est rechargée sur la page suivante.


And voilà ! :gb: 