### PR TITLE
Calcul des dates féries non asujettis aux changements d'heures

### DIFF
--- a/Tests/Units/hr/Fonctions.php
+++ b/Tests/Units/hr/Fonctions.php
@@ -1,0 +1,59 @@
+<?php
+namespace Tests\Units\hr;
+
+/**
+ * Classe de test des fonctions du HR
+ *
+ * @since 1.11
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ */
+class Fonctions extends \Tests\Units\TestUnit
+{
+    /**
+     * Test le bon calcul auto des jours féries
+     *
+     * @dataProvider providerJourFeries
+     */
+    public function testFcListJourFeries($annee, $joursFeries)
+    {
+        $class = $this->testedClass->getClass();
+        $this->array(array_values($class::fcListJourFeries($annee)))
+            ->isIdenticalTo($joursFeries);
+    }
+
+    protected function providerJourFeries()
+    {
+        return [
+            [
+                '2018', [
+                    '2018-01-01',
+                    '2018-04-01',
+                    '2018-04-02',
+                    '2018-05-01',
+                    '2018-05-08',
+                    '2018-05-10',
+                    '2018-07-14',
+                    '2018-08-15',
+                    '2018-11-01',
+                    '2018-11-11',
+                    '2018-12-25',
+                ],
+            ],
+            [
+                '2019', [
+                    '2019-01-01',
+                    '2019-04-21',
+                    '2019-04-22',
+                    '2019-05-01',
+                    '2019-05-08',
+                    '2019-05-30',
+                    '2019-07-14',
+                    '2019-08-15',
+                    '2019-11-01',
+                    '2019-11-11',
+                    '2019-12-25',
+                ],
+            ]
+        ];
+    }
+}

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -1488,24 +1488,22 @@ class Fonctions
     {
 
         //Initialisation de variables
-        $iCstJour = 3600*24;
-        $tbJourFerie=array();
+        $unJour = 3600*24;
+        $tbJourFerie = array();
+        $timePaques = easter_date($iAnnee) + 6 * 3600; // évite les changements d'heures
 
-        // Détermination des dates toujours fixes
-        $tbJourFerie["Jour de l an"]     = $iAnnee . "-01-01";
-        $tbJourFerie["Armistice 39-45"]  = $iAnnee . "-05-08";
-        $tbJourFerie["Toussaint"]        = $iAnnee . "-11-01";
-        $tbJourFerie["Armistice 14-18"]  = $iAnnee . "-11-11";
-        $tbJourFerie["Assomption"]       = $iAnnee . "-08-15";
-        $tbJourFerie["Fete du travail"]  = $iAnnee . "-05-01";
-        $tbJourFerie["Fete nationale"]   = $iAnnee . "-07-14";
-        $tbJourFerie["Noel"]    = $iAnnee . "-12-25";
+        $tbJourFerie["Jour de l an"] = $iAnnee . "-01-01";
+        $tbJourFerie["Paques"] = date('Y-m-d', $timePaques);
+        $tbJourFerie["Lundi de Paques"] = $iAnnee . date("-m-d", $timePaques + 1 * $unJour);
+        $tbJourFerie["Fete du travail"] = $iAnnee . "-05-01";
+        $tbJourFerie["Armistice 39-45"] = $iAnnee . "-05-08";
+        $tbJourFerie["Jeudi de l ascension"] = $iAnnee . date("-m-d", easter_date($iAnnee) + 39 * $unJour);
+        $tbJourFerie["Fete nationale"] = $iAnnee . "-07-14";
+        $tbJourFerie["Assomption"] = $iAnnee . "-08-15";
+        $tbJourFerie["Toussaint"] = $iAnnee . "-11-01";
+        $tbJourFerie["Armistice 14-18"] = $iAnnee . "-11-11";
+        $tbJourFerie["Noel"] = $iAnnee . "-12-25";
 
-        // Récupération des fêtes mobiles
-             $tbJourFerie["Lundi de Paques"]   = $iAnnee . date( "-m-d", easter_date($iAnnee) + 1*$iCstJour );
-             $tbJourFerie["Jeudi de l ascension"] = $iAnnee . date( "-m-d", easter_date($iAnnee) + 39*$iCstJour );
-
-        // Retour du tableau des jours fériés pour l'année demandée
         return $tbJourFerie;
     }
 


### PR DESCRIPTION
fix #631 

Date est une fonction fourbe, je m'en méfie depuis longtemps ; contrainte par le serveur, elle n'est pas si universelle qu'on le pense. J'ai donc fait un quickfix pour ne pas subir les éventuels changements d'heures.

Je me suis planté, j'ai basé sur `develop`, donc le code ne sera pas poussé en prod avant la release d'Akhaten. Voilà, bisous.