### PR TITLE
Un calendrier sans événement ne s'affiche pas

### DIFF
--- a/App/Libraries/Calendrier/Evenements.php
+++ b/App/Libraries/Calendrier/Evenements.php
@@ -158,17 +158,8 @@ class Evenements
         return 'weekend' === $nomEvenement;
     }
 
-    /**
-     * @TODO: utile ?
-     */
-    public function getEmploye($idEmploye)
-    {
-        $this->verificationExistenceEmploye($idEmploye);
-    }
-
     public function getEvenementsDate($idEmploye, $date)
     {
-        $this->verificationExistenceEmploye($idEmploye);
         if (!isset($this->evenements[$idEmploye]['dates'][$date])) {
             return [];
         }
@@ -178,19 +169,11 @@ class Evenements
 
     public function getTitleDate($idEmploye, $date)
     {
-        $this->verificationExistenceEmploye($idEmploye);
         if (!isset($this->evenements[$idEmploye]['dates'][$date])) {
             return [];
         }
 
         return $this->evenements[$idEmploye]['dates'][$date]['title'];
 
-    }
-
-    private function verificationExistenceEmploye($idEmploye)
-    {
-        if (!isset($this->evenements[$idEmploye])) {
-            throw new \DomainException('Employé inconnu');
-        }
     }
 }

--- a/Tests/Units/App/Libraries/Calendrier/Evenements.php
+++ b/Tests/Units/App/Libraries/Calendrier/Evenements.php
@@ -30,17 +30,6 @@ class Evenements extends \Tests\Units\TestUnit
         $this->calling($this->injectableCreator)->get = $this->evenement;
     }
 
-    public function testGetEvenementsDateEmployeInconnu()
-    {
-        $this->calling($this->evenement)->getListe = [];
-        $calendrier = new _Evenements($this->injectableCreator);
-        $calendrier->fetchEvenements($this->dateDebut, $this->dateFin, $this->employes, false, false);
-
-        $this->exception(function () use ($calendrier) {
-            $calendrier->getEvenementsDate('PetitLapin', '0000-00-00');
-        })->isInstanceOf('\DomainException');
-    }
-
     public function testGetEvenementsDateDateInconnue()
     {
         $this->calling($this->evenement)->getListe = ['2017-02-12'];


### PR DESCRIPTION
Fix #555 

Le ticket n'avait pas vraiment mis la main dessus, mais ça a donné une bonne piste. Lorsqu'aucun événement est associé à un employé, il n'avait simplement pas le droit de s'afficher. C'était une sécurité que j'avais mise pour éviter qu'on ne demande un employé qui n'existait pas, mais cet excès de zèle fait plus de mal que de bien, ça saute donc.