### PR TITLE
Allow @ in login name

### DIFF
--- a/admin/Fonctions.php
+++ b/admin/Fonctions.php
@@ -1942,7 +1942,7 @@ class Fonctions
     }
 
     public static function FormAddUserLoginOk($login) {
-        return preg_match('/^[a-z.\d_-]{2,30}$/i', $login);
+        return preg_match('/^[@a-z.\d_-]{2,30}$/i', $login);
     }
 
     public static function FormAddUserQuotiteOk($quot) {


### PR DESCRIPTION
Hi,

Login name may contain @, especially AD/LDAP logins.
This PR then adds `@` as a valid login character.
Tested with 1.10, works perfectly.

In develop branch, sounds like the corresponding code is here, however I did not test it :
https://github.com/Libertempo/Libertempo-web/blob/83da2ee581ef2448016720ec90c1008512f7d926/App/ProtoControllers/HautResponsable/Utilisateur.php#L727

Thank you 👍 

Ben