### PR TITLE
Session repoussée dans le temps + redirection depuis l'index

### DIFF
--- a/includes/fonction.php
+++ b/includes/fonction.php
@@ -178,18 +178,12 @@ function disable_plugin($plugin){
 //
 function session_is_valid()
 {
-    $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
-   // ATTENTION:  on fixe l'id de session comme nom de session pour que , sur un meme pc, on puisse se loguer sous 2 users à la fois
-   if (session_id() == "")
-   {
-      session_start();
-   }
+    if (session_id() == "") {
+        session_start();
+    }
 
-    if ((isset($_SESSION['timestamp_last'])) && (isset($_SESSION['config']))) {
-        $difference = time() - $_SESSION['timestamp_last'];
-
-        if ( ($difference < SESSION_DURATION) )
-            return true;
+    if (isset($_SESSION['timestamp_last']) && isset($_SESSION['config'])) {
+        return time() < $_SESSION['timestamp_last'];
     }
 
     return false;
@@ -209,7 +203,7 @@ function session_create($username)
         $_SESSION['userlogin']=$username;
         $maintenant=time();
         $_SESSION['timestamp_start']=$maintenant;
-        $_SESSION['timestamp_last']=$maintenant;
+        $_SESSION['timestamp_last']= $maintenant + SESSION_DURATION;
         if (function_exists('init_config_tab'))
             $_SESSION['config']=init_config_tab();      // on initialise le tableau des variables de config
 
@@ -229,10 +223,7 @@ function session_create($username)
 //
 function session_update($session)
 {
-   if ($session != "")
-   {
-        $_SESSION['timestamp_last'] = time();
-   }
+    $_SESSION['timestamp_last'] = time() + SESSION_DURATION;
 }
 
 //

--- a/includes/session.php
+++ b/includes/session.php
@@ -17,7 +17,7 @@ $session='';
 if (session_id() == '' || !isset($_SESSION)) {
     redirect(ROOT_PATH . 'index.php');
 } else {
-    if(session_is_valid($session) )
+    if(session_is_valid())
     session_update($session);
     else {
         session_delete();


### PR DESCRIPTION
Fix #517

Je devais m'arrêter dans les dev pour préparer la beta, mais j'ai découvert cet important bug . Je me suis aperçu que quand on restait plus de 20 minutes dans l'appli à faire des choses et d'autres, on se faisait automatiquement déco après 20~min. Après vérification, l'API n'est pas en cause, c'est donc le Web. Et en effet, il y avait une mauvaise comparaison dans le calcul de la date limite de durée de session. Là où normalement, une session se repousse, notre date était une date absolue, d'où la fermeture impromptue.

Puisque j'étais sur la session, j'ai corrigé #517. Ce que j'ai fait n'est pas propre, je le sais, mais je pense que c'est le meilleur investissement temps / énergie. Refaire les choses signifierai refaire la gestion de la session de 0, et nous y passerons d'ici quelques mois.

## Test

Le test n'est pas très compliqué. Pour #517, il suffit d'aller sur l'index avec une session ouverte et s'apercevoir que l'on est redirigé.
Pour l'autre, il est nécessaire de modifier `SESSION_DURATION` pour le mettre à une durée courte. En parcourant l'appli deci delà, sur develop ça ferme la session, pas sur cette PR ci.