### PR TITLE
Empêcher la prise d'absence dans le  passé

### DIFF
--- a/Public/Assets/Js/reboot.js
+++ b/Public/Assets/Js/reboot.js
@@ -85,13 +85,11 @@ function generateDatePicker(opts, compter)
         todayHighlight     : true,
         daysOfWeekDisabled : [],
         datesDisabled      : [],
-        startDate          : ''
     };
     var toApply = defaultOpts;
 
-    /* On ne peut pas écraser une option qui n'existe en défaut */
-    for (var i in defaultOpts) {
-        toApply[i] = (undefined !== opts[i]) ? opts[i] : defaultOpts[i];
+    for (var i in opts) {
+        toApply[i] = opts[i];
     }
     $(document).ready(function () {
         $('input.date').datepicker(toApply).on("change", function() {
@@ -770,7 +768,7 @@ function searchLdapUser() {
                 list.appendChild(frag);
                 list.style.display = "block";
             } else {
-                list.style.display = "none";			
+                list.style.display = "none";
             }
         },
     });

--- a/utilisateur/Fonctions.php
+++ b/utilisateur/Fonctions.php
@@ -68,6 +68,10 @@ class Fonctions
         if ($config->canSoldeNegatif()) {
             $valid = $valid && \utilisateur\Fonctions::verif_solde_user($_SESSION['userlogin'], $new_type, $new_nb_jours);
         }
+        if (!$config->canUserSaisieDemandePasse()) {
+            $now = time();
+            $valid = $valid && strtotime($new_debut) - $now >= 0 && strtotime($new_fin) - $now >= 0;
+        }
 
         if ( $valid ) {
             if ( in_array(\utilisateur\Fonctions::get_type_abs($new_type) , array('conges','conges_exceptionnels') ) ) {
@@ -218,13 +222,14 @@ class Fonctions
                     $datesDisabled[] = \App\Helpers\Formatter::dateIso2Fr($date);
                 }
             }
-            $startDate = ($config->canUserSaisieDemandePasse()) ? 'd' : '';
 
             $datePickerOpts = [
                 'daysOfWeekDisabled' => $daysOfWeekDisabled,
                 'datesDisabled'      => $datesDisabled,
-                'startDate'          => $startDate,
             ];
+            if (!$config->canUserSaisieDemandePasse()) {
+                $datePickerOpts['startDate'] = 'd';
+            }
             $return .= '<script>generateDatePicker(' . json_encode($datePickerOpts) . ');</script>';
             $return .= '<h1>' . _('resp_traite_user_new_conges') . '</h1>';
 


### PR DESCRIPTION
fix #383 

Dès lors où « interdit saisie date passée » est à TRUE, le datepicker ne permet plus de choisir une date dans le passé. Pour autant, il est toujours possible de saisir à la main l'absence à la date que l'on souhaite. Cette PR corrige ça.