### PR TITLE
Reject crawlers by default

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Hi,

For security reasons, this PR adds a `robots.txt` file which reject crawlers by default, avoiding them to browse and reference the tool.

Thank you 👍 

Ben