### PR TITLE
Allow @ in login name

### DIFF
--- a/App/ProtoControllers/HautResponsable/Utilisateur.php
+++ b/App/ProtoControllers/HautResponsable/Utilisateur.php
@@ -724,7 +724,7 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
     {
         $return = true;
 
-        if (!preg_match('/^[a-z.\d_-]{2,30}$/i', $data['login'])) {
+        if (!preg_match('/^[@a-z.\d_-]{2,30}$/i', $data['login'])) {
             $errors[] = _('Identifiant incorrect.');
             $return = false;
         }


### PR DESCRIPTION
Hi,

Login name may contain @, especially AD/LDAP logins.
This PR then adds @ as a valid login character.

It's a re-work of #624.

Thank you 👍 

Ben