### PR TITLE
Afficher des congés à cheval sur deux mois

### DIFF
--- a/App/Views/Calendrier/Mois.php
+++ b/App/Views/Calendrier/Mois.php
@@ -31,10 +31,13 @@ require_once VIEW_PATH . 'Calendrier.php';
             <?php foreach ($week as $day) : ?>
             <?php
             $today = ($day->isCurrent()) ? 'today' : '';
+            $horsMois = ($day->getBegin()->format('m') != $mois->format('m')) ? 'horsMois' : '';
             $jourString = $day->getBegin()->format('Y-m-d');
             $jours[] = $jourString;
             ?>
-            <th class="<?= $today ?>"><?= $day->getBegin()->format('d') ?></th>
+            <th class="<?= $today  . ' ' . $horsMois ?>">
+                <?= $day->getBegin()->format('d') ?>
+            </th>
             <?php endforeach ?>
             <?php endforeach ?>
         </tr>

--- a/Public/Assets/Css/reboot.css
+++ b/Public/Assets/Css/reboot.css
@@ -659,8 +659,9 @@ td.calendrier-jour.fermeture {
     background: #CEB6FF;
 }
 
-td.calendrier-jour.horsMois {
+th.horsMois {
     background: #CCC;
+    color: white;
 }
 
 td.calendrier-jour.conge_all.conge_ok {

--- a/calendrier.php
+++ b/calendrier.php
@@ -28,11 +28,6 @@ function getUrlMois(\DateTimeInterface $date, $idGroupe)
 
 function getClassesJour(\App\Libraries\Calendrier\Evenements $evenements, $nom, $jour, \DateTimeInterface $moisDemande)
 {
-    $moisJour = date('m', strtotime($jour));
-    if ($moisDemande->format('m') !== $moisJour) {
-        return 'horsMois';
-    }
-
     return implode(' ', $evenements->getEvenementsDate($nom, $jour));
 }
 


### PR DESCRIPTION
Fix {j'ai perdu le ticket}

Lorsque le calendrier possédait des congés sur deux mois, il s'affichait bien sur l'info-bulle mais c'est tout, ce n'était donc pas très parlant. J'ai donc fait sauté l'aspect grisé des périodes de bordures qui n'étaient pas dans le mois courant et l'ai mis sur les dates à la place, cela permet donc de voir les périodes d'absence prises à cheval.