### PR TITLE
date limite reliquat après changement d'exercice

### DIFF
--- a/App/ProtoControllers/Responsable/Traitement/Conge.php
+++ b/App/ProtoControllers/Responsable/Traitement/Conge.php
@@ -246,14 +246,14 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
     protected function putValidationFinale($demandeId)
     {
         $demande = $this->getInfoDemandes(explode(" ", $demandeId))[$demandeId];
-        if (0 < $this->updateSoldeReliquatEmploye($demande['p_login'], $demande['p_nb_jours'], $demande['p_type'])) {
+        if (0 < $this->updateSoldeReliquatEmploye($demande['p_login'], $demande['p_date_deb'], $demande['p_nb_jours'], $demande['p_type'])) {
             return $this->updateStatutValidationFinale($demande['p_num']);
         } else {
             return NIL_INT;
         }
     }
 
-    protected function updateSoldeReliquatEmploye($user, $duree, $typeId)
+    protected function updateSoldeReliquatEmploye($user, $debut, $duree, $typeId)
     {
         if (!$this->isOptionReliquatActive()) {
             return $this->updateSoldeUser($user, $duree, $typeId);
@@ -266,7 +266,7 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
 
         $sql = \includes\SQL::singleton();
 
-        if ($this->isReliquatUtilisable(date("m-d"))) {
+        if ($this->isReliquatUtilisable($debut)) {
             $sql->getPdoObj()->begin_transaction();
             if ($SoldeReliquat>=$duree) {
                 $updateReliquat = $this->updateReliquatUser($user, $duree, $typeId);
@@ -606,19 +606,9 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
      * @param int $findemande date de fin de la demande
      * @return bool
      */
-    public function isReliquatUtilisable($findemande)
+    public function isReliquatUtilisable($debutDemande)
     {
-        $sql = \includes\SQL::singleton();
-        $req = 'SELECT conf_valeur
-                    FROM conges_config
-                    WHERE conf_nom = "jour_mois_limite_reliquats"';
-        $query = $sql->query($req);
-
-        $dlimite = $query->fetch_array()[0];
-        if ($dlimite == 0) {
-            return true;
-        }
-        return $findemande < $dlimite;
+        return $_SESSION['config']['date_limite_reliquats'] < $debutDemande;
     }
 
     /**

--- a/App/ProtoControllers/Responsable/Traitement/Conge.php
+++ b/App/ProtoControllers/Responsable/Traitement/Conge.php
@@ -246,14 +246,14 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
     protected function putValidationFinale($demandeId)
     {
         $demande = $this->getInfoDemandes(explode(" ", $demandeId))[$demandeId];
-        if (0 < $this->updateSoldeReliquatEmploye($demande['p_login'], $demande['p_date_deb'], $demande['p_nb_jours'], $demande['p_type'])) {
+        if (0 < $this->updateSoldeReliquatEmploye($demande['p_login'], $demande['p_nb_jours'], $demande['p_type'])) {
             return $this->updateStatutValidationFinale($demande['p_num']);
         } else {
             return NIL_INT;
         }
     }
 
-    protected function updateSoldeReliquatEmploye($user, $debut, $duree, $typeId)
+    protected function updateSoldeReliquatEmploye($user, $duree, $typeId)
     {
         if (!$this->isOptionReliquatActive()) {
             return $this->updateSoldeUser($user, $duree, $typeId);
@@ -266,7 +266,7 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
 
         $sql = \includes\SQL::singleton();
 
-        if ($this->isReliquatUtilisable($debut)) {
+        if ($this->isReliquatUtilisable()) {
             $sql->getPdoObj()->begin_transaction();
             if ($SoldeReliquat>=$duree) {
                 $updateReliquat = $this->updateReliquatUser($user, $duree, $typeId);
@@ -606,9 +606,9 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
      * @param int $findemande date de fin de la demande
      * @return bool
      */
-    public function isReliquatUtilisable($debutDemande)
+    public function isReliquatUtilisable()
     {
-        return $_SESSION['config']['date_limite_reliquats'] < $debutDemande;
+        return $_SESSION['config']['date_limite_reliquats'] > date('Y-m-d');
     }
 
     /**


### PR DESCRIPTION
La date limite de prise en compte des reliquats doit se baser sur la valeur stockée dans conges_appli.date_limite_reliquats. Elle est alimentée lors du changement d'exercice. 

Le test consiste a mettre une date (YYYY-mm-dd) futur dans conges_appli.date_limite_reliquats et s'assurer que lors du traitement d'une demande de congés (débutant avant la date limite) le reliquat est déduit normalement, avec une date limite dépassé le reliquat doit passer à 0... ~~je me rend soudainement compte que ça ne va pas il faut que je revois ma copie!~~

corrigé, au final je ne change presque rien, on vérifie que date_limite_reliquats n'est pas passé le jour du traitement. 