### PR TITLE
L'init set pour allow_url_fopen est interdite

### DIFF
--- a/App/Libraries/ApiClient.php
+++ b/App/Libraries/ApiClient.php
@@ -27,7 +27,7 @@ final class ApiClient
     public function __construct(ClientInterface $client)
     {
         if (!extension_loaded('curl')) {
-            throw new \RuntimeException('cURL or allow_url_fopen are required');
+            throw new \RuntimeException('cURL is required');
         }
         $this->client = $client;
     }

--- a/App/Libraries/ApiClient.php
+++ b/App/Libraries/ApiClient.php
@@ -27,9 +27,7 @@ final class ApiClient
     public function __construct(ClientInterface $client)
     {
         if (!extension_loaded('curl')) {
-            if (false === ini_set('allow_url_fopen', true)) {
-                throw new \RuntimeException('cURL or allow_url_fopen are required');
-            }
+            throw new \RuntimeException('cURL or allow_url_fopen are required');
         }
         $this->client = $client;
     }

--- a/Tests/Units/App/Libraries/ApiClient.php
+++ b/Tests/Units/App/Libraries/ApiClient.php
@@ -41,8 +41,6 @@ class ApiClient extends \Tests\Units\TestUnit
 
         switch ($testMethod) {
             case 'testConstructWithCurl':
-            case 'testConstructWithoutCurlWithFopen':
-            case 'testConstructWithoutCurlWithoutFopen':
                 break;
 
             default:
@@ -65,27 +63,11 @@ class ApiClient extends \Tests\Units\TestUnit
     }
 
     /**
-     * Test de la construction quand l'extension curl n'est pas chargée
-     * mais que la directive sur fopen est activée
-     */
-    public function testConstructWithoutCurlWithFopen()
-    {
-        $this->function->extension_loaded = false;
-        $this->function->ini_set = true;
-
-        $api = new _ApiClient($this->client);
-
-        $this->object($api)->isInstanceOf('\App\Libraries\ApiClient');
-    }
-
-    /**
      * Test de la construction quand ni l'extension curl n'est chargée
-     * ni la directive est activée
      */
-    public function testConstructWithoutCurlWithoutFopen()
+    public function testConstructWithoutCurl()
     {
         $this->function->extension_loaded = false;
-        $this->function->ini_set = false;
 
         $this->exception(function () {
             new _ApiClient($this->client);


### PR DESCRIPTION
Pour l'API, nous utilisons Guzzle qui s'appuie sur deux techno possibles pour faire sa sinistre office : 
- allow_url_fopen
- curl

Je pensais pouvoir apporter un peu de souplesse à l'utilisateur si on ne rendait pas `curl` obligatoire, mais en réalité, la modification `ini_set` à la volée de `allow_url_fopen` est interdite ; j'ai donc supprimé cette possibilité. En revanche, nous devons désormais communiquer sur l'obligation d'installer curl.