### PR TITLE
LT php7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - '5.6'
   - '7.0'
 notifications:
   email:

--- a/App/Libraries/ApiClient.php
+++ b/App/Libraries/ApiClient.php
@@ -143,7 +143,7 @@ final class ApiClient
             $emptyClass->data = [];
             return $emptyClass;
         }
-        $jsonBody = json_decode($body, false);
+        $jsonBody = json_decode($body, true);
         if (null === $jsonBody) {
             throw new \RuntimeException('La réponse n\'est pas du JSON');
         }

--- a/App/Views/Planning/Liste.php
+++ b/App/Views/Planning/Liste.php
@@ -22,16 +22,16 @@
     <tr><td colspan="2"><center><?= _('aucun_resultat') ?></center></td></tr>
 <?php else : ?>
     <?php foreach ($plannings as $planning) : ?>
-        <tr><td><?= $planning->name ?></td>
+        <tr><td><?= $planning['name'] ?></td>
             <td>
                 <form action="" method="post" accept-charset="UTF-8"
                 enctype="application/x-www-form-urlencoded">
-                <a title="<?= _('form_modif') ?>" href="<?= $lienModif ?>&amp;id=<?= $planning->id ?>"><i class="fa fa-pencil"></i></a>&nbsp;&nbsp;
+                <a title="<?= _('form_modif') ?>" href="<?= $lienModif ?>&amp;id=<?= $planning['id'] ?>"><i class="fa fa-pencil"></i></a>&nbsp;&nbsp;
                 <?php if ($isHr) : ?>
-                    <?php if (in_array($planning->id, $listIdUsed)) : ?>
+                    <?php if (in_array($planning['id'], $listIdUsed)) : ?>
                         <button title="<?= _('planning_used') ?>" type="button" class="btn btn-link disabled"><i class="fa fa-times-circle"></i></button>
                     <?php else : ?>
-                            <input type="hidden" name="planning_id" value="<?= $planning->id ?>" />
+                            <input type="hidden" name="planning_id" value="<?= $planning['id'] ?>" />
                             <input type="hidden" name="_METHOD" value="DELETE" />
                             <button type="submit" class="btn btn-link" title="<?= _('form_supprim') ?>"><i class="fa fa-times-circle"></i></button>
                     <?php endif ?>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Chaque nouvelle version est mise à disposition sur [github](https://github.com/
 # Support minimum
 | Logiciel | Version |
 |-------|-----|
-| php   | 5.6 |
+| php   | 7.0 |
 | mysql | 5.6 |
 | apache| 2.4 |
 

--- a/Tests/Units/App/Libraries/ApiClient.php
+++ b/Tests/Units/App/Libraries/ApiClient.php
@@ -218,10 +218,10 @@ class ApiClient extends \Tests\Units\TestUnit
 
         $this->mock($this->client)->call('request')->withIdenticalArguments($method, $uri, $options)->once();
 
-        $this->string($request->code);
-        $this->string($request->status);
-        $this->string($request->message);
-        $this->string($request->data);
+        $this->string($request['code']);
+        $this->string($request['status']);
+        $this->string($request['message']);
+        $this->string($request['data']);
     }
 
     public function testClone()

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "vendor-dir": "vendor"
     },
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^7.0",
         "ext-mbstring": "*",
         "ext-Reflection": "*",
         "ext-curl": "*",
@@ -37,7 +37,7 @@
         "jasig/phpcas": "1.3.5",
         "yohang/calendr": "^2.0",
         "guzzlehttp/guzzle": "6.2.2",
-        "libertempo/libertempo-api": "0.7.0"
+        "libertempo/libertempo-api": "1.0.0"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -1,27 +1,28 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5729cab80e0b4930fd056a72f317aefd",
+    "content-hash": "33636716666ce69d1622c78d49f662c3",
     "packages": [
         {
             "name": "Libertempo/libertempo-api",
-            "version": "v0.7.0",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Libertempo/libertempo-api.git",
-                "reference": "dba1f29d480772d489924dca86e89761967c2f69"
+                "reference": "7082a2d81bc7bba429b93ad2f50dfc48450c6a92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Libertempo/libertempo-api/zipball/dba1f29d480772d489924dca86e89761967c2f69",
-                "reference": "dba1f29d480772d489924dca86e89761967c2f69",
+                "url": "https://api.github.com/repos/Libertempo/libertempo-api/zipball/7082a2d81bc7bba429b93ad2f50dfc48450c6a92",
+                "reference": "7082a2d81bc7bba429b93ad2f50dfc48450c6a92",
                 "shasum": ""
             },
             "require": {
                 "doctrine/dbal": "2.5",
+                "php": "^7.0",
                 "raveren/kint": "^1.0",
                 "slim/slim": "^3.5"
             },
@@ -52,10 +53,10 @@
             "support": {
                 "email": "libertempo@lists.tuxfamily.org",
                 "irc": "irc://irc.tuxfamily.org/#Libertempo",
-                "source": "https://github.com/Libertempo/libertempo-api/tree/v0.7.0",
+                "source": "https://github.com/Libertempo/libertempo-api/tree/v1.0.0",
                 "issues": "https://github.com/Libertempo/libertempo-api/issues"
             },
-            "time": "2018-03-12T19:40:09+00:00"
+            "time": "2018-05-08T21:32:19+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -1456,7 +1457,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6|^7.0",
+        "php": "^7.0",
         "ext-mbstring": "*",
         "ext-reflection": "*",
         "ext-curl": "*"

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -1538,7 +1538,7 @@ class Fonctions
         return true;
     }
 
-    public static function insert_year($tab_checkbox_j_chome) : bool
+    public static function insert_year($tab_checkbox_j_chome) : bool
     {
         foreach($tab_checkbox_j_chome as $key => $value)
             $result = \includes\SQL::query('INSERT INTO conges_jours_feries SET jf_date="'. \includes\SQL::quote($key).'";');
@@ -1628,7 +1628,7 @@ class Fonctions
 
     // affichage du calendrier du mois avec les case à cocher
     // on lui passe en parametre le tableau des jour chomé de l'année (pour pré-cocher certaines cases)
-    public static function affiche_calendrier_saisie_jours_chomes($year, $mois, $tab_year) : string
+    public static function affiche_calendrier_saisie_jours_chomes($year, $mois, $tab_year) : string
     {
         $jour_today=date("j");
         $jour_today_name=date("D");
@@ -1715,7 +1715,7 @@ class Fonctions
         return $return;
     }
 
-    public static function saisie($year_calendrier_saisie) : string
+    public static function saisie($year_calendrier_saisie) : string
     {
         $sql = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($sql);
@@ -1907,7 +1907,7 @@ class Fonctions
         }
     }
 
-    public static function cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $commentaire) : string
+    public static function cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $commentaire) : string
     {
         $return = '';
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
@@ -2065,7 +2065,7 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage_cloture_globale_pour_tous($tab_type_conges) : string
+    public static function affichage_cloture_globale_pour_tous($tab_type_conges) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -2095,7 +2095,7 @@ class Fonctions
         return $return;
     }
 
-    public static function affiche_ligne_du_user($current_login, $tab_type_conges, $tab_current_user, $i = true) : string
+    public static function affiche_ligne_du_user($current_login, $tab_type_conges, $tab_current_user, $i = true) : string
     {
         $return = '';
         $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
@@ -2275,7 +2275,7 @@ class Fonctions
         return $return;
     }
 
-    public static function affiche_calendrier_fermeture_mois($year, $mois, $tab_year) : string
+    public static function affiche_calendrier_fermeture_mois($year, $mois, $tab_year) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $jour_today=date("j");
@@ -2764,7 +2764,7 @@ class Fonctions
         }
     }
 
-    public static function saisie_dates_fermeture($year, $groupe_id, $new_date_debut, $new_date_fin, $code_erreur) : string
+    public static function saisie_dates_fermeture($year, $groupe_id, $new_date_debut, $new_date_fin, $code_erreur) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -2802,7 +2802,7 @@ class Fonctions
         return $return;
     }
 
-    public static function saisie_groupe_fermeture() : string
+    public static function saisie_groupe_fermeture() : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -810,7 +810,7 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage($user_login,  $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date, $onglet) : string
+    public static function affichage($user_login, $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date, $onglet) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
 
@@ -1385,7 +1385,7 @@ class Fonctions
         return $list_users;
     }
 
-    public static function saisie_ajout( $tab_type_conges) : string
+    public static function saisie_ajout($tab_type_conges) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);

--- a/hr/Fonctions.php
+++ b/hr/Fonctions.php
@@ -7,7 +7,7 @@ namespace hr;
  */
 class Fonctions
 {
-    public static function traite_all_demande_en_cours($tab_bt_radio, $tab_text_refus)
+    public static function traite_all_demande_en_cours(array $tab_bt_radio, array $tab_text_refus) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
@@ -70,7 +70,7 @@ class Fonctions
         return $return;
     }
 
-    public static function affiche_all_demandes_en_cours($tab_type_conges)
+    public static function affiche_all_demandes_en_cours($tab_type_conges) : string
     {
         $return = '';
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
@@ -229,11 +229,10 @@ class Fonctions
      * @param array  $tab_type_cong
      * @param string $onglet
      *
-     * @return void
      * @access public
      * @static
      */
-    public static function pageTraitementDemandeModule(array $tab_type_cong, $onglet)
+    public static function pageTraitementDemandeModule(array $tab_type_cong, $onglet) : string
     {
         $return = '';
 
@@ -256,7 +255,7 @@ class Fonctions
         return $return;
     }
 
-    public static function new_conges($user_login, $numero_int, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id)
+    public static function new_conges($user_login, $numero_int, $new_debut, $new_demi_jour_deb, $new_fin, $new_demi_jour_fin, $new_nb_jours, $new_comment, $new_type_id) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -307,7 +306,7 @@ class Fonctions
         return $return;
     }
 
-    public static function traite_demandes($user_login, $tab_radio_traite_demande, $tab_text_refus)
+    public static function traite_demandes($user_login, $tab_radio_traite_demande, $tab_text_refus) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
@@ -392,7 +391,7 @@ class Fonctions
         return $return;
     }
 
-    public static function annule_conges($user_login, $tab_checkbox_annule, $tab_text_annul)
+    public static function annule_conges($user_login, $tab_checkbox_annule, $tab_text_annul) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
@@ -442,7 +441,7 @@ class Fonctions
     }
 
     //affiche l'état des conges du user (avec le formulaire pour le responsable)
-    public static function affiche_etat_conges_user_for_resp($user_login, $year_affichage, $tri_date)
+    public static function affiche_etat_conges_user_for_resp($user_login, $year_affichage, $tri_date) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
@@ -590,7 +589,7 @@ class Fonctions
     }
 
     //affiche l'état des demande en attente de 2ieme validation du user (avec le formulaire pour le responsable)
-    public static function affiche_etat_demande_2_valid_user_for_resp($user_login)
+    public static function affiche_etat_demande_2_valid_user_for_resp($user_login) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
@@ -691,7 +690,7 @@ class Fonctions
     }
 
     //affiche l'état des demande du user (avec le formulaire pour le responsable)
-    public static function affiche_etat_demande_user_for_resp($user_login, $tab_user, $tab_grd_resp)
+    public static function affiche_etat_demande_user_for_resp($user_login, $tab_user, $tab_grd_resp) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL); ;
@@ -811,7 +810,7 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage($user_login,  $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date, $onglet)
+    public static function affichage($user_login,  $year_affichage, $year_calendrier_saisie_debut, $mois_calendrier_saisie_debut, $year_calendrier_saisie_fin, $mois_calendrier_saisie_fin, $tri_date, $onglet) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
 
@@ -962,11 +961,10 @@ class Fonctions
      *
      * @param string $onglet
      *
-     * @return void
      * @access public
      * @static
      */
-    public static function pageTraiteUserModule($onglet)
+    public static function pageTraiteUserModule($onglet) : string
     {
         //var pour hr_traite_user.php
         $user_login                 = htmlentities(getpost_variable('user_login'), ENT_QUOTES | ENT_HTML401);
@@ -1011,7 +1009,7 @@ class Fonctions
     }
 
     // recup de la liste de tous les groupes pour le mode RH
-    public static function get_list_groupes_pour_rh($user_login)
+    public static function get_list_groupes_pour_rh($user_login) : string
     {
         $list_group="";
 
@@ -1093,7 +1091,7 @@ class Fonctions
         }
     }
 
-    public static function ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all)
+    public static function ajout_global($tab_new_nb_conges_all, $tab_calcul_proportionnel, $tab_new_comment_all) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -1172,7 +1170,7 @@ class Fonctions
         }
     }
 
-    public static function affichage_saisie_globale_groupe($tab_type_conges)
+    public static function affichage_saisie_globale_groupe($tab_type_conges) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -1228,7 +1226,7 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage_saisie_globale_pour_tous($tab_type_conges)
+    public static function affichage_saisie_globale_pour_tous($tab_type_conges) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -1265,7 +1263,7 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage_saisie_user_par_user($tab_type_conges, $tab_type_conges_exceptionnels, $tab_all_users_du_hr, $tab_all_users_du_grand_resp)
+    public static function affichage_saisie_user_par_user($tab_type_conges, $tab_type_conges_exceptionnels, $tab_all_users_du_hr, $tab_all_users_du_grand_resp) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
@@ -1350,7 +1348,7 @@ class Fonctions
     }
 
     // renvoit un tableau de tableau contenant les informations de tous les users dont $login est HR responsable
-    public static function recup_infos_all_users_du_hr($login)
+    public static function recup_infos_all_users_du_hr($login) : array
     {
         $tab=array();
         $list_groupes_double_validation=get_list_groupes_double_valid();
@@ -1368,7 +1366,7 @@ class Fonctions
 
     // recup de la liste de TOUS les users pour le responsable RH
     // renvoit une liste de login entre quotes et séparés par des virgules
-    public static function get_list_all_users_du_hr($resp_login)
+    public static function get_list_all_users_du_hr($resp_login) : string
     {
         $list_users="";
 
@@ -1387,7 +1385,7 @@ class Fonctions
         return $list_users;
     }
 
-    public static function saisie_ajout( $tab_type_conges)
+    public static function saisie_ajout( $tab_type_conges) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
@@ -1433,11 +1431,10 @@ class Fonctions
      *
      * @param array  $tab_type_cong
      *
-     * @return void
      * @access public
      * @static
      */
-    public static function pageAjoutCongesModule($tab_type_cong)
+    public static function pageAjoutCongesModule($tab_type_cong) : string
     {
         //var pour resp_ajout_conges_all.php
         $ajout_conges = getpost_variable('ajout_conges');
@@ -1484,9 +1481,8 @@ class Fonctions
 
     //fonction de recherche des jours fériés de l'année demandée
     // trouvée sur http://www.phpcs.com/codes/LISTE-JOURS-FERIES-ANNEE_32791.aspx
-    public static function fcListJourFeries($iAnnee = 2000)
+    public static function fcListJourFeries($iAnnee = 2000) : array
     {
-
         //Initialisation de variables
         $iCstJour = 3600*24;
         $tbJourFerie=array();
@@ -1512,7 +1508,6 @@ class Fonctions
     // retourne un tableau des jours feriés de l'année dans un tables passé par référence
     public static function get_tableau_jour_feries($year, &$tab_year)
     {
-
         $sql_select='SELECT jf_date FROM conges_jours_feries WHERE jf_date LIKE "'. \includes\SQL::quote($year).'-%" ;';
         $res_select = \includes\SQL::query($sql_select);
         $num_select = $res_select->num_rows;
@@ -1524,7 +1519,8 @@ class Fonctions
         }
     }
 
-    public static function verif_year_deja_saisie($tab_checkbox_j_chome) {
+    public static function verif_year_deja_saisie($tab_checkbox_j_chome) : bool
+    {
         $date_1=key($tab_checkbox_j_chome);
         $year=substr($date_1, 0, 4);
         $sql_select='SELECT jf_date FROM conges_jours_feries WHERE jf_date LIKE "'. \includes\SQL::quote($year).'%" ;';
@@ -1532,7 +1528,8 @@ class Fonctions
         return($relog->num_rows != 0);
     }
 
-    public static function delete_year($tab_checkbox_j_chome) {
+    public static function delete_year($tab_checkbox_j_chome) : bool
+    {
         $date_1=key($tab_checkbox_j_chome);
         $year=substr($date_1, 0, 4);
         $sql_delete='DELETE FROM conges_jours_feries WHERE jf_date LIKE "'. \includes\SQL::quote($year).'%" ;';
@@ -1541,13 +1538,14 @@ class Fonctions
         return true;
     }
 
-    public static function insert_year($tab_checkbox_j_chome) {
+    public static function insert_year($tab_checkbox_j_chome) : bool
+    {
         foreach($tab_checkbox_j_chome as $key => $value)
             $result = \includes\SQL::query('INSERT INTO conges_jours_feries SET jf_date="'. \includes\SQL::quote($key).'";');
         return true;
     }
 
-    public static function commit_saisie($tab_checkbox_j_chome)
+    public static function commit_saisie($tab_checkbox_j_chome) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -1577,7 +1575,7 @@ class Fonctions
         return $return;
     }
 
-    public static function confirm_saisie($tab_checkbox_j_chome)
+    public static function confirm_saisie($tab_checkbox_j_chome) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -1610,13 +1608,15 @@ class Fonctions
         bottom();
     }
 
-    public static function affiche_jour_hors_mois($mois,$i,$year,$tab_year) {
+    public static function affiche_jour_hors_mois($mois,$i,$year,$tab_year) : string
+    {
         $j_timestamp=mktime (0,0,0,$mois,$i,$year);
         $td_second_class=get_td_class_of_the_day_in_the_week($j_timestamp);
         return "<td class=\"cal-saisie2 month-out $td_second_class\">&nbsp;</td>\n";
     }
 
-    public static function affiche_jour_checkbox($mois,$i,$year,$tab_year) {
+    public static function affiche_jour_checkbox($mois,$i,$year,$tab_year) : string
+    {
         $j_timestamp=mktime (0,0,0,$mois,$i,$year);
         $j_date=date("Y-m-d", $j_timestamp);
         $j_day=date("d", $j_timestamp);
@@ -1628,7 +1628,7 @@ class Fonctions
 
     // affichage du calendrier du mois avec les case à cocher
     // on lui passe en parametre le tableau des jour chomé de l'année (pour pré-cocher certaines cases)
-    public static function affiche_calendrier_saisie_jours_chomes($year, $mois, $tab_year)
+    public static function affiche_calendrier_saisie_jours_chomes($year, $mois, $tab_year) : string
     {
         $jour_today=date("j");
         $jour_today_name=date("D");
@@ -1715,7 +1715,7 @@ class Fonctions
         return $return;
     }
 
-    public static function saisie($year_calendrier_saisie)
+    public static function saisie($year_calendrier_saisie) : string
     {
         $sql = \includes\SQL::singleton();
         $config = new \App\Libraries\Configuration($sql);
@@ -1772,11 +1772,10 @@ class Fonctions
     /**
      * Encapsule le comportement du module des jours chomés
      *
-     * @return void
      * @access public
      * @static
      */
-    public static function pageJoursChomesModule()
+    public static function pageJoursChomesModule() : string
     {
         // verif des droits du user à afficher la page
         verif_droits_user( "is_hr");
@@ -1847,7 +1846,7 @@ class Fonctions
     }
 
     // cloture / debut d'exercice pour TOUS les users d'un groupe'
-    public static function cloture_globale_groupe($group_id, $tab_type_conges)
+    public static function cloture_globale_groupe($group_id, $tab_type_conges) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -1866,7 +1865,7 @@ class Fonctions
     }
 
     // cloture / debut d'exercice pour TOUS les users du resp (ou grand resp)
-    public static function cloture_globale($tab_type_conges)
+    public static function cloture_globale($tab_type_conges) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -1908,7 +1907,7 @@ class Fonctions
         }
     }
 
-    public static function cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $commentaire)
+    public static function cloture_current_year_for_login($current_login, $tab_current_user, $tab_type_conges, $commentaire) : string
     {
         $return = '';
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
@@ -1987,7 +1986,7 @@ class Fonctions
     }
 
     // cloture / debut d'exercice user par user pour les users du resp (ou grand resp)
-    public static function cloture_users($tab_type_conges, $tab_cloture_users, $tab_commentaire_saisie)
+    public static function cloture_users($tab_type_conges, $tab_cloture_users, $tab_commentaire_saisie) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -2010,7 +2009,7 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage_cloture_globale_groupe($tab_type_conges)
+    public static function affichage_cloture_globale_groupe($tab_type_conges) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -2066,7 +2065,7 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage_cloture_globale_pour_tous($tab_type_conges)
+    public static function affichage_cloture_globale_pour_tous($tab_type_conges) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -2096,7 +2095,7 @@ class Fonctions
         return $return;
     }
 
-    public static function affiche_ligne_du_user($current_login, $tab_type_conges, $tab_current_user, $i = true)
+    public static function affiche_ligne_du_user($current_login, $tab_type_conges, $tab_current_user, $i = true) : string
     {
         $return = '';
         $return .= '<tr class="' . ($i ? 'i' : 'p') . '">';
@@ -2130,7 +2129,7 @@ class Fonctions
         return $return;
     }
 
-    public static function affichage_cloture_user_par_user($tab_type_conges, $tab_all_users_du_hr, $tab_all_users_du_grand_resp)
+    public static function affichage_cloture_user_par_user($tab_type_conges, $tab_all_users_du_hr, $tab_all_users_du_grand_resp) : string 
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -2194,7 +2193,7 @@ class Fonctions
         return $return;
     }
 
-    public static function saisie_cloture( $tab_type_conges)
+    public static function saisie_cloture( $tab_type_conges) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
@@ -2230,11 +2229,10 @@ class Fonctions
     /**
      * Encapsule le comportement du module de cloture d'exercice
      *
-     * @return void
      * @access public
      * @static
      */
-    public static function pageClotureYearModule()
+    public static function pageClotureYearModule() : string
     {
         /*************************************/
         // recup des parametres reçus :
@@ -2277,7 +2275,7 @@ class Fonctions
         return $return;
     }
 
-    public static function affiche_calendrier_fermeture_mois($year, $mois, $tab_year)
+    public static function affiche_calendrier_fermeture_mois($year, $mois, $tab_year) : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $jour_today=date("j");
@@ -2432,8 +2430,8 @@ class Fonctions
     }
 
     //calendrier des fermeture
-    public static function affiche_calendrier_fermeture($year, $groupe_id = 0) {
-
+    public static function affiche_calendrier_fermeture($year, $groupe_id = 0) : string
+    {
         // on construit le tableau de l'année considérée
         $tab_year=array();
         \hr\Fonctions::get_tableau_jour_fermeture($year, $tab_year,  $groupe_id);
@@ -2466,7 +2464,7 @@ class Fonctions
     }
 
     //insertion des nouvelles dates de fermeture
-    public static function insert_year_fermeture($fermeture_id, $tab_j_ferme, $groupe_id)
+    public static function insert_year_fermeture($fermeture_id, $tab_j_ferme, $groupe_id) : bool
     {
         $sql_insert="";
         foreach($tab_j_ferme as $jf_date ) {
@@ -2477,16 +2475,15 @@ class Fonctions
     }
 
     // supprime une fermeture
-    public static function delete_year_fermeture($fermeture_id, $groupe_id)
+    public static function delete_year_fermeture($fermeture_id, $groupe_id) : bool
     {
-
         $sql_delete="DELETE FROM conges_jours_fermeture WHERE jf_id = '$fermeture_id' AND jf_gid= '$groupe_id' ;";
         $result = \includes\SQL::query($sql_delete);
         return TRUE;
     }
 
     // recup l'id de la derniere fermeture (le max)
-    public static function get_last_fermeture_id()
+    public static function get_last_fermeture_id() : int
     {
         $req_1="SELECT MAX(jf_id) FROM conges_jours_fermeture ";
         $res_1 = \includes\SQL::query($req_1);
@@ -2520,7 +2517,7 @@ class Fonctions
         }
     }
 
-    public static function commit_annul_fermeture($fermeture_id, $groupe_id)
+    public static function commit_annul_fermeture($fermeture_id, $groupe_id) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -2593,7 +2590,7 @@ class Fonctions
         return $return;
     }
 
-    public static function commit_new_fermeture($new_date_debut, $new_date_fin, $groupe_id, $id_type_conges)
+    public static function commit_new_fermeture($new_date_debut, $new_date_fin, $groupe_id, $id_type_conges) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -2681,7 +2678,7 @@ class Fonctions
         return $return;
     }
 
-    public static function confirm_annul_fermeture($fermeture_id, $groupe_id, $fermeture_date_debut, $fermeture_date_fin)
+    public static function confirm_annul_fermeture($fermeture_id, $groupe_id, $fermeture_date_debut, $fermeture_date_fin) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -2723,7 +2720,7 @@ class Fonctions
     }
 
     // Affichage d'un SELECT de formulaire pour choix d'un type d'absence
-    public static function affiche_select_conges_id()
+    public static function affiche_select_conges_id() : string
     {
         $tab_conges=recup_tableau_types_conges();
         $tab_conges_except=recup_tableau_types_conges_exceptionnels();
@@ -2767,7 +2764,7 @@ class Fonctions
         }
     }
 
-    public static function saisie_dates_fermeture($year, $groupe_id, $new_date_debut, $new_date_fin, $code_erreur)
+    public static function saisie_dates_fermeture($year, $groupe_id, $new_date_debut, $new_date_fin, $code_erreur) : string
     {
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
         $return = '';
@@ -2805,7 +2802,7 @@ class Fonctions
         return $return;
     }
 
-    public static function saisie_groupe_fermeture()
+    public static function saisie_groupe_fermeture() : string
     {
         $config = new \App\Libraries\Configuration(\includes\SQL::singleton());
         $PHP_SELF = filter_input(INPUT_SERVER, 'PHP_SELF', FILTER_SANITIZE_URL);
@@ -2898,11 +2895,10 @@ class Fonctions
     /**
      * Encapsule le comportement du module de jours de fermeture
      *
-     * @return void
      * @access public
      * @static
      */
-    public static function pageJoursFermetureModule()
+    public static function pageJoursFermetureModule() : string
     {
         // verif des droits du user à afficher la page
         verif_droits_user("is_hr");

--- a/hr/hr_liste_planning.php
+++ b/hr/hr_liste_planning.php
@@ -36,9 +36,9 @@ if (empty($listPlanningId)) {
     $config = new \App\Libraries\Configuration($sql);
     $injectableCreator = new \App\Libraries\InjectableCreator($sql, $config);
     $api = $injectableCreator->get(\App\Libraries\ApiClient::class);
-    $plannings = $api->get('planning', $_SESSION['token'])->data;
+    $plannings = $api->get('planning', $_SESSION['token'])['data'];
     $plannings = array_filter($plannings, function ($planning) {
-        return $planning->status === \App\Models\Planning::STATUS_ACTIVE;
+        return $planning['status'] === \App\Models\Planning::STATUS_ACTIVE;
     });
 }
 

--- a/vendor/Libertempo/libertempo-api/.atoum.php
+++ b/vendor/Libertempo/libertempo-api/.atoum.php
@@ -1,3 +1,3 @@
-<?php
+<?php declare(strict_types = 1);
 $runner->addTestsFromDirectory(__DIR__ . '/Tests/Units');
 $script->bootstrapFile(__DIR__ . '/.bootstrap.atoum.php');

--- a/vendor/Libertempo/libertempo-api/.bootstrap.atoum.php
+++ b/vendor/Libertempo/libertempo-api/.bootstrap.atoum.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 /* Autoload */
 require_once __DIR__ . '/Vendor/autoload.php';
 require_once __DIR__ . '/Vendor/raveren/kint/Kint.class.php';

--- a/vendor/Libertempo/libertempo-api/.travis.yml
+++ b/vendor/Libertempo/libertempo-api/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - '5.6'
   - '7.0'
 notifications:
   email:

--- a/vendor/Libertempo/libertempo-api/Absence/Type/TypeController.php
+++ b/vendor/Libertempo/libertempo-api/Absence/Type/TypeController.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Absence\Type;
 
 use LibertAPI\Tools\Interfaces;
@@ -21,7 +21,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    protected function ensureAccessUser($order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
+    protected function ensureAccessUser(string $order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
     {
         // uniquement accessible par l'admin ?
     }
@@ -29,7 +29,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    public function get(IRequest $request, IResponse $response, array $arguments)
+    public function get(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         if (!isset($arguments['typeId'])) {
             return $this->getList($request, $response);
@@ -46,7 +46,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
      *
      * @return IResponse, 404 si l'élément n'est pas trouvé, 200 sinon
      */
-    private function getOne(IResponse $response, $id)
+    private function getOne(IResponse $response, int $id) : IResponse
     {
         try {
             $responseResource = $this->repository->getOne($id);
@@ -84,10 +84,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }
-        $entites = [];
-        foreach ($responseResources as $responseResource) {
-            $entites[] = $this->buildData($responseResource);
-        }
+        $entites = array_map([$this, 'buildData'], $responseResources);
 
         return $this->getResponseSuccess($response, $entites, 200);
     }
@@ -112,7 +109,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    public function post(IRequest $request, IResponse $response, array $routeArguments)
+    public function post(IRequest $request, IResponse $response, array $routeArguments) : IResponse
     {
         $body = $request->getParsedBody();
         if (null === $body) {
@@ -141,7 +138,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    public function put(IRequest $request, IResponse $response, array $arguments)
+    public function put(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         $body = $request->getParsedBody();
         if (null === $body) {
@@ -173,7 +170,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    public function delete(IRequest $request, IResponse $response, array $arguments)
+    public function delete(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         $id = (int) $arguments['typeId'];
         try {

--- a/vendor/Libertempo/libertempo-api/Absence/Type/TypeDao.php
+++ b/vendor/Libertempo/libertempo-api/Absence/Type/TypeDao.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Absence\Type;
 
 use LibertAPI\Tools\Libraries\AEntite;
@@ -20,7 +20,7 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function getById($id)
+    public function getById(int $id) : AEntite
     {
         $this->queryBuilder->select('*');
         $this->setWhere(['id' => $id]);
@@ -50,7 +50,7 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function getList(array $parametres)
+    public function getList(array $parametres) : array
     {
         $this->queryBuilder->select('*');
         $this->setWhere($parametres);
@@ -61,11 +61,11 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
             throw new \UnexpectedValueException('No resource match with these parameters');
         }
 
-        $entites = [];
-        foreach ($data as $value) {
-            $entite = new TypeEntite($this->getStorage2Entite($value));
-            $entites[$entite->getId()] = $entite;
-        }
+        $entites = array_map(function ($value) {
+                return new TypeEntite($this->getStorage2Entite($value));
+            },
+            $data
+        );
 
         return $entites;
     }
@@ -77,7 +77,7 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function post(AEntite $entite)
+    public function post(AEntite $entite) : int
     {
         $this->queryBuilder->insert($this->getTableName());
         $this->setValues($this->getEntite2Storage($entite));
@@ -121,7 +121,7 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    final protected function getEntite2Storage(AEntite $entite)
+    final protected function getEntite2Storage(AEntite $entite) : array
     {
         return [
             'type' => $entite->getType(),
@@ -154,7 +154,7 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function delete($id)
+    public function delete(int $id) : int
     {
         $this->queryBuilder->delete($this->getTableName());
         $this->setWhere(['ta_id' => $id]);
@@ -180,7 +180,7 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    final protected function getTableName()
+    final protected function getTableName() : string
     {
         return 'conges_type_absence';
     }

--- a/vendor/Libertempo/libertempo-api/Absence/Type/TypeEntite.php
+++ b/vendor/Libertempo/libertempo-api/Absence/Type/TypeEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Absence\Type;
 
 /**
@@ -14,10 +14,8 @@ class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
 {
     /**
      * Retourne la donnée la plus à jour du champ type
-     *
-     * @return string
      */
-    public function getType()
+    public function getType() : string
     {
         return $this->getFreshData('type');
     }
@@ -25,10 +23,9 @@ class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
     /**
      * Retourne la donnée la plus à jour du champ libelle
      *
-     * @return string
      * @TODO : changer le schema bd, le transcodage ne devrait pas être nécessaire
      */
-    public function getLibelle()
+    public function getLibelle() : string
     {
         if ('utf-8' !== strtolower(mb_detect_encoding($this->getFreshData('libelle')))) {
             return utf8_encode($this->getFreshData('libelle'));
@@ -40,10 +37,8 @@ class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
 
     /**
      * Retourne la donnée la plus à jour du champ libelle court
-     *
-     * @return string
      */
-    public function getLibelleCourt()
+    public function getLibelleCourt() : string
     {
         return $this->getFreshData('libelleCourt');
     }
@@ -68,10 +63,9 @@ class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
      *
      * Stocke une erreur si la donnée ne colle pas au domaine
      *
-     * @param string $type
      * @todo
      */
-    private function setType($type)
+    private function setType(string $type)
     {
         // domaine ?
         if (empty($type)) {
@@ -87,10 +81,9 @@ class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
      *
      * Stocke une erreur si la donnée ne colle pas au domaine
      *
-     * @param string $var
      * @todo
      */
-    private function setLibelle($var)
+    private function setLibelle(string $var)
     {
         // domaine ?
         if (empty($var)) {
@@ -106,10 +99,9 @@ class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
      *
      * Stocke une erreur si la donnée ne colle pas au domaine
      *
-     * @param string $var
      * @todo
      */
-    private function setLibelleCourt($var)
+    private function setLibelleCourt(string $var)
     {
         // domaine ?
         if (empty($var)) {

--- a/vendor/Libertempo/libertempo-api/Absence/Type/TypeRepository.php
+++ b/vendor/Libertempo/libertempo-api/Absence/Type/TypeRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Absence\Type;
 
 use LibertAPI\Tools\Libraries\AEntite;
@@ -17,7 +17,7 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * {@inheritDoc}
      */
-    final protected function getParamsConsumer2Dao(array $paramsConsumer)
+    final protected function getParamsConsumer2Dao(array $paramsConsumer) : array
     {
         unset($paramsConsumer);
         return [];
@@ -29,8 +29,8 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
     public function deleteOne(AEntite $entite)
     {
         try {
-            $entite->reset();
             $this->dao->delete($entite->getId());
+            $entite->reset();
         } catch (\Exception $e) {
             throw $e;
         }

--- a/vendor/Libertempo/libertempo-api/Authentification/AuthentificationController.php
+++ b/vendor/Libertempo/libertempo-api/Authentification/AuthentificationController.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Authentification;
 
 use LibertAPI\Tools\Libraries\ARepository;
@@ -28,14 +28,14 @@ implements Interfaces\IGetable
     /**
      * {@inheritDoc}
      */
-    protected function ensureAccessUser($order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
+    protected function ensureAccessUser(string $order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
     {
     }
 
     /**
      * {@inheritDoc}
      */
-    public function get(IRequest $request, IResponse $response, array $arguments)
+    public function get(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         $authentificationType = 'Basic';
         $authentification = $request->getHeaderLine('Authorization');

--- a/vendor/Libertempo/libertempo-api/Groupe/GroupeController.php
+++ b/vendor/Libertempo/libertempo-api/Groupe/GroupeController.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Groupe;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
@@ -24,7 +24,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    protected function ensureAccessUser($order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
+    protected function ensureAccessUser(string $order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
     {
         unset($order);
         if (!$utilisateur->isAdmin()) {
@@ -35,7 +35,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    public function get(IRequest $request, IResponse $response, array $arguments)
+    public function get(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         if (!isset($arguments['groupeId'])) {
             return $this->getList($request, $response);
@@ -91,10 +91,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }
-        $entites = [];
-        foreach ($groupes as $groupe) {
-            $entites[] = $this->buildData($groupe);
-        }
+        $entites = array_map([$this, 'buildData'], $groupes);
 
         return $this->getResponseSuccess($response, $entites, 200);
     }
@@ -119,7 +116,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    public function post(IRequest $request, IResponse $response, array $routeArguments)
+    public function post(IRequest $request, IResponse $response, array $routeArguments) : IResponse
     {
         $body = $request->getParsedBody();
         if (null === $body) {
@@ -148,7 +145,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    public function put(IRequest $request, IResponse $response, array $arguments)
+    public function put(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         $body = $request->getParsedBody();
         if (null === $body) {
@@ -180,7 +177,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    public function delete(IRequest $request, IResponse $response, array $arguments)
+    public function delete(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         $id = (int) $arguments['groupeId'];
         try {

--- a/vendor/Libertempo/libertempo-api/Groupe/GroupeDao.php
+++ b/vendor/Libertempo/libertempo-api/Groupe/GroupeDao.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Groupe;
 
 use LibertAPI\Tools\Libraries\AEntite;
@@ -23,7 +23,7 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function getById($id)
+    public function getById(int $id) : AEntite
     {
         $this->queryBuilder->select('*');
         $this->setWhere(['id' => $id]);
@@ -53,7 +53,7 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function getList(array $parametres)
+    public function getList(array $parametres) : array
     {
         $this->queryBuilder->select('*');
         $this->setWhere($parametres);
@@ -64,11 +64,11 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
             throw new \UnexpectedValueException('No resource match with these parameters');
         }
 
-        $entites = [];
-        foreach ($data as $value) {
-            $entite = new GroupeEntite($this->getStorage2Entite($value));
-            $entites[$entite->getId()] = $entite;
-        }
+        $entites = array_map(function ($value) {
+                return new GroupeEntite($this->getStorage2Entite($value));
+            },
+            $data
+        );
 
         return $entites;
     }
@@ -80,7 +80,7 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function post(AEntite $entite)
+    public function post(AEntite $entite) : int
     {
         $this->queryBuilder->insert($this->getTableName());
         $this->setValues($this->getEntite2Storage($entite));
@@ -123,7 +123,7 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    final protected function getEntite2Storage(AEntite $entite)
+    final protected function getEntite2Storage(AEntite $entite) : array
     {
         return [
             'name' => $entite->getName(),
@@ -155,7 +155,7 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function delete($id)
+    public function delete(int $id) : int
     {
         $this->queryBuilder->delete($this->getTableName());
         $this->setWhere(['id' => $id]);
@@ -181,7 +181,7 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    final protected function getTableName()
+    final protected function getTableName() : string
     {
         return 'conges_groupe';
     }

--- a/vendor/Libertempo/libertempo-api/Groupe/GroupeEntite.php
+++ b/vendor/Libertempo/libertempo-api/Groupe/GroupeEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Groupe;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
@@ -12,7 +12,7 @@ use LibertAPI\Tools\Exceptions\MissingArgumentException;
  * @since 0.7
  * @see \LibertAPI\Tests\Units\Groupe\GroupeEntite
  *
- * Ne devrait être contacté que par le GroupeRepository
+ * Ne devrait être contacté que par le GroupeDao
  * Ne devrait contacter personne
  */
 class GroupeEntite extends \LibertAPI\Tools\Libraries\AEntite

--- a/vendor/Libertempo/libertempo-api/Groupe/GroupeRepository.php
+++ b/vendor/Libertempo/libertempo-api/Groupe/GroupeRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Groupe;
 
 use LibertAPI\Tools\Libraries\AEntite;
@@ -24,7 +24,7 @@ class GroupeRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    final protected function getParamsConsumer2Dao(array $paramsConsumer)
+    final protected function getParamsConsumer2Dao(array $paramsConsumer) : array
     {
         unset($paramsConsumer);
         return [];
@@ -41,8 +41,8 @@ class GroupeRepository extends \LibertAPI\Tools\Libraries\ARepository
     public function deleteOne(AEntite $entite)
     {
         try {
-            $entite->reset();
             $this->dao->delete($entite->getId());
+            $entite->reset();
         } catch (\Exception $e) {
             throw $e;
         }

--- a/vendor/Libertempo/libertempo-api/Groupe/Responsable/ResponsableController.php
+++ b/vendor/Libertempo/libertempo-api/Groupe/Responsable/ResponsableController.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Groupe\Responsable;
+
+use LibertAPI\Tools\Exceptions\MissingArgumentException;
+use LibertAPI\Tools\Interfaces;
+use Psr\Http\Message\ServerRequestInterface as IRequest;
+use Psr\Http\Message\ResponseInterface as IResponse;
+use LibertAPI\Utilisateur\UtilisateurEntite;
+
+/**
+ * Contrôleur de responsable de groupes
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.7
+ * @see \Tests\Units\GroupeController
+ *
+ * Ne devrait être contacté que par le routeur
+ * Ne devrait contacter que le ResponsableRepository
+ */
+final class ResponsableController extends \LibertAPI\Tools\Libraries\AController
+implements Interfaces\IGetable
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function ensureAccessUser(string $order, UtilisateurEntite $utilisateur)
+    {
+        unset($order);
+        if (!$utilisateur->isAdmin()) {
+            throw new \LibertAPI\Tools\Exceptions\MissingRightException('');
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get(IRequest $request, IResponse $response, array $arguments) : IResponse
+    {
+        unset($arguments);
+        try {
+            $this->ensureAccessUser(__FUNCTION__, $this->currentUser);
+            $groupes = $this->repository->getList(
+                $request->getQueryParams()
+            );
+        } catch (\UnexpectedValueException $e) {
+            return $this->getResponseNoContent($response);
+        } catch (\LibertAPI\Tools\Exceptions\MissingRightException $e) {
+            return $this->getResponseForbidden($response, $request);
+        } catch (\Exception $e) {
+            return $this->getResponseError($response, $e);
+        }
+        $entites = array_map([$this, 'buildData'], $groupes);
+
+        return $this->getResponseSuccess($response, $entites, 200);
+    }
+
+    /**
+     * Construit le « data » du json
+     *
+     * @param UtilisateurEntite $entite Responsable
+     *
+     * @return array
+     */
+    private function buildData(UtilisateurEntite $entite)
+    {
+        return [
+            'id' => $entite->getId(),
+            'login' => $entite->getLogin(),
+            'nom' => $entite->getNom(),
+            'prenom' => $entite->getPrenom(),
+            'isResp' => $entite->isResponsable(),
+            'isAdmin' => $entite->isAdmin(),
+            'isHr' => $entite->isHautReponsable(),
+            'isActif' => $entite->isActif(),
+            'password' => $entite->getMotDePasse(),
+            'quotite' => $entite->getQuotite(),
+            'email' => $entite->getMail(),
+            'numeroExercice' => $entite->getNumeroExercice(),
+            'planningId' => $entite->getPlanningId(),
+            'heureSolde' => $entite->getHeureSolde(),
+            'dateInscription' => $entite->getDateInscription(),
+            'dateLastAccess' => $entite->getDateLastAccess(),
+        ];
+    }
+}

--- a/vendor/Libertempo/libertempo-api/Groupe/Responsable/ResponsableRepository.php
+++ b/vendor/Libertempo/libertempo-api/Groupe/Responsable/ResponsableRepository.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types = 1);
-namespace LibertAPI\Journal;
+namespace LibertAPI\Groupe\Responsable;
 
 use LibertAPI\Tools\Libraries\AEntite;
 
@@ -10,9 +10,9 @@ use LibertAPI\Tools\Libraries\AEntite;
  * @author Wouldsmina
  *
  * @since 0.5
- * @see \LibertAPI\Tests\Units\Journal\JournalRepository
+ * @see \LibertAPI\Tests\Units\Groupe\ResponsableRepository
  */
-class JournalRepository extends \LibertAPI\Tools\Libraries\ARepository
+class ResponsableRepository extends \LibertAPI\Tools\Libraries\ARepository
 {
     /*************************************************
      * GET
@@ -23,7 +23,7 @@ class JournalRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     public function getOne(int $id) : AEntite
     {
-        throw new \RuntimeException('Journal#' . $id . ' is not a callable resource');
+        throw new \RuntimeException('#' . $id . ' is not a callable resource');
     }
 
     /**

--- a/vendor/Libertempo/libertempo-api/Journal/JournalController.php
+++ b/vendor/Libertempo/libertempo-api/Journal/JournalController.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Journal;
 
 use Psr\Http\Message\ServerRequestInterface as IRequest;
@@ -18,7 +18,7 @@ final class JournalController extends \LibertAPI\Tools\Libraries\AController
     /**
      * {@inheritDoc}
      */
-    protected function ensureAccessUser($order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
+    protected function ensureAccessUser(string $order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
     {
     }
 
@@ -34,9 +34,8 @@ final class JournalController extends \LibertAPI\Tools\Libraries\AController
      * @param array $arguments Arguments de route
      *
      * @return IResponse
-     * @throws \Exception en cas d'erreur inconnue (fallback, ne doit pas arriver)
      */
-    public function get(IRequest $request, IResponse $response, array $arguments)
+    public function get(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         unset($arguments);
         try {
@@ -46,13 +45,9 @@ final class JournalController extends \LibertAPI\Tools\Libraries\AController
         } catch (\UnexpectedValueException $e) {
             return $this->getResponseNoContent($response);
         } catch (\Exception $e) {
-            throw $e;
+            return $this->getResponseError($response, $e);
         }
-
-        $entites = [];
-        foreach ($resources as $resource) {
-            $entites[] = $this->buildData($resource);
-        }
+        $entites = array_map([$this, 'buildData'], $resources);
 
         return $this->getResponseSuccess($response, $entites, 200);
     }

--- a/vendor/Libertempo/libertempo-api/Journal/JournalEntite.php
+++ b/vendor/Libertempo/libertempo-api/Journal/JournalEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Journal;
 
 /**

--- a/vendor/Libertempo/libertempo-api/Planning/Creneau/CreneauController.php
+++ b/vendor/Libertempo/libertempo-api/Planning/Creneau/CreneauController.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Planning\Creneau;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
@@ -25,14 +25,14 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable
     /**
      * {@inheritDoc}
      */
-    protected function ensureAccessUser($order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
+    protected function ensureAccessUser(string $order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
     {
     }
 
     /**
      * {@inheritDoc}
      */
-    public function get(IRequest $request, IResponse $response, array $arguments)
+    public function get(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         if (!isset($arguments['creneauId'])) {
             return $this->getList($response, (int) $arguments['planningId']);
@@ -85,10 +85,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }
-        $entites = [];
-        foreach ($creneaux as $creneau) {
-            $entites[] = $this->buildData($creneau);
-        }
+        $entites = array_map([$this, 'buildData'], $creneaux);
 
         return $this->getResponseSuccess($response, $entites, 200);
     }
@@ -116,7 +113,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable
     /**
      * {@inheritDoc}
      */
-    public function post(IRequest $request, IResponse $response, array $arguments)
+    public function post(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         $body = $request->getParsedBody();
         if (null === $body) {
@@ -154,7 +151,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable
     /**
      * {@inheritDoc}
      */
-    public function put(IRequest $request, IResponse $response, array $arguments)
+    public function put(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         $body = $request->getParsedBody();
         if (null === $body) {

--- a/vendor/Libertempo/libertempo-api/Planning/Creneau/CreneauDao.php
+++ b/vendor/Libertempo/libertempo-api/Planning/Creneau/CreneauDao.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Planning\Creneau;
 
 use LibertAPI\Tools\Libraries\AEntite;
@@ -25,7 +25,7 @@ class CreneauDao extends \LibertAPI\Tools\Libraries\ADao
      *
      * @param int $planningId Contrainte de recherche sur le planning
      */
-    public function getById($id, $planningId = null)
+    public function getById(int $id, $planningId = null) : AEntite
     {
         $this->queryBuilder->select('*');
         $this->setWhere(['id' => $id, 'planning_id' => $planningId]);
@@ -58,7 +58,7 @@ class CreneauDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function getList(array $parametres)
+    public function getList(array $parametres) : array
     {
         $this->queryBuilder->select('*');
         $this->setWhere($parametres);
@@ -102,7 +102,7 @@ class CreneauDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function post(AEntite $entite)
+    public function post(AEntite $entite) : int
     {
         $this->queryBuilder->insert($this->getTableName());
         $this->setValues($this->getEntite2Storage($entite));
@@ -146,7 +146,7 @@ class CreneauDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    final protected function getEntite2Storage(AEntite $entite)
+    final protected function getEntite2Storage(AEntite $entite) : array
     {
         return [
             'planning_id' => $entite->getPlanningId(),
@@ -193,14 +193,15 @@ class CreneauDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function delete($id)
+    public function delete(int $id) : int
     {
+        throw new \RuntimeException('Forbidden action');
     }
 
     /**
      * @inheritDoc
      */
-    final protected function getTableName()
+    final protected function getTableName() : string
     {
         return 'planning_creneau';
     }

--- a/vendor/Libertempo/libertempo-api/Planning/Creneau/CreneauEntite.php
+++ b/vendor/Libertempo/libertempo-api/Planning/Creneau/CreneauEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Planning\Creneau;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
@@ -12,7 +12,7 @@ use LibertAPI\Tools\Exceptions\MissingArgumentException;
  * @since 0.1
  * @see \LibertAPI\Tests\Units\Planning\Creneau\Entite
  *
- * Ne devrait être contacté que par le Planning\Creneau\Repository
+ * Ne devrait être contacté que par le Planning\Creneau\CreneauDao
  * Ne devrait contacter personne
  */
 class CreneauEntite extends \LibertAPI\Tools\Libraries\AEntite

--- a/vendor/Libertempo/libertempo-api/Planning/Creneau/CreneauRepository.php
+++ b/vendor/Libertempo/libertempo-api/Planning/Creneau/CreneauRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Planning\Creneau;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
@@ -24,15 +24,15 @@ class CreneauRepository extends \LibertAPI\Tools\Libraries\ARepository
      *
      * @param int $planningId Contrainte de recherche sur le planning
      */
-    public function getOne($id, $planningId = -1)
+    public function getOne(int $id, $planningId = -1) : AEntite
     {
-        return $this->dao->getById((int) $id, $planningId);
+        return $this->dao->getById($id, $planningId);
     }
 
     /**
      * @inheritDoc
      */
-    final protected function getParamsConsumer2Dao(array $paramsConsumer)
+    final protected function getParamsConsumer2Dao(array $paramsConsumer) : array
     {
         $results = [];
         if (!empty($paramsConsumer['planningId'])) {
@@ -56,18 +56,14 @@ class CreneauRepository extends \LibertAPI\Tools\Libraries\ARepository
      * @throws MissingArgumentException Si un élément requis n'est pas présent
      * @throws \DomainException Si un élément de la ressource n'est pas dans le bon domaine de définition
      */
-    public function postList(array $data, AEntite $entite)
+    public function postList(array $data, AEntite $entite) : array
     {
         $postIds = [];
         $this->dao->beginTransaction();
         foreach ($data as $creneau) {
             try {
-                $postIds[] = $this->postOne($creneau, $entite);
-                /*
-                 * Le plus cool aurait été de cloner l'objet de base,
-                 * mais le clonage de mock est nul, donc on reset pour la boucle
-                 */
-                $entite->reset();
+                $cloneEntite = clone $entite;
+                $postIds[] = $this->postOne($creneau, $cloneEntite);
             } catch (\Exception $e) {
                 $this->dao->rollback();
                 throw $e;

--- a/vendor/Libertempo/libertempo-api/Planning/PlanningController.php
+++ b/vendor/Libertempo/libertempo-api/Planning/PlanningController.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Planning;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
@@ -24,7 +24,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    protected function ensureAccessUser($order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
+    protected function ensureAccessUser(string $order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
     {
         $rights = [
             'getList' => $utilisateur->isResponsable() || $utilisateur->isHautReponsable() || $utilisateur->isAdmin(),
@@ -38,7 +38,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    public function get(IRequest $request, IResponse $response, array $arguments)
+    public function get(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         if (!isset($arguments['planningId'])) {
             return $this->getList($request, $response);
@@ -94,10 +94,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }
-        $entites = [];
-        foreach ($plannings as $planning) {
-            $entites[] = $this->buildData($planning);
-        }
+        $entites = array_map([$this, 'buildData'], $plannings);
 
         return $this->getResponseSuccess($response, $entites, 200);
     }
@@ -121,7 +118,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    public function post(IRequest $request, IResponse $response, array $routeArguments)
+    public function post(IRequest $request, IResponse $response, array $routeArguments) : IResponse
     {
         $body = $request->getParsedBody();
         if (null === $body) {
@@ -150,7 +147,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    public function put(IRequest $request, IResponse $response, array $arguments)
+    public function put(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         $body = $request->getParsedBody();
         if (null === $body) {
@@ -182,7 +179,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     /**
      * {@inheritDoc}
      */
-    public function delete(IRequest $request, IResponse $response, array $arguments)
+    public function delete(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         $id = (int) $arguments['planningId'];
         try {

--- a/vendor/Libertempo/libertempo-api/Planning/PlanningDao.php
+++ b/vendor/Libertempo/libertempo-api/Planning/PlanningDao.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Planning;
 
 use LibertAPI\Tools\Libraries\AEntite;
@@ -23,7 +23,7 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function getById($id)
+    public function getById(int $id) : AEntite
     {
         $this->queryBuilder->select('*');
         $this->setWhere(['id' => $id]);
@@ -52,7 +52,7 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function getList(array $parametres)
+    public function getList(array $parametres) : array
     {
         $this->queryBuilder->select('*');
         $this->setWhere($parametres);
@@ -79,7 +79,7 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function post(AEntite $entite)
+    public function post(AEntite $entite) : int
     {
         $this->queryBuilder->insert($this->getTableName());
         $this->setValues($this->getEntite2Storage($entite));
@@ -120,7 +120,7 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    final protected function getEntite2Storage(AEntite $entite)
+    final protected function getEntite2Storage(AEntite $entite) : array
     {
         return [
             'name' => $entite->getName(),
@@ -147,7 +147,7 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function delete($id)
+    public function delete(int $id) : int
     {
         $this->queryBuilder->delete($this->getTableName());
         $this->setWhere(['id' => $id]);
@@ -166,14 +166,14 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     {
         if (!empty($parametres['id'])) {
             $this->queryBuilder->andWhere('planning_id = :id');
-            $this->queryBuilder->setParameter(':id', (int) $parametres['id']);
+            $this->queryBuilder->setParameter(':id', $parametres['id']);
         }
     }
 
     /**
      * @inheritDoc
      */
-    final protected function getTableName()
+    final protected function getTableName() : string
     {
         return 'planning';
     }

--- a/vendor/Libertempo/libertempo-api/Planning/PlanningEntite.php
+++ b/vendor/Libertempo/libertempo-api/Planning/PlanningEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Planning;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
@@ -12,7 +12,7 @@ use LibertAPI\Tools\Exceptions\MissingArgumentException;
  * @since 0.1
  * @see \LibertAPI\Tests\Units\Planning\PlanningEntite
  *
- * Ne devrait être contacté que par le Planning\Repository
+ * Ne devrait être contacté que par le Planning\PlanningDao
  * Ne devrait contacter personne
  */
 class PlanningEntite extends \LibertAPI\Tools\Libraries\AEntite

--- a/vendor/Libertempo/libertempo-api/Planning/PlanningRepository.php
+++ b/vendor/Libertempo/libertempo-api/Planning/PlanningRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Planning;
 
 use LibertAPI\Tools\Libraries\AEntite;
@@ -17,14 +17,10 @@ use LibertAPI\Tools\Libraries\AEntite;
  */
 class PlanningRepository extends \LibertAPI\Tools\Libraries\ARepository
 {
-    /*************************************************
-     * GET
-     *************************************************/
-
     /**
      * @inheritDoc
      */
-    final protected function getParamsConsumer2Dao(array $paramsConsumer)
+    final protected function getParamsConsumer2Dao(array $paramsConsumer) : array
     {
         unset($paramsConsumer);
         return [];
@@ -41,8 +37,8 @@ class PlanningRepository extends \LibertAPI\Tools\Libraries\ARepository
     public function deleteOne(AEntite $entite)
     {
         try {
-            $entite->reset();
             $this->dao->delete($entite->getId());
+            $entite->reset();
         } catch (\Exception $e) {
             throw $e;
         }

--- a/vendor/Libertempo/libertempo-api/Public/index.php
+++ b/vendor/Libertempo/libertempo-api/Public/index.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 /**
  * API de Libertempo
  * @since 0.1

--- a/vendor/Libertempo/libertempo-api/README.md
+++ b/vendor/Libertempo/libertempo-api/README.md
@@ -2,7 +2,6 @@
 [![BCH compliance](https://bettercodehub.com/edge/badge/Libertempo/libertempo-api?branch=develop)](https://bettercodehub.com/)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c9248e3a815347209c8e56d2291f0da7)](https://www.codacy.com/app/Libertempo/libertempo-api?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Libertempo/libertempo-api&amp;utm_campaign=Badge_Grade)
 [![Build Status](https://travis-ci.org/Libertempo/libertempo-api.svg?branch=master)](https://travis-ci.org/Libertempo/libertempo-api)
-[![Dependency Status](https://gemnasium.com/badges/github.com/Libertempo/libertempo-api.svg)](https://gemnasium.com/github.com/Libertempo/libertempo-api)
 
 
 API Libertempo
@@ -74,16 +73,18 @@ Les réponses de l'API se font sous la spécification jsend. Autrement dit :
 
 # Routes disponibles
 Suivant les règles de l'architecture REST, les routes disponibles à ce jour sont :
-* `GET /absences/types/{id}`
-* `GET /planning`
-* `POST /planning`
-* `GET /planning/{id}`
-* `PUT /planning/{id}`
-* `DELETE /planning/{id}`
-* `GET /planning/{id}/creneau`
-* `POST /planning/{id}/creneau`
-* `GET /planning/{id}/creneau/{id}`
-* `DELETE /planning/{id}/creneau/{id}`
+* `GET|POST /absence/type`
+* `GET|PUT|DELETE /absence/type/{id}`
+* `GET /groupe`
+* `GET /groupe/{id}`
+* `GET /groupe/{id}/responsable`
+* `GET /journal`
+* `GET|POST /planning`
+* `GET|PUT|DELETE /planning/{id}`
+* `GET|POST /planning/{id}/creneau`
+* `GET|DELETE /planning/{id}/creneau/{id}`
+* `GET /utilisateur`
+* `GET /utilisateur/{id}`
 
 # Versions
 

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Absence/Type/TypeController.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Absence/Type/TypeController.php
@@ -1,5 +1,7 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Absence\Type;
+
+use Psr\Http\Message\ResponseInterface as IResponse;
 
 /**
  * Classe de test du contrôleur des type d'absence
@@ -44,12 +46,12 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestC
         ]);
     }
 
-    protected function getOne()
+    protected function getOne() : IResponse
     {
         return $this->testedInstance->get($this->request, $this->response, ['typeId' => 99]);
     }
 
-    protected function getList()
+    protected function getList() : IResponse
     {
         return $this->testedInstance->get($this->request, $this->response, []);
     }

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Absence/Type/TypeDao.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Absence/Type/TypeDao.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Absence\Type;
 
 use LibertAPI\Absence\Type\TypeEntite;

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Absence/Type/TypeEntite.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Absence/Type/TypeEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Absence\Type;
 
 /**
@@ -43,7 +43,7 @@ final class TypeEntite extends \LibertAPI\Tests\Units\Tools\Libraries\AEntite
     public function testPopulateBadDomain()
     {
         $this->newTestedInstance([]);
-        $data = ['type' => '', 'libelle' => 45, 'libelleCourt' => 'non'];
+        $data = ['type' => '', 'libelle' => '45', 'libelleCourt' => 'non'];
 
         $this->exception(function () use ($data) {
             $this->testedInstance->populate($data);

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Absence/Type/TypeRepository.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Absence/Type/TypeRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Absence\Type;
 
 /**
@@ -38,9 +38,8 @@ final class TypeRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepos
         $this->newTestedInstance($this->dao);
 
         $this->exception(function () {
-            $this->testedInstance->deleteOne(new \LibertAPI\Absence\Type\TypeEntite([]));
+            $this->testedInstance->deleteOne(new \LibertAPI\Absence\Type\TypeEntite(['id' => 49]));
         })->isInstanceOf('\LogicException');
-
     }
 
     /**
@@ -50,7 +49,7 @@ final class TypeRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepos
     {
         $this->dao->getMockController()->delete = 4;
         $this->newTestedInstance($this->dao);
-        $entite = new \LibertAPI\Absence\Type\TypeEntite([]);
+        $entite = new \LibertAPI\Absence\Type\TypeEntite(['id' => 49]);
 
         $this->variable($this->testedInstance->deleteOne($entite))->isNull();
     }

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Authentification/AuthentificationController.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Authentification/AuthentificationController.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Authentification;
 
 /**

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/GroupeController.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/GroupeController.php
@@ -1,5 +1,7 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Groupe;
+
+use Psr\Http\Message\ResponseInterface as IResponse;
 
 /**
  * Classe de test du contrôleur de groupe
@@ -54,12 +56,12 @@ final class GroupeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARes
         $this->assertFail($response, 403);
     }
 
-    protected function getOne()
+    protected function getOne() : IResponse
     {
         return $this->testedInstance->get($this->request, $this->response, ['groupeId' => 99]);
     }
 
-    protected function getList()
+    protected function getList() : IResponse
     {
         return $this->testedInstance->get($this->request, $this->response, []);
     }

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/GroupeDao.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/GroupeDao.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Groupe;
 
 use LibertAPI\Groupe\GroupeEntite;

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/GroupeEntite.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/GroupeEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Groupe;
 
 /**

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/GroupeRepository.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/GroupeRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Groupe;
 
 /**
@@ -20,7 +20,7 @@ final class GroupeRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARep
 
     protected function initEntite()
     {
-        $this->entite = new \LibertAPI\Groupe\GroupeEntite([]);
+        $this->entite = new \LibertAPI\Groupe\GroupeEntite(['id' => 123]);
     }
 
     /*************************************************

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/Responsable/ResponsableController.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/Responsable/ResponsableController.php
@@ -1,22 +1,22 @@
 <?php declare(strict_types = 1);
-namespace LibertAPI\Tests\Units\Journal;
+namespace LibertAPI\Tests\Units\Groupe\Responsable;
 
 use LibertAPI\Utilisateur\UtilisateurEntite;
 
 /**
- * Classe de test du contrôleur de journal
+ * Classe de test du contrôleur de reponsable de groupe
  *
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
  *
- * @since 0.5
+ * @since 0.7
  */
-final class JournalController extends \LibertAPI\Tests\Units\Tools\Libraries\AController
+final class ResponsableController extends \LibertAPI\Tests\Units\Tools\Libraries\AController
 {
     /**
-     * @var UtilisateurEntite Standardisation d'un rôle employé
+     * @var UtilisateurEntite Standardisation d'un rôle admin
      */
-    protected $currentEmploye;
+    protected $currentAdmin;
 
     /**
      * {@inheritdoc}
@@ -24,7 +24,7 @@ final class JournalController extends \LibertAPI\Tests\Units\Tools\Libraries\ACo
     public function beforeTestMethod($method)
     {
         parent::beforeTestMethod($method);
-        $this->currentEmploye = new UtilisateurEntite(['id' => 'user', 'isResp' => false]);
+        $this->currentAdmin = new UtilisateurEntite(['id' => 'user', 'isAdmin' => true]);
     }
 
     /**
@@ -34,7 +34,7 @@ final class JournalController extends \LibertAPI\Tests\Units\Tools\Libraries\ACo
     {
         $this->mockGenerator->orphanize('__construct');
         $this->mockGenerator->shuntParentClassCalls();
-        $this->repository = new \mock\LibertAPI\Journal\JournalRepository();
+        $this->repository = new \mock\LibertAPI\Groupe\Responsable\ResponsableRepository();
     }
 
     /**
@@ -42,14 +42,25 @@ final class JournalController extends \LibertAPI\Tests\Units\Tools\Libraries\ACo
      */
     protected function initEntite()
     {
-        $this->entite = new \LibertAPI\Journal\JournalEntite([
-            'id' => 42,
-            'numeroPeriode' => 88,
-            'utilisateurActeur' => '4',
-            'utilisateurObjet' => '8',
-            'etat' => 'cassé',
-            'commentaire' => 'c\'est cassé',
-            'date' => 'now',
+        $this->entite = new \LibertAPI\Utilisateur\UtilisateurEntite([
+            'id' => 816,
+            'login' => 'Spider-man',
+            'nom' => 'Parker',
+            'prenom' => 'Peter',
+            'isResp' => 'N',
+            'isAdmin' => 'N',
+            'isHr' => 'N',
+            'isActif' => 'Y',
+            'seeAll' => 'N',
+            'password' => 'MJ',
+            'quotite' => '10',
+            'email' => 'p.parker@dailybugle.com',
+            'numeroExercice' => 3,
+            'planningId' => 666,
+            'heureSolde' => 1,
+            'dateInscription' => '1-08-1962',
+            'token' => '',
+            'dateLastAccess' => '1-08-2006',
         ]);
     }
 
@@ -64,7 +75,7 @@ final class JournalController extends \LibertAPI\Tests\Units\Tools\Libraries\ACo
     {
         $this->calling($this->request)->getQueryParams = [];
         $this->calling($this->repository)->getList = [$this->entite,];
-        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentAdmin);
         $response = $this->testedInstance->get($this->request, $this->response, []);
         $data = $this->getJsonDecoded($response->getBody());
 
@@ -87,7 +98,7 @@ final class JournalController extends \LibertAPI\Tests\Units\Tools\Libraries\ACo
         $this->calling($this->repository)->getList = function () {
             throw new \UnexpectedValueException('');
         };
-        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentAdmin);
         $response = $this->testedInstance->get($this->request, $this->response, []);
 
         $this->assertSuccessEmpty($response);
@@ -102,7 +113,7 @@ final class JournalController extends \LibertAPI\Tests\Units\Tools\Libraries\ACo
         $this->calling($this->repository)->getList = function () {
             throw new \Exception('');
         };
-        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentAdmin);
 
         $response = $this->testedInstance->get($this->request, $this->response, []);
         $this->assertError($response);

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/Responsable/ResponsableDao.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/Responsable/ResponsableDao.php
@@ -1,17 +1,17 @@
 <?php declare(strict_types = 1);
-namespace LibertAPI\Tests\Units\Journal;
+namespace LibertAPI\Tests\Units\Groupe\Responsable;
 
-use LibertAPI\Journal\JournalEntite;
+use LibertAPI\Utilisateur\UtilisateurEntite;
 
 /**
- * Classe de test du DAO de planning
+ * Classe de test du DAO de responsable de groupe
  *
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
  *
- * @since 0.5
+ * @since 0.7
  */
-final class JournalDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
+final class ResponsableDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
 {
     /*************************************************
      * GET
@@ -49,7 +49,7 @@ final class JournalDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->post(new JournalEntite([]));
+            $this->testedInstance->post(new UtilisateurEntite([]));
         })->isInstanceOf(\RuntimeException::class);
     }
 
@@ -65,7 +65,7 @@ final class JournalDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->put(new JournalEntite([]));
+            $this->testedInstance->put(new UtilisateurEntite([]));
         })->isInstanceOf(\RuntimeException::class);
     }
 
@@ -81,20 +81,34 @@ final class JournalDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->delete(218);
+            $this->testedInstance->delete(0);
         })->isInstanceOf(\RuntimeException::class);
     }
 
+    /**
+     * Duplication de la fonction dans UtilisateurDao (Cf. decisions.md #2018-02-17)
+     */
     protected function getStorageContent()
     {
         return [
-            'log_id' => 81,
-            'log_p_num' => 1213,
-            'log_user_login_par' => 'Baloo',
-            'log_user_login_pour' => 'Mowgli',
-            'log_etat' => 'gere',
-            'log_comment' => 'nope',
-            'log_date' => '2017-12-01',
+            'id' => 'Aladdin',
+            'token' => 'token',
+            'date_last_access' => 'date_last_access',
+            'u_login' => 'Aladdin',
+            'u_prenom' => 'Aladdin',
+            'u_nom' => 'Genie',
+            'u_is_resp' => 'Y',
+            'u_is_admin' => 'Y',
+            'u_is_hr' => 'N',
+            'u_is_active' => 'Y',
+            'u_see_all' => 'Y',
+            'u_passwd' => 'Sésame Ouvre toi',
+            'u_quotite' => '21220',
+            'u_email' => 'aladdin@example.org',
+            'u_num_exercice' => '3',
+            'planning_id' => 12,
+            'u_heure_solde' => 1,
+            'date_inscription' => 123456789,
         ];
     }
 }

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/Responsable/ResponsableRepository.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Groupe/Responsable/ResponsableRepository.php
@@ -1,26 +1,26 @@
 <?php declare(strict_types = 1);
-namespace LibertAPI\Tests\Units\Journal;
+namespace LibertAPI\Tests\Units\Groupe\Responsable;
 
 /**
- * Classe de test du repository de journal
+ * Classe de test du repository de responsable de groupe
  *
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
  *
  * @since 0.5
  */
-final class JournalRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepository
+final class ResponsableRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepository
 {
     protected function initDao()
     {
         $this->mockGenerator->orphanize('__construct');
         $this->mockGenerator->shuntParentClassCalls();
-        $this->dao = new \mock\LibertAPI\Journal\JournalDao();
+        $this->dao = new \mock\LibertAPI\Groupe\Responsable\ResponsableDao();
     }
 
     protected function initEntite()
     {
-        $this->entite = new \LibertAPI\Journal\JournalEntite([]);
+        $this->entite = new \LibertAPI\Utilisateur\UtilisateurEntite([]);
     }
 
     /*************************************************
@@ -95,13 +95,6 @@ final class JournalRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
     protected function getEntiteContent()
     {
         return [
-            'id' => 298,
-            'numeroPeriode' => 1,
-            'utilisateurActeur' => 'Romeo',
-            'utilisateurObjet' => 'Juliette',
-            'etat' => 'gere',
-            'commentaire' => 'nope',
-            'date' => '2017-12-01',
         ];
     }
 }

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Journal/JournalEntite.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Journal/JournalEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Journal;
 
 /**

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Planning/Creneau/CreneauController.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Planning/Creneau/CreneauController.php
@@ -1,5 +1,7 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Planning\Creneau;
+
+use Psr\Http\Message\ResponseInterface as IResponse;
 
 /**
  * Classe de test du contrôleur de créneau de planning
@@ -30,12 +32,12 @@ final class CreneauController extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
         $this->entite->getMockController()->getFin = 12;
     }
 
-    protected function getOne()
+    protected function getOne() : IResponse
     {
         return $this->testedInstance->get($this->request, $this->response, ['creneauId' => 99, 'planningId' => 45]);
     }
 
-    protected function getList()
+    protected function getList() : IResponse
     {
         return $this->testedInstance->get($this->request, $this->response, ['planningId' => 45]);
     }

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Planning/Creneau/CreneauDao.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Planning/Creneau/CreneauDao.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Planning\Creneau;
 
 use LibertAPI\Planning\Creneau\CreneauEntite;
@@ -55,12 +55,11 @@ final class CreneauDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
      */
     public function testDeleteOk()
     {
-        $this->calling($this->result)->rowCount = 1;
         $this->newTestedInstance($this->connector);
 
-        $res = $this->testedInstance->delete(7);
-
-        $this->variable($res)->isNull();
+        $this->exception(function () {
+            $this->testedInstance->delete(7);
+        });
     }
 
     protected function getStorageContent()

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Planning/Creneau/CreneauEntite.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Planning/Creneau/CreneauEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Planning\Creneau;
 
 use \LibertAPI\Planning\Creneau\CreneauEntite as _Entite;

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Planning/Creneau/CreneauRepository.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Planning/Creneau/CreneauRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Planning\Creneau;
 
 /**
@@ -16,6 +16,9 @@ final class CreneauRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
         $this->mockGenerator->orphanize('__construct');
         $this->mockGenerator->shuntParentClassCalls();
         $this->dao = new \mock\LibertAPI\Planning\Creneau\CreneauDao();
+        $this->calling($this->dao)->beginTransaction = true;
+        $this->calling($this->dao)->commit = true;
+        $this->calling($this->dao)->rollback = true;
     }
 
     protected function initEntite()
@@ -33,8 +36,8 @@ final class CreneauRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
     public function testPostListException()
     {
         $repository = $this->newTestedInstance($this->dao);
-        $entite = new \mock\LibertAPI\Planning\Creneau\CreneauEntite([]);
-        $entite->getMockController()->populate = function () {
+        $entite = new \LibertAPI\Planning\Creneau\CreneauEntite([]);
+        $this->calling($this->dao)->post = function () {
             throw new \LogicException('');
         };
         $data = [

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Planning/PlanningController.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Planning/PlanningController.php
@@ -1,5 +1,7 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Planning;
+
+use Psr\Http\Message\ResponseInterface as IResponse;
 
 /**
  * Classe de test du contrôleur de planning
@@ -32,6 +34,10 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
         $this->entite->getMockController()->getStatus = 12;
     }
 
+    /*************************************************
+     * GET
+     *************************************************/
+
     /**
      * Teste la méthode get d'une liste avec des droits insuffisants
      */
@@ -52,12 +58,12 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
         $this->assertFail($response, 403);
     }
 
-    protected function getOne()
+    protected function getOne() : IResponse
     {
         return $this->testedInstance->get($this->request, $this->response, ['planningId' => 99]);
     }
 
-    protected function getList()
+    protected function getList() : IResponse
     {
         return $this->testedInstance->get($this->request, $this->response, []);
     }

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Planning/PlanningDao.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Planning/PlanningDao.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Planning;
 
 use LibertAPI\Planning\PlanningDao as _Dao;

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Planning/PlanningEntite.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Planning/PlanningEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Planning;
 
 use \LibertAPI\Planning\PlanningEntite as _Entite;

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Planning/PlanningRepository.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Planning/PlanningRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Planning;
 
 use \LibertAPI\Planning\PlanningRepository as _Repository;
@@ -22,7 +22,7 @@ final class PlanningRepository extends \LibertAPI\Tests\Units\Tools\Libraries\AR
 
     protected function initEntite()
     {
-        $this->entite = new \LibertAPI\Planning\PlanningEntite([]);
+        $this->entite = new \LibertAPI\Planning\PlanningEntite(['id' => 42]);
     }
 
     /*************************************************
@@ -42,7 +42,6 @@ final class PlanningRepository extends \LibertAPI\Tests\Units\Tools\Libraries\AR
         $this->exception(function () use ($repository) {
             $repository->deleteOne($this->entite);
         })->isInstanceOf('\LogicException');
-
     }
 
     /**

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Helpers/Formatter.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Helpers/Formatter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Tools\Helpers;
 
 use LibertAPI\Tools\Helpers\Formatter as _Formatter;

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/AController.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/AController.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Tools\Libraries;
 
 use Psr\Http\Message\ResponseInterface as IResponse;
@@ -70,7 +70,7 @@ abstract class AController extends \Atoum
      *
      * @return array | mixed si le json est mal formé
      */
-    protected function getJsonDecoded($json)
+    protected function getJsonDecoded($json) : array
     {
         return json_decode((string) $json, true);
     }

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/AControllerFactory.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/AControllerFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Tools\Libraries;
 
 use LibertAPI\Tools\Libraries\AControllerFactory as _AControllerFactory;

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/ADao.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/ADao.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Tools\Libraries;
 
 use LibertAPI\Tools\Libraries\AEntite;

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/AEntite.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/AEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Tools\Libraries;
 
 use LibertAPI\Tools\Libraries\AEntite as _AEntite;

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/ARepository.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/ARepository.php
@@ -1,5 +1,7 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Tools\Libraries;
+
+use LibertAPI\Tools\Libraries\AEntite;
 
 /**
  * Classe de test des repositories
@@ -41,12 +43,12 @@ abstract class ARepository extends \Atoum
      */
     public function testGetOne()
     {
-        $this->dao->getMockController()->getById = new \stdClass;
+        $this->dao->getMockController()->getById = $this->entite;
         $repository = $this->newTestedInstance($this->dao);
 
         $entite = $repository->getOne(42);
 
-        $this->object($entite);
+        $this->object($entite)->isInstanceOf(AEntite::class);
     }
 
     /**
@@ -54,7 +56,7 @@ abstract class ARepository extends \Atoum
      */
     public function testGetList()
     {
-        $this->calling($this->dao)->getList = [42 => new \stdClass];
+        $this->calling($this->dao)->getList = [42 => $this->entite];
         $repository = $this->newTestedInstance($this->dao);
 
         $entites = $repository->getList([]);

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/ARestController.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/ARestController.php
@@ -1,7 +1,8 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Tools\Libraries;
 
 use LibertAPI\Utilisateur\UtilisateurEntite;
+use Psr\Http\Message\ResponseInterface as IResponse;
 
 /**
  * Classe de base des tests sur les contrôleurs REST
@@ -91,7 +92,7 @@ abstract class ARestController extends AController
         $response = $this->assertError($response);
     }
 
-    abstract protected function getOne();
+    abstract protected function getOne() : IResponse;
 
     /**
      * Teste la méthode get d'une liste trouvée
@@ -99,9 +100,7 @@ abstract class ARestController extends AController
     public function testGetListFound()
     {
         $this->request->getMockController()->getQueryParams = [];
-        $this->repository->getMockController()->getList = [
-            42 => $this->entite,
-        ];
+        $this->repository->getMockController()->getList = [$this->entite,];
         $this->newTestedInstance($this->repository, $this->router, $this->currentAdmin);
 
         $response = $this->getList();
@@ -147,5 +146,5 @@ abstract class ARestController extends AController
         $this->assertError($response);
     }
 
-    abstract protected function getList();
+    abstract protected function getList() : IResponse;
 }

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/Application.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Libraries/Application.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Tools\Libraries;
 
 use LibertAPI\Tools\Libraries\Application as _Application;

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Middlewares/Identification.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Tools/Middlewares/Identification.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Tools\Middlewares;
 
 use LibertAPI\Tools\Middlewares\Identification as _Identification;

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Utilisateur/UtilisateurDao.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Utilisateur/UtilisateurDao.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Utilisateur;
 
 use \LibertAPI\Utilisateur\UtilisateurDao as _Dao;
@@ -45,8 +45,10 @@ final class UtilisateurDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
 
     public function testPost()
     {
-        $dao = new _Dao($this->connector);
-        $this->variable($dao->post(new UtilisateurEntite($this->entiteContent)))->isNull();
+        $this->exception(function () {
+            $dao = new _Dao($this->connector);
+            $this->variable($dao->post(new UtilisateurEntite($this->entiteContent)));
+        })->isInstanceOf(\RuntimeException::class);
     }
 
     /*************************************************
@@ -74,12 +76,11 @@ final class UtilisateurDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
      */
     public function testDeleteOk()
     {
-        $this->calling($this->result)->rowCount = 1;
         $this->newTestedInstance($this->connector);
 
-        $res = $this->testedInstance->delete(7);
-
-        $this->variable($res)->isNull();
+        $this->exception(function () {
+            $this->testedInstance->delete(7);
+        });
     }
 
     protected function getStorageContent()

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Utilisateur/UtilisateurEntite.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Utilisateur/UtilisateurEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Utilisateur;
 
 use \LibertAPI\Utilisateur\UtilisateurEntite as _Entite;

--- a/vendor/Libertempo/libertempo-api/Tests/Units/Utilisateur/UtilisateurRepository.php
+++ b/vendor/Libertempo/libertempo-api/Tests/Units/Utilisateur/UtilisateurRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Utilisateur;
 
 use LibertAPI\Utilisateur\UtilisateurRepository as _Repository;
@@ -146,7 +146,10 @@ final class UtilisateurRepository extends \LibertAPI\Tests\Units\Tools\Libraries
 
     public function testPostOne()
     {
-        $this->variable((new _Repository($this->dao))->postOne([], $this->entite))->isNull();
+        $this->exception(function () {
+            $repo = new _Repository($this->dao);
+            $repo->postOne([], $this->entite);
+        });
     }
 
     /*************************************************

--- a/vendor/Libertempo/libertempo-api/Tools/Exceptions/MissingArgumentException.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Exceptions/MissingArgumentException.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Exceptions;
 
 /**

--- a/vendor/Libertempo/libertempo-api/Tools/Exceptions/MissingRightException.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Exceptions/MissingRightException.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Exceptions;
 
 /**

--- a/vendor/Libertempo/libertempo-api/Tools/Handlers.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Handlers.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 /*
  * Simple déclaration des handlers à injecter dans le serveur Slim
  */

--- a/vendor/Libertempo/libertempo-api/Tools/Helpers/Formatter.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Helpers/Formatter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Helpers;
 
 /**

--- a/vendor/Libertempo/libertempo-api/Tools/Interfaces/IDeletable.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Interfaces/IDeletable.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Interfaces;
 
 use Psr\Http\Message\ServerRequestInterface as IRequest;
@@ -18,5 +18,5 @@ interface IDeletable
      *
      * @return IResponse
      */
-    public function delete(IRequest $request, IResponse $response, array $routeArguments);
+    public function delete(IRequest $request, IResponse $response, array $routeArguments) : IResponse;
 }

--- a/vendor/Libertempo/libertempo-api/Tools/Interfaces/IGetable.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Interfaces/IGetable.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Interfaces;
 
 use Psr\Http\Message\ServerRequestInterface as IRequest;
@@ -18,5 +18,5 @@ interface IGetable
      *
      * @return IResponse
      */
-    public function get(IRequest $request, IResponse $response, array $routeArguments);
+    public function get(IRequest $request, IResponse $response, array $routeArguments) : IResponse;
 }

--- a/vendor/Libertempo/libertempo-api/Tools/Interfaces/IPostable.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Interfaces/IPostable.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Interfaces;
 
 use Psr\Http\Message\ServerRequestInterface as IRequest;
@@ -18,5 +18,5 @@ interface IPostable
      *
      * @return IResponse
      */
-    public function post(IRequest $request, IResponse $response, array $routeArguments);
+    public function post(IRequest $request, IResponse $response, array $routeArguments) : IResponse;
 }

--- a/vendor/Libertempo/libertempo-api/Tools/Interfaces/IPutable.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Interfaces/IPutable.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Interfaces;
 
 use Psr\Http\Message\ServerRequestInterface as IRequest;
@@ -18,5 +18,5 @@ interface IPutable
      *
      * @return IResponse
      */
-    public function put(IRequest $request, IResponse $response, array $routeArguments);
+    public function put(IRequest $request, IResponse $response, array $routeArguments) : IResponse;
 }

--- a/vendor/Libertempo/libertempo-api/Tools/Libraries/AController.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Libraries/AController.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Libraries;
 
 use LibertAPI\Tools\Libraries\ARepository;
@@ -46,11 +46,11 @@ abstract class AController
      * Vérifie les bons droits de l'utilisateur pour accéder à l'ordre demandé
      *
      * @param string $order Ordre dont on veut vérifier les droits
-     * @param LibertAPI\Utilisateur\UtilisateurEntite $utilisateur Utilisateur courant
+     * @param \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur Utilisateur courant
      *
      * @throws \LibertAPI\Tools\Exceptions\MissingRightException if rights aren't enought to execute action
      */
-    abstract protected function ensureAccessUser($order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur);
+    abstract protected function ensureAccessUser(string $order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur);
 
     /**
      * Retourne une réponse de succès normalisée
@@ -61,7 +61,7 @@ abstract class AController
      *
      * @return IResponse
      */
-    final protected function getResponseSuccess(IResponse $response, $messageData, $code)
+    final protected function getResponseSuccess(IResponse $response, $messageData, int $code) : IResponse
     {
         return $this->getResponse($response, $messageData, $code, 'success');
     }
@@ -74,7 +74,7 @@ abstract class AController
      *
      * @return IResponse
      */
-    final protected function getResponseError(IResponse $response, \Exception $e)
+    final protected function getResponseError(IResponse $response, \Exception $e) : IResponse
     {
         return $this->getResponse($response, $e->getMessage(), 500, 'error');
     }
@@ -87,7 +87,7 @@ abstract class AController
      *
      * @return IResponse
      */
-    final protected function getResponseBadRequest(IResponse $response, $message)
+    final protected function getResponseBadRequest(IResponse $response, string $message) : IResponse
     {
         return $this->getResponseFail($response, $message, 400);
     }
@@ -100,7 +100,7 @@ abstract class AController
      *
      * @return IResponse
      */
-    final protected function getResponseForbidden(IResponse $response, IRequest $request)
+    final protected function getResponseForbidden(IResponse $response, IRequest $request) : IResponse
     {
         return $this->getResponseFail($response, 'User has not access to « ' . $request->getUri()->getPath() . ' » resource', 403);
     }
@@ -112,7 +112,7 @@ abstract class AController
      *
      * @return IResponse
      */
-    final protected function getResponseMissingArgument(IResponse $response)
+    final protected function getResponseMissingArgument(IResponse $response) : IResponse
     {
         return $this->getResponseFail($response, 'Missing required argument', 412);
     }
@@ -125,7 +125,7 @@ abstract class AController
      *
      * @return IResponse
      */
-    final protected function getResponseBadDomainArgument(IResponse $response, \Exception $e)
+    final protected function getResponseBadDomainArgument(IResponse $response, \Exception $e) : IResponse
     {
         return $this->getResponseFail($response, json_decode($e->getMessage(), true), 412);
     }
@@ -138,7 +138,7 @@ abstract class AController
      *
      * @return IResponse
      */
-    final protected function getResponseNotFound(IResponse $response, $messageData)
+    final protected function getResponseNotFound(IResponse $response, string $messageData) : IResponse
     {
         return $this->getResponseFail($response, $messageData, 404);
     }
@@ -150,7 +150,7 @@ abstract class AController
      *
      * @return IResponse
      */
-    final protected function getResponseNoContent(IResponse $response)
+    final protected function getResponseNoContent(IResponse $response) : IResponse
     {
         return $this->getResponseSuccess($response, 'No Content', 204);
     }
@@ -164,7 +164,7 @@ abstract class AController
      *
      * @return IResponse
      */
-    private function getResponseFail(IResponse $response, $messageData, $code)
+    private function getResponseFail(IResponse $response, $messageData, int $code) : IResponse
     {
         return $this->getResponse($response, $messageData, $code, 'fail');
     }
@@ -179,7 +179,7 @@ abstract class AController
      *
      * @return IResponse
      */
-    private function getResponse(IResponse $response, $messageData, $code, $status)
+    private function getResponse(IResponse $response, $messageData, int $code, string $status) : IResponse
     {
         $response = $response->withStatus($code);
         $data = [

--- a/vendor/Libertempo/libertempo-api/Tools/Libraries/AControllerFactory.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Libraries/AControllerFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Libraries;
 
 use \Slim\Interfaces\RouterInterface as IRouter;
@@ -26,10 +26,10 @@ abstract class AControllerFactory
      * @param Connection $storageConnector Connecteur à la BDD
      * @param IRouter $router Routeur de l'application
      *
-     * @return \LibertAPI\Tools\Libraries\AController
+     * @return AController
      * @throws \DomainException Si la ressource est inconnue
      */
-    final public static function createControllerAuthentification($ressourcePath, Connection $storageConnector, IRouter $router)
+    final public static function createControllerAuthentification($ressourcePath, Connection $storageConnector, IRouter $router) : AController
     {
         $controllerClass = static::getControllerClassname($ressourcePath);
         if (!class_exists($controllerClass, true)) {
@@ -56,10 +56,10 @@ abstract class AControllerFactory
      * @param IRouter $router Routeur de l'application
      * @param AEntite $currentUser Utilisateur authentifié
      *
-     * @return \App\Libraries\AController
+     * @return AController
      * @throws \DomainException Si la ressource est inconnue
      */
-    final public static function createControllerWithUser($ressourcePath, Connection $storageConnector, IRouter $router, AEntite $currentUser)
+    final public static function createControllerWithUser($ressourcePath, Connection $storageConnector, IRouter $router, AEntite $currentUser) : AController
     {
         $controllerClass = static::getControllerClassname($ressourcePath);
         if (!class_exists($controllerClass, true)) {
@@ -87,7 +87,7 @@ abstract class AControllerFactory
      *
      * @return string
      */
-    final private static function getControllerClassname($ressourcePath)
+    final private static function getControllerClassname($ressourcePath) : string
     {
         $paths = explode('\\', $ressourcePath);
         $end = array_pop($paths);

--- a/vendor/Libertempo/libertempo-api/Tools/Libraries/ADao.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Libraries/ADao.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Libraries;
 
 use Doctrine\DBAL\Query;
@@ -21,7 +21,7 @@ abstract class ADao
     {
         $this->storageConnector = $storageConnector;
         $this->queryBuilder = $storageConnector->createQueryBuilder();
-        $this->queryBuilder->from($this->getTableName());
+        $this->queryBuilder->from($this->getTableName(), 'current');
     }
 
     /**
@@ -46,7 +46,7 @@ abstract class ADao
      * @return AEntite
      * @throws \DomainException si $id n'est pas dans le domaine de définition
      */
-    abstract public function getById($id);
+    abstract public function getById(int $id) : AEntite;
 
     /**
      * Effectue le mapping des éléments venant de la DAO pour qu'ils soient compréhensibles pour l'Entité
@@ -65,7 +65,7 @@ abstract class ADao
      *
      * @return array, vide si les critères ne sont pas pertinents
      */
-    abstract public function getList(array $parametres);
+    abstract public function getList(array $parametres) : array;
 
     /*************************************************
      * POST
@@ -78,7 +78,7 @@ abstract class ADao
      *
      * @return int Id de la ressource nouvellement créée
      */
-    abstract public function post(AEntite $entite);
+    abstract public function post(AEntite $entite) : int;
 
     /*************************************************
      * PUT
@@ -98,7 +98,7 @@ abstract class ADao
      *
      * @return array
      */
-    abstract protected function getEntite2Storage(AEntite $entite);
+    abstract protected function getEntite2Storage(AEntite $entite) : array;
 
     /*************************************************
      * DELETE
@@ -111,21 +111,21 @@ abstract class ADao
      *
      * @return int Nombre d'éléments affectés
      */
-    abstract public function delete($id);
+    abstract public function delete(int $id) : int;
 
     /**
      * Retourne le nom de la table
      *
      * @return string
      */
-    abstract protected function getTableName();
+    abstract protected function getTableName() : string;
 
     /**
      * Initie une transaction
      *
      * @return bool
      */
-    public function beginTransaction()
+    public function beginTransaction() : bool
     {
         return $this->storageConnector->beginTransaction();
     }
@@ -135,7 +135,7 @@ abstract class ADao
      *
      * @return bool
      */
-    public function commit()
+    public function commit() : bool
     {
         return $this->storageConnector->commit();
     }
@@ -145,7 +145,7 @@ abstract class ADao
      *
      * @return bool
      */
-    public function rollback()
+    public function rollback() : bool
     {
         return $this->storageConnector->rollBack();
     }

--- a/vendor/Libertempo/libertempo-api/Tools/Libraries/AEntite.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Libraries/AEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Libraries;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
@@ -91,7 +91,7 @@ abstract class AEntite
      * @param string $champ Champ
      * @param string $message Message d'erreur
      */
-    final protected function setErreur($champ, $message)
+    final protected function setErreur(string $champ, string $message)
     {
         $this->erreurs[$champ][] = $message;
     }
@@ -101,7 +101,7 @@ abstract class AEntite
      *
      * @return array
      */
-    final protected function getErreurs()
+    final protected function getErreurs() : array
     {
         return $this->erreurs;
     }
@@ -123,7 +123,7 @@ abstract class AEntite
      *
      * @return string
      */
-    final protected function getFreshData($data)
+    final protected function getFreshData(string $data)
     {
         if (isset($this->dataUpdated[$data])) {
             return $this->dataUpdated[$data];

--- a/vendor/Libertempo/libertempo-api/Tools/Libraries/ARepository.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Libraries/ARepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Libraries;
 
 /**
@@ -35,11 +35,12 @@ abstract class ARepository
      *
      * @param int $id Id potentiel de ressource
      *
-     * @return \LibertAPI\Tools\Libraries\AEntite
+     * @return AEntite
+     * @throws \DomainException Si $id n'est pas dans le domaine de définition
      */
-    public function getOne($id)
+    public function getOne(int $id) : AEntite
     {
-        return $this->dao->getById((int) $id);
+        return $this->dao->getById($id);
     }
 
     /**
@@ -48,8 +49,9 @@ abstract class ARepository
      * @param array $parametres
      *
      * @return array [$objetId => $objet]
+     * @throws \UnexpectedValueException Si les critères ne sont pas pertinents
      */
-    public function getList(array $parametres)
+    public function getList(array $parametres) : array
     {
         return $this->dao->getList($this->getParamsConsumer2Dao($parametres));
     }
@@ -64,7 +66,7 @@ abstract class ARepository
      *
      * @return array
      */
-    abstract protected function getParamsConsumer2Dao(array $paramsConsumer);
+    abstract protected function getParamsConsumer2Dao(array $paramsConsumer) : array;
 
     /*************************************************
      * POST

--- a/vendor/Libertempo/libertempo-api/Tools/Libraries/Application.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Libraries/Application.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Libraries;
 
 use Doctrine\DBAL\Driver\Connection;
@@ -41,7 +41,7 @@ class Application
      *
      * @return array
      */
-    private function fetchAllData()
+    private function fetchAllData() : array
     {
         $req = 'SELECT * FROM `conges_appli`';
         $res = $this->storageConnector->query($req);
@@ -49,7 +49,7 @@ class Application
         return $res->fetchAll(\PDO::FETCH_ASSOC);
     }
 
-    public function getTokenInstance()
+    public function getTokenInstance() : string
     {
         return $this->data['token_instance'];
     }

--- a/vendor/Libertempo/libertempo-api/Tools/Middlewares.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Middlewares.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 /*
  * Doit être importé après la création de $app.
  *

--- a/vendor/Libertempo/libertempo-api/Tools/Middlewares/Identification.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Middlewares/Identification.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Tools\Middlewares;
 
 use \LibertAPI\Tools\Libraries\AEntite;
@@ -42,7 +42,7 @@ final class Identification
      *
      * @return string
      */
-    private function getDateLastAccessAuthorized()
+    private function getDateLastAccessAuthorized() : string
     {
         return Formatter::timeToSQLDatetime(time() - static::DUREE_SESSION);
     }
@@ -52,7 +52,7 @@ final class Identification
      *
      * @return bool
      */
-    public function isTokenOk()
+    public function isTokenOk() : bool
     {
         return $this->getUtilisateur() instanceof AEntite;
     }

--- a/vendor/Libertempo/libertempo-api/Tools/Route/Absence.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Route/Absence.php
@@ -1,8 +1,8 @@
-<?php
+<?php declare(strict_types = 1);
 /*
  * Doit être importé après la création de $app. Ne créé rien.
  *
- * La convention de nommage est de mettre les routes au pluriel
+ * La convention de nommage est de mettre les routes au singulier
  */
 
 /* Routes sur une absence et associés */

--- a/vendor/Libertempo/libertempo-api/Tools/Route/Authentification.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Route/Authentification.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 /*
  * Doit être importé après la création de $app. Ne créé rien.
  */

--- a/vendor/Libertempo/libertempo-api/Tools/Route/Groupe.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Route/Groupe.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 /*
  * Doit être importé après la création de $app. Ne créé rien.
  *
@@ -10,6 +10,9 @@ $app->group('/groupe', function () {
     $this->group('/{groupeId:[0-9]+}', function () {
         /* Detail */
         $this->get('', 'controller:get')->setName('getGroupeDetail');
+
+        /* Dependances de groupe : responsable */
+        $this->get('/responsable', 'controller:get')->setName('getGroupeResponsableListe');
     });
 
     /* Collection */

--- a/vendor/Libertempo/libertempo-api/Tools/Route/Journal.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Route/Journal.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 /*
  * Doit être importé après la création de $app. Ne créé rien.
  *

--- a/vendor/Libertempo/libertempo-api/Tools/Route/Planning.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Route/Planning.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 /*
  * Doit être importé après la création de $app. Ne créé rien.
  *

--- a/vendor/Libertempo/libertempo-api/Tools/Route/Utilisateur.php
+++ b/vendor/Libertempo/libertempo-api/Tools/Route/Utilisateur.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 /*
  * Doit être importé après la création de $app. Ne créé rien.
  *

--- a/vendor/Libertempo/libertempo-api/Utilisateur/UtilisateurController.php
+++ b/vendor/Libertempo/libertempo-api/Utilisateur/UtilisateurController.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Utilisateur;
 
 use Psr\Http\Message\ServerRequestInterface as IRequest;
@@ -11,7 +11,7 @@ use Psr\Http\Message\ResponseInterface as IResponse;
  * @author Wouldsmina
  *
  * @since 0.4
- * @see \Tests\Units\App\Components\Utilisateur\Controller
+ * @see \LibertAPI\Utilisateur\UtilisateurController
  *
  * Ne devrait être contacté que par le routeur
  * Ne devrait contacter que le Utilisateur\Repository
@@ -21,7 +21,7 @@ final class UtilisateurController extends \LibertAPI\Tools\Libraries\AController
     /**
      * {@inheritDoc}
      */
-    protected function ensureAccessUser($order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
+    protected function ensureAccessUser(string $order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
     {
     }
 
@@ -43,7 +43,7 @@ final class UtilisateurController extends \LibertAPI\Tools\Libraries\AController
      * @return IResponse
      * @throws \Exception en cas d'erreur inconnue (fallback, ne doit pas arriver)
      */
-    public function get(IRequest $request, IResponse $response, array $arguments)
+    public function get(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
         if (!isset($arguments['utilisateurId'])) {
             return $this->getList($request, $response);
@@ -97,10 +97,7 @@ final class UtilisateurController extends \LibertAPI\Tools\Libraries\AController
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }
-        $entites = [];
-        foreach ($utilisateurs as $utilisateur) {
-            $entites[] = $this->buildData($utilisateur);
-        }
+        $entites = array_map([$this, 'buildData'], $utilisateurs);
 
         return $this->getResponseSuccess($response, $entites, 200);
     }

--- a/vendor/Libertempo/libertempo-api/Utilisateur/UtilisateurEntite.php
+++ b/vendor/Libertempo/libertempo-api/Utilisateur/UtilisateurEntite.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Utilisateur;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
@@ -14,7 +14,7 @@ use LibertAPI\Tools\Helpers\Formatter;
  * @since 0.2
  * @see \LibertAPI\Tests\Units\Utilisateur\Entite
  *
- * Ne devrait être contacté que par le Utilisateur\Repository
+ * Ne devrait être contacté que par le Utilisateur\UtilisateurDao et Groupe\Responsable\ResponsableDao
  * Ne devrait contacter personne
  */
 class UtilisateurEntite extends \LibertAPI\Tools\Libraries\AEntite

--- a/vendor/Libertempo/libertempo-api/Utilisateur/UtilisateurRepository.php
+++ b/vendor/Libertempo/libertempo-api/Utilisateur/UtilisateurRepository.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 namespace LibertAPI\Utilisateur;
 
 use LibertAPI\Tools\Libraries\AEntite;
@@ -54,14 +54,14 @@ class UtilisateurRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    final protected function getParamsConsumer2Dao(array $paramsConsumer)
+    final protected function getParamsConsumer2Dao(array $paramsConsumer) : array
     {
         $results = [];
         if (!empty($paramsConsumer['login'])) {
             $results['u_login'] = (string) $paramsConsumer['login'];
         }
         if (!empty($paramsConsumer['password'])) {
-            $results['u_passwd'] = md5($paramsConsumer['password']);
+            $results['u_passwd'] = $paramsConsumer['password'];
         }
         if (!empty($paramsConsumer['token'])) {
             $results['token'] = (string) $paramsConsumer['token'];
@@ -79,8 +79,9 @@ class UtilisateurRepository extends \LibertAPI\Tools\Libraries\ARepository
      * POST
      *************************************************/
 
-    public function postOne(array $data, AEntite $entite)
+    public function postOne(array $data, AEntite $entite) : int
     {
+        throw new \Exception('Not implemented');
     }
 
     /*************************************************

--- a/vendor/Libertempo/libertempo-api/composer.json
+++ b/vendor/Libertempo/libertempo-api/composer.json
@@ -27,6 +27,7 @@
         "vendor-dir": "Vendor"
     },
     "require": {
+        "php": "^7.0",
         "raveren/kint": "^1.0",
         "slim/slim": "^3.5",
         "doctrine/dbal": "2.5"

--- a/vendor/Libertempo/libertempo-api/decisions.md
+++ b/vendor/Libertempo/libertempo-api/decisions.md
@@ -1,3 +1,8 @@
+## 2018-02-17
+* Dans le processus d'écriture de routes pour l'API, la table `conges_groupe_resp` fait apparaître une relation N-N ; problème, rien est encore fait dans ce sens et le [« package par feature »](http://www.codingthearchitecture.com/2015/03/08/package_by_component_and_architecturally_aligned_testing.html) nous ennuie un peu. Suivant la règle de 3 et le principe selon lequel on doit repousser les décisions importantes plus tard, je vise la simplicité et manipule l'entité « Utilisateur/UtilisateurEntite » suite à la requête. Quand nous en saurons plus on changera.
+
+~ Prytoegrian
+
 ## 2017-11-04
 * À l'origine, j'avais mis les routes au pluriel car la sémantique était meilleure (avec `GET /plannings`, je veux la liste des plannings), mais l'idée atteint ses limites quand on se confronte à la langue (ex : journaux). Obliger à tenir une map serait inutilement lourd, aussi je vais au plus simple et je mets toutes les routes au singulier.
 
@@ -20,12 +25,12 @@
 
 * Histoire de faciliter la transmission des connaissances et des intentions, j'amorce la création de ce fichier, en m'appuyant sur cette [proposition](http://akazlou.com/posts/2015-11-09-every-project-should-have-decisions.html).
 
-* Convaincu de la nécessité de séparer les reponsabilités de l'application malgré une apparence de simplicité, je commence la création d'une API.
+* Convaincu de la nécessité de séparer les responsabilités de l'application malgré une apparence de simplicité, je commence la création d'une API.
 L'un des risques qu'il pourrait y avoir est la dispersion et un ralentissement dans le processus de production,
 puisqu'il faut qu'un projet soit à jour pour que l'autre puisse avancer.
 Je suppose que ça ne sera vrai que le temps que l'API gagne en puissance.
 
-* Comme l'évoque [cette issue](https://github.com/wouldsmina/Libertempo/issues/134), un framework permet de se concentrer sur son coeur de métier et d'avancer rapidement.
+* Comme l'évoque [cette issue](https://github.com/wouldsmina/Libertempo/issues/134), un framework permet de se concentrer sur son cœur de métier et d'avancer rapidement.
 Vu les besoins de l'API, Slim semble faire l'affaire. Le risque évident est la possibilité qu'il ne suffise pas aux besoins de l'application front
 et qu'on se retrouve avec deux framework.
 J'ai étudié les alternatives Lumen et Laravel, mais tous les frameworks semblent s'être pris d'amour pour le pattern ActiveRecord,

--- a/vendor/composer/ClassLoader.php
+++ b/vendor/composer/ClassLoader.php
@@ -377,11 +377,11 @@ class ClassLoader
             $subPath = $class;
             while (false !== $lastPos = strrpos($subPath, '\\')) {
                 $subPath = substr($subPath, 0, $lastPos);
-                $search = $subPath.'\\';
+                $search = $subPath . '\\';
                 if (isset($this->prefixDirsPsr4[$search])) {
+                    $pathEnd = DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $lastPos + 1);
                     foreach ($this->prefixDirsPsr4[$search] as $dir) {
-                        $length = $this->prefixLengthsPsr4[$first][$search];
-                        if (file_exists($file = $dir . DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $length))) {
+                        if (file_exists($file = $dir . $pathEnd)) {
                             return $file;
                         }
                     }

--- a/vendor/composer/autoload_files.php
+++ b/vendor/composer/autoload_files.php
@@ -7,8 +7,8 @@ $baseDir = dirname($vendorDir);
 
 return array(
     '253c157292f75eb38082b5acb06f3f01' => $vendorDir . '/nikic/fast-route/src/functions.php',
-    '6bc45d0537e6858fd179bdbc31d62c79' => $vendorDir . '/raveren/kint/Kint.class.php',
-    'a0edc8309cc5e1d60e3047b5df6b7052' => $vendorDir . '/guzzlehttp/psr7/src/functions_include.php',
     'c964ee0ededf28c96ebd9db5099ef910' => $vendorDir . '/guzzlehttp/promises/src/functions_include.php',
+    'a0edc8309cc5e1d60e3047b5df6b7052' => $vendorDir . '/guzzlehttp/psr7/src/functions_include.php',
+    '6bc45d0537e6858fd179bdbc31d62c79' => $vendorDir . '/raveren/kint/Kint.class.php',
     '37a3dc5111fe8f707ab4c132ef1dbc62' => $vendorDir . '/guzzlehttp/guzzle/src/functions_include.php',
 );

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -8,9 +8,9 @@ class ComposerStaticInitfd23b7dd905d561816f77d072cde6740
 {
     public static $files = array (
         '253c157292f75eb38082b5acb06f3f01' => __DIR__ . '/..' . '/nikic/fast-route/src/functions.php',
-        '6bc45d0537e6858fd179bdbc31d62c79' => __DIR__ . '/..' . '/raveren/kint/Kint.class.php',
-        'a0edc8309cc5e1d60e3047b5df6b7052' => __DIR__ . '/..' . '/guzzlehttp/psr7/src/functions_include.php',
         'c964ee0ededf28c96ebd9db5099ef910' => __DIR__ . '/..' . '/guzzlehttp/promises/src/functions_include.php',
+        'a0edc8309cc5e1d60e3047b5df6b7052' => __DIR__ . '/..' . '/guzzlehttp/psr7/src/functions_include.php',
+        '6bc45d0537e6858fd179bdbc31d62c79' => __DIR__ . '/..' . '/raveren/kint/Kint.class.php',
         '37a3dc5111fe8f707ab4c132ef1dbc62' => __DIR__ . '/..' . '/guzzlehttp/guzzle/src/functions_include.php',
     );
 

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -1,317 +1,57 @@
 [
     {
-        "name": "tecnickcom/tcpdf",
-        "version": "6.2.6",
-        "version_normalized": "6.2.6.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/tecnickcom/TCPDF.git",
-            "reference": "a2e8f5b505a7a14a4ed960313c4baf699fd1f4bb"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/a2e8f5b505a7a14a4ed960313c4baf699fd1f4bb",
-            "reference": "a2e8f5b505a7a14a4ed960313c4baf699fd1f4bb",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.3.0"
-        },
-        "time": "2015-01-28T18:51:40+00:00",
-        "type": "library",
-        "installation-source": "dist",
-        "autoload": {
-            "classmap": [
-                "fonts",
-                "config",
-                "include",
-                "tcpdf.php",
-                "tcpdf_parser.php",
-                "tcpdf_import.php",
-                "tcpdf_barcodes_1d.php",
-                "tcpdf_barcodes_2d.php",
-                "include/tcpdf_colors.php",
-                "include/tcpdf_filters.php",
-                "include/tcpdf_font_data.php",
-                "include/tcpdf_fonts.php",
-                "include/tcpdf_images.php",
-                "include/tcpdf_static.php",
-                "include/barcodes/datamatrix.php",
-                "include/barcodes/pdf417.php",
-                "include/barcodes/qrcode.php"
-            ]
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "LGPLv3"
-        ],
-        "authors": [
-            {
-                "name": "Nicola Asuni",
-                "email": "info@tecnick.com",
-                "homepage": "http://nicolaasuni.tecnick.com"
-            }
-        ],
-        "description": "TCPDF is a PHP class for generating PDF documents and barcodes.",
-        "homepage": "http://www.tcpdf.org/",
-        "keywords": [
-            "PDFD32000-2008",
-            "TCPDF",
-            "barcodes",
-            "datamatrix",
-            "pdf",
-            "pdf417",
-            "qrcode"
-        ]
-    },
-    {
-        "name": "yohang/calendr",
-        "version": "2.0.0",
-        "version_normalized": "2.0.0.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/yohang/CalendR.git",
-            "reference": "019c651adbb952fed4d76f944cee5b46bf687be5"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/yohang/CalendR/zipball/019c651adbb952fed4d76f944cee5b46bf687be5",
-            "reference": "019c651adbb952fed4d76f944cee5b46bf687be5",
-            "shasum": ""
-        },
-        "require": {
-            "php": "^5.5|^7.0",
-            "symfony/options-resolver": "^2.7|^3.0"
-        },
-        "require-dev": {
-            "doctrine/cache": "^1.5",
-            "doctrine/common": "^2.5",
-            "doctrine/orm": "^2.5",
-            "phpunit/phpunit": "^4.0",
-            "silex/silex": "^1.3",
-            "twig/twig": "^1.23"
-        },
-        "time": "2016-04-17T15:22:39+00:00",
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "2.0.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-0": {
-                "CalendR": "src/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "MIT"
-        ],
-        "authors": [
-            {
-                "name": "Yohan GIARELLI",
-                "email": "yohan@giarel.li",
-                "homepage": "http://yohan.giarel.li"
-            }
-        ],
-        "description": "Object Oriented calendar management",
-        "homepage": "https://github.com/yohang/CalendR",
-        "keywords": [
-            "calendar",
-            "date",
-            "events"
-        ]
-    },
-    {
-        "name": "raveren/kint",
-        "version": "1.1",
-        "version_normalized": "1.1.0.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/kint-php/kint.git",
-            "reference": "a8549198558560b24e2879c6bac2875de5371483"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/kint-php/kint/zipball/a8549198558560b24e2879c6bac2875de5371483",
-            "reference": "a8549198558560b24e2879c6bac2875de5371483",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.1.0"
-        },
-        "time": "2017-01-15T14:23:43+00:00",
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.0.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "files": [
-                "Kint.class.php"
-            ]
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "MIT"
-        ],
-        "authors": [
-            {
-                "name": "Rokas Šleinius",
-                "homepage": "https://github.com/kint-php"
-            },
-            {
-                "name": "Contributors",
-                "homepage": "https://github.com/kint-php/kint/contributors"
-            }
-        ],
-        "description": "Kint - debugging helper for PHP developers",
-        "homepage": "https://github.com/kint-php/kint",
-        "keywords": [
-            "debug",
-            "kint",
-            "php"
-        ],
-        "abandoned": "kint-php/kint"
-    },
-    {
-        "name": "psr/container",
-        "version": "1.0.0",
+        "name": "Libertempo/libertempo-api",
+        "version": "v1.0.0",
         "version_normalized": "1.0.0.0",
         "source": {
             "type": "git",
-            "url": "https://github.com/php-fig/container.git",
-            "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            "url": "https://github.com/Libertempo/libertempo-api.git",
+            "reference": "7082a2d81bc7bba429b93ad2f50dfc48450c6a92"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-            "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+            "url": "https://api.github.com/repos/Libertempo/libertempo-api/zipball/7082a2d81bc7bba429b93ad2f50dfc48450c6a92",
+            "reference": "7082a2d81bc7bba429b93ad2f50dfc48450c6a92",
             "shasum": ""
         },
         "require": {
-            "php": ">=5.3.0"
+            "doctrine/dbal": "2.5",
+            "php": "^7.0",
+            "raveren/kint": "^1.0",
+            "slim/slim": "^3.5"
         },
-        "time": "2017-02-14T16:28:37+00:00",
+        "require-dev": {
+            "atoum/atoum": "3.0.0"
+        },
+        "time": "2018-05-08T21:32:19+00:00",
         "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.0.x-dev"
-            }
-        },
         "installation-source": "dist",
         "autoload": {
             "psr-4": {
-                "Psr\\Container\\": "src/"
+                "LibertAPI\\": "."
             }
         },
-        "notification-url": "https://packagist.org/downloads/",
         "license": [
-            "MIT"
+            "AGPL-3.0"
         ],
         "authors": [
             {
-                "name": "PHP-FIG",
-                "homepage": "http://www.php-fig.org/"
-            }
-        ],
-        "description": "Common Container Interface (PHP FIG PSR-11)",
-        "homepage": "https://github.com/php-fig/container",
-        "keywords": [
-            "PSR-11",
-            "container",
-            "container-interface",
-            "container-interop",
-            "psr"
-        ]
-    },
-    {
-        "name": "container-interop/container-interop",
-        "version": "1.2.0",
-        "version_normalized": "1.2.0.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/container-interop/container-interop.git",
-            "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-            "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-            "shasum": ""
-        },
-        "require": {
-            "psr/container": "^1.0"
-        },
-        "time": "2017-02-14T19:40:03+00:00",
-        "type": "library",
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Interop\\Container\\": "src/Interop/Container/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "MIT"
-        ],
-        "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-        "homepage": "https://github.com/container-interop/container-interop"
-    },
-    {
-        "name": "psr/http-message",
-        "version": "1.0.1",
-        "version_normalized": "1.0.1.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/php-fig/http-message.git",
-            "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-            "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.3.0"
-        },
-        "time": "2016-08-06T14:39:51+00:00",
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.0.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Psr\\Http\\Message\\": "src/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "MIT"
-        ],
-        "authors": [
+                "name": "wouldsmina",
+                "role": "Developer"
+            },
             {
-                "name": "PHP-FIG",
-                "homepage": "http://www.php-fig.org/"
+                "name": "Prytoegrian",
+                "email": "prytoegrian@protonmail.com",
+                "homepage": "https://github.com/Prytoegrian",
+                "role": "Developer"
             }
         ],
-        "description": "Common interface for HTTP messages",
-        "homepage": "https://github.com/php-fig/http-message",
-        "keywords": [
-            "http",
-            "http-message",
-            "psr",
-            "psr-7",
-            "request",
-            "response"
-        ]
+        "support": {
+            "email": "libertempo@lists.tuxfamily.org",
+            "irc": "irc://irc.tuxfamily.org/#Libertempo",
+            "source": "https://github.com/Libertempo/libertempo-api/tree/v1.0.0",
+            "issues": "https://github.com/Libertempo/libertempo-api/issues"
+        }
     },
     {
         "name": "atoum/atoum",
@@ -400,413 +140,72 @@
         ]
     },
     {
-        "name": "guzzlehttp/psr7",
-        "version": "1.4.2",
-        "version_normalized": "1.4.2.0",
+        "name": "container-interop/container-interop",
+        "version": "1.2.0",
+        "version_normalized": "1.2.0.0",
         "source": {
             "type": "git",
-            "url": "https://github.com/guzzle/psr7.git",
-            "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+            "url": "https://github.com/container-interop/container-interop.git",
+            "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
-            "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+            "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+            "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
             "shasum": ""
         },
         "require": {
-            "php": ">=5.4.0",
-            "psr/http-message": "~1.0"
+            "psr/container": "^1.0"
         },
-        "provide": {
-            "psr/http-message-implementation": "1.0"
-        },
-        "require-dev": {
-            "phpunit/phpunit": "~4.0"
-        },
-        "time": "2017-03-20T17:10:46+00:00",
+        "time": "2017-02-14T19:40:03+00:00",
         "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.4-dev"
-            }
-        },
         "installation-source": "dist",
         "autoload": {
             "psr-4": {
-                "GuzzleHttp\\Psr7\\": "src/"
-            },
-            "files": [
-                "src/functions_include.php"
-            ]
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "MIT"
-        ],
-        "authors": [
-            {
-                "name": "Michael Dowling",
-                "email": "mtdowling@gmail.com",
-                "homepage": "https://github.com/mtdowling"
-            },
-            {
-                "name": "Tobias Schultze",
-                "homepage": "https://github.com/Tobion"
-            }
-        ],
-        "description": "PSR-7 message implementation that also provides common utility methods",
-        "keywords": [
-            "http",
-            "message",
-            "request",
-            "response",
-            "stream",
-            "uri",
-            "url"
-        ]
-    },
-    {
-        "name": "guzzlehttp/promises",
-        "version": "v1.3.1",
-        "version_normalized": "1.3.1.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/guzzle/promises.git",
-            "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
-            "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.5.0"
-        },
-        "require-dev": {
-            "phpunit/phpunit": "^4.0"
-        },
-        "time": "2016-12-20T10:07:11+00:00",
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.4-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "GuzzleHttp\\Promise\\": "src/"
-            },
-            "files": [
-                "src/functions_include.php"
-            ]
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "MIT"
-        ],
-        "authors": [
-            {
-                "name": "Michael Dowling",
-                "email": "mtdowling@gmail.com",
-                "homepage": "https://github.com/mtdowling"
-            }
-        ],
-        "description": "Guzzle promises library",
-        "keywords": [
-            "promise"
-        ]
-    },
-    {
-        "name": "guzzlehttp/guzzle",
-        "version": "6.2.2",
-        "version_normalized": "6.2.2.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/guzzle/guzzle.git",
-            "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
-            "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
-            "shasum": ""
-        },
-        "require": {
-            "guzzlehttp/promises": "^1.0",
-            "guzzlehttp/psr7": "^1.3.1",
-            "php": ">=5.5"
-        },
-        "require-dev": {
-            "ext-curl": "*",
-            "phpunit/phpunit": "^4.0",
-            "psr/log": "^1.0"
-        },
-        "time": "2016-10-08T15:01:37+00:00",
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "6.2-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "files": [
-                "src/functions_include.php"
-            ],
-            "psr-4": {
-                "GuzzleHttp\\": "src/"
+                "Interop\\Container\\": "src/Interop/Container/"
             }
         },
         "notification-url": "https://packagist.org/downloads/",
         "license": [
             "MIT"
         ],
-        "authors": [
-            {
-                "name": "Michael Dowling",
-                "email": "mtdowling@gmail.com",
-                "homepage": "https://github.com/mtdowling"
-            }
-        ],
-        "description": "Guzzle is a PHP HTTP client library",
-        "homepage": "http://guzzlephp.org/",
-        "keywords": [
-            "client",
-            "curl",
-            "framework",
-            "http",
-            "http client",
-            "rest",
-            "web service"
-        ]
+        "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+        "homepage": "https://github.com/container-interop/container-interop"
     },
     {
-        "name": "phpmailer/phpmailer",
-        "version": "v5.2.26",
-        "version_normalized": "5.2.26.0",
+        "name": "doctrine/annotations",
+        "version": "v1.6.0",
+        "version_normalized": "1.6.0.0",
         "source": {
             "type": "git",
-            "url": "https://github.com/PHPMailer/PHPMailer.git",
-            "reference": "70362997bda4376378be7d92d81e2200550923f7"
+            "url": "https://github.com/doctrine/annotations.git",
+            "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/70362997bda4376378be7d92d81e2200550923f7",
-            "reference": "70362997bda4376378be7d92d81e2200550923f7",
+            "url": "https://api.github.com/repos/doctrine/annotations/zipball/c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+            "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
             "shasum": ""
         },
         "require": {
-            "ext-ctype": "*",
-            "php": ">=5.0.0"
-        },
-        "require-dev": {
-            "doctrine/annotations": "1.2.*",
-            "jms/serializer": "0.16.*",
-            "phpdocumentor/phpdocumentor": "2.*",
-            "phpunit/phpunit": "4.8.*",
-            "symfony/debug": "2.8.*",
-            "symfony/filesystem": "2.8.*",
-            "symfony/translation": "2.8.*",
-            "symfony/yaml": "2.8.*",
-            "zendframework/zend-cache": "2.5.1",
-            "zendframework/zend-config": "2.5.1",
-            "zendframework/zend-eventmanager": "2.5.1",
-            "zendframework/zend-filter": "2.5.1",
-            "zendframework/zend-i18n": "2.5.1",
-            "zendframework/zend-json": "2.5.1",
-            "zendframework/zend-math": "2.5.1",
-            "zendframework/zend-serializer": "2.5.*",
-            "zendframework/zend-servicemanager": "2.5.*",
-            "zendframework/zend-stdlib": "2.5.1"
-        },
-        "suggest": {
-            "league/oauth2-google": "Needed for Google XOAUTH2 authentication"
-        },
-        "time": "2017-11-04T09:26:05+00:00",
-        "type": "library",
-        "installation-source": "dist",
-        "autoload": {
-            "classmap": [
-                "class.phpmailer.php",
-                "class.phpmaileroauth.php",
-                "class.phpmaileroauthgoogle.php",
-                "class.smtp.php",
-                "class.pop3.php",
-                "extras/EasyPeasyICS.php",
-                "extras/ntlm_sasl_client.php"
-            ]
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "LGPL-2.1"
-        ],
-        "authors": [
-            {
-                "name": "Jim Jagielski",
-                "email": "jimjag@gmail.com"
-            },
-            {
-                "name": "Marcus Bointon",
-                "email": "phpmailer@synchromedia.co.uk"
-            },
-            {
-                "name": "Andy Prevost",
-                "email": "codeworxtech@users.sourceforge.net"
-            },
-            {
-                "name": "Brent R. Matzelle"
-            }
-        ],
-        "description": "PHPMailer is a full-featured email creation and transfer class for PHP"
-    },
-    {
-        "name": "jasig/phpcas",
-        "version": "1.3.5",
-        "version_normalized": "1.3.5.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/apereo/phpCAS.git",
-            "reference": "61c8899c8f91204e8b9135d795461e50fe5c2db0"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/apereo/phpCAS/zipball/61c8899c8f91204e8b9135d795461e50fe5c2db0",
-            "reference": "61c8899c8f91204e8b9135d795461e50fe5c2db0",
-            "shasum": ""
-        },
-        "require": {
-            "ext-curl": "*",
-            "php": ">=5.4.0"
-        },
-        "require-dev": {
-            "phpunit/phpunit": "~3.7.10"
-        },
-        "time": "2017-04-10T19:12:45+00:00",
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.3.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "classmap": [
-                "source/"
-            ]
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "Apache-2.0"
-        ],
-        "authors": [
-            {
-                "name": "Joachim Fritschi",
-                "homepage": "https://wiki.jasig.org/display/~fritschi"
-            },
-            {
-                "name": "Adam Franco",
-                "homepage": "https://wiki.jasig.org/display/~adamfranco"
-            }
-        ],
-        "description": "Provides a simple API for authenticating users against a CAS server",
-        "homepage": "https://wiki.jasig.org/display/CASC/phpCAS",
-        "keywords": [
-            "cas",
-            "jasig"
-        ]
-    },
-    {
-        "name": "doctrine/lexer",
-        "version": "v1.0.1",
-        "version_normalized": "1.0.1.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/doctrine/lexer.git",
-            "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
-            "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.3.2"
-        },
-        "time": "2014-09-09T13:34:57+00:00",
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.0.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-0": {
-                "Doctrine\\Common\\Lexer\\": "lib/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "MIT"
-        ],
-        "authors": [
-            {
-                "name": "Roman Borschel",
-                "email": "roman@code-factory.org"
-            },
-            {
-                "name": "Guilherme Blanco",
-                "email": "guilhermeblanco@gmail.com"
-            },
-            {
-                "name": "Johannes Schmitt",
-                "email": "schmittjoh@gmail.com"
-            }
-        ],
-        "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
-        "homepage": "http://www.doctrine-project.org",
-        "keywords": [
-            "lexer",
-            "parser"
-        ]
-    },
-    {
-        "name": "doctrine/collections",
-        "version": "v1.5.0",
-        "version_normalized": "1.5.0.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/doctrine/collections.git",
-            "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/doctrine/collections/zipball/a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
-            "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
-            "shasum": ""
-        },
-        "require": {
+            "doctrine/lexer": "1.*",
             "php": "^7.1"
         },
         "require-dev": {
-            "doctrine/coding-standard": "~0.1@dev",
-            "phpunit/phpunit": "^5.7"
+            "doctrine/cache": "1.*",
+            "phpunit/phpunit": "^6.4"
         },
-        "time": "2017-07-22T10:37:32+00:00",
+        "time": "2017-12-06T07:11:42+00:00",
         "type": "library",
         "extra": {
             "branch-alias": {
-                "dev-master": "1.3.x-dev"
+                "dev-master": "1.6.x-dev"
             }
         },
         "installation-source": "dist",
         "autoload": {
-            "psr-0": {
-                "Doctrine\\Common\\Collections\\": "lib/"
+            "psr-4": {
+                "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
             }
         },
         "notification-url": "https://packagist.org/downloads/",
@@ -835,12 +234,12 @@
                 "email": "schmittjoh@gmail.com"
             }
         ],
-        "description": "Collections Abstraction library",
+        "description": "Docblock Annotations Parser",
         "homepage": "http://www.doctrine-project.org",
         "keywords": [
-            "array",
-            "collections",
-            "iterator"
+            "annotations",
+            "docblock",
+            "parser"
         ]
     },
     {
@@ -920,39 +319,38 @@
         ]
     },
     {
-        "name": "doctrine/annotations",
-        "version": "v1.6.0",
-        "version_normalized": "1.6.0.0",
+        "name": "doctrine/collections",
+        "version": "v1.5.0",
+        "version_normalized": "1.5.0.0",
         "source": {
             "type": "git",
-            "url": "https://github.com/doctrine/annotations.git",
-            "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5"
+            "url": "https://github.com/doctrine/collections.git",
+            "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/doctrine/annotations/zipball/c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
-            "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+            "url": "https://api.github.com/repos/doctrine/collections/zipball/a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
+            "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
             "shasum": ""
         },
         "require": {
-            "doctrine/lexer": "1.*",
             "php": "^7.1"
         },
         "require-dev": {
-            "doctrine/cache": "1.*",
-            "phpunit/phpunit": "^6.4"
+            "doctrine/coding-standard": "~0.1@dev",
+            "phpunit/phpunit": "^5.7"
         },
-        "time": "2017-12-06T07:11:42+00:00",
+        "time": "2017-07-22T10:37:32+00:00",
         "type": "library",
         "extra": {
             "branch-alias": {
-                "dev-master": "1.6.x-dev"
+                "dev-master": "1.3.x-dev"
             }
         },
         "installation-source": "dist",
         "autoload": {
-            "psr-4": {
-                "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+            "psr-0": {
+                "Doctrine\\Common\\Collections\\": "lib/"
             }
         },
         "notification-url": "https://packagist.org/downloads/",
@@ -981,12 +379,12 @@
                 "email": "schmittjoh@gmail.com"
             }
         ],
-        "description": "Docblock Annotations Parser",
+        "description": "Collections Abstraction library",
         "homepage": "http://www.doctrine-project.org",
         "keywords": [
-            "annotations",
-            "docblock",
-            "parser"
+            "array",
+            "collections",
+            "iterator"
         ]
     },
     {
@@ -1138,6 +536,707 @@
         ]
     },
     {
+        "name": "doctrine/inflector",
+        "version": "v1.3.0",
+        "version_normalized": "1.3.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/doctrine/inflector.git",
+            "reference": "5527a48b7313d15261292c149e55e26eae771b0a"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/doctrine/inflector/zipball/5527a48b7313d15261292c149e55e26eae771b0a",
+            "reference": "5527a48b7313d15261292c149e55e26eae771b0a",
+            "shasum": ""
+        },
+        "require": {
+            "php": "^7.1"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "^6.2"
+        },
+        "time": "2018-01-09T20:05:19+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.3.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Roman Borschel",
+                "email": "roman@code-factory.org"
+            },
+            {
+                "name": "Benjamin Eberlei",
+                "email": "kontakt@beberlei.de"
+            },
+            {
+                "name": "Guilherme Blanco",
+                "email": "guilhermeblanco@gmail.com"
+            },
+            {
+                "name": "Jonathan Wage",
+                "email": "jonwage@gmail.com"
+            },
+            {
+                "name": "Johannes Schmitt",
+                "email": "schmittjoh@gmail.com"
+            }
+        ],
+        "description": "Common String Manipulations with regard to casing and singular/plural rules.",
+        "homepage": "http://www.doctrine-project.org",
+        "keywords": [
+            "inflection",
+            "pluralize",
+            "singularize",
+            "string"
+        ]
+    },
+    {
+        "name": "doctrine/lexer",
+        "version": "v1.0.1",
+        "version_normalized": "1.0.1.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/doctrine/lexer.git",
+            "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+            "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.2"
+        },
+        "time": "2014-09-09T13:34:57+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.0.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-0": {
+                "Doctrine\\Common\\Lexer\\": "lib/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Roman Borschel",
+                "email": "roman@code-factory.org"
+            },
+            {
+                "name": "Guilherme Blanco",
+                "email": "guilhermeblanco@gmail.com"
+            },
+            {
+                "name": "Johannes Schmitt",
+                "email": "schmittjoh@gmail.com"
+            }
+        ],
+        "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+        "homepage": "http://www.doctrine-project.org",
+        "keywords": [
+            "lexer",
+            "parser"
+        ]
+    },
+    {
+        "name": "guzzlehttp/guzzle",
+        "version": "6.2.2",
+        "version_normalized": "6.2.2.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/guzzle/guzzle.git",
+            "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+            "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+            "shasum": ""
+        },
+        "require": {
+            "guzzlehttp/promises": "^1.0",
+            "guzzlehttp/psr7": "^1.3.1",
+            "php": ">=5.5"
+        },
+        "require-dev": {
+            "ext-curl": "*",
+            "phpunit/phpunit": "^4.0",
+            "psr/log": "^1.0"
+        },
+        "time": "2016-10-08T15:01:37+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "6.2-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "files": [
+                "src/functions_include.php"
+            ],
+            "psr-4": {
+                "GuzzleHttp\\": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Michael Dowling",
+                "email": "mtdowling@gmail.com",
+                "homepage": "https://github.com/mtdowling"
+            }
+        ],
+        "description": "Guzzle is a PHP HTTP client library",
+        "homepage": "http://guzzlephp.org/",
+        "keywords": [
+            "client",
+            "curl",
+            "framework",
+            "http",
+            "http client",
+            "rest",
+            "web service"
+        ]
+    },
+    {
+        "name": "guzzlehttp/promises",
+        "version": "v1.3.1",
+        "version_normalized": "1.3.1.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/guzzle/promises.git",
+            "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+            "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.5.0"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "^4.0"
+        },
+        "time": "2016-12-20T10:07:11+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.4-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "GuzzleHttp\\Promise\\": "src/"
+            },
+            "files": [
+                "src/functions_include.php"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Michael Dowling",
+                "email": "mtdowling@gmail.com",
+                "homepage": "https://github.com/mtdowling"
+            }
+        ],
+        "description": "Guzzle promises library",
+        "keywords": [
+            "promise"
+        ]
+    },
+    {
+        "name": "guzzlehttp/psr7",
+        "version": "1.4.2",
+        "version_normalized": "1.4.2.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/guzzle/psr7.git",
+            "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+            "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.4.0",
+            "psr/http-message": "~1.0"
+        },
+        "provide": {
+            "psr/http-message-implementation": "1.0"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "~4.0"
+        },
+        "time": "2017-03-20T17:10:46+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.4-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "GuzzleHttp\\Psr7\\": "src/"
+            },
+            "files": [
+                "src/functions_include.php"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Michael Dowling",
+                "email": "mtdowling@gmail.com",
+                "homepage": "https://github.com/mtdowling"
+            },
+            {
+                "name": "Tobias Schultze",
+                "homepage": "https://github.com/Tobion"
+            }
+        ],
+        "description": "PSR-7 message implementation that also provides common utility methods",
+        "keywords": [
+            "http",
+            "message",
+            "request",
+            "response",
+            "stream",
+            "uri",
+            "url"
+        ]
+    },
+    {
+        "name": "jasig/phpcas",
+        "version": "1.3.5",
+        "version_normalized": "1.3.5.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/apereo/phpCAS.git",
+            "reference": "61c8899c8f91204e8b9135d795461e50fe5c2db0"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/apereo/phpCAS/zipball/61c8899c8f91204e8b9135d795461e50fe5c2db0",
+            "reference": "61c8899c8f91204e8b9135d795461e50fe5c2db0",
+            "shasum": ""
+        },
+        "require": {
+            "ext-curl": "*",
+            "php": ">=5.4.0"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "~3.7.10"
+        },
+        "time": "2017-04-10T19:12:45+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.3.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "classmap": [
+                "source/"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "Apache-2.0"
+        ],
+        "authors": [
+            {
+                "name": "Joachim Fritschi",
+                "homepage": "https://wiki.jasig.org/display/~fritschi"
+            },
+            {
+                "name": "Adam Franco",
+                "homepage": "https://wiki.jasig.org/display/~adamfranco"
+            }
+        ],
+        "description": "Provides a simple API for authenticating users against a CAS server",
+        "homepage": "https://wiki.jasig.org/display/CASC/phpCAS",
+        "keywords": [
+            "cas",
+            "jasig"
+        ]
+    },
+    {
+        "name": "nikic/fast-route",
+        "version": "v1.3.0",
+        "version_normalized": "1.3.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/nikic/FastRoute.git",
+            "reference": "181d480e08d9476e61381e04a71b34dc0432e812"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/nikic/FastRoute/zipball/181d480e08d9476e61381e04a71b34dc0432e812",
+            "reference": "181d480e08d9476e61381e04a71b34dc0432e812",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.4.0"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "^4.8.35|~5.7"
+        },
+        "time": "2018-02-13T20:26:39+00:00",
+        "type": "library",
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "FastRoute\\": "src/"
+            },
+            "files": [
+                "src/functions.php"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "BSD-3-Clause"
+        ],
+        "authors": [
+            {
+                "name": "Nikita Popov",
+                "email": "nikic@php.net"
+            }
+        ],
+        "description": "Fast request router for PHP",
+        "keywords": [
+            "router",
+            "routing"
+        ]
+    },
+    {
+        "name": "phpmailer/phpmailer",
+        "version": "v5.2.26",
+        "version_normalized": "5.2.26.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/PHPMailer/PHPMailer.git",
+            "reference": "70362997bda4376378be7d92d81e2200550923f7"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/70362997bda4376378be7d92d81e2200550923f7",
+            "reference": "70362997bda4376378be7d92d81e2200550923f7",
+            "shasum": ""
+        },
+        "require": {
+            "ext-ctype": "*",
+            "php": ">=5.0.0"
+        },
+        "require-dev": {
+            "doctrine/annotations": "1.2.*",
+            "jms/serializer": "0.16.*",
+            "phpdocumentor/phpdocumentor": "2.*",
+            "phpunit/phpunit": "4.8.*",
+            "symfony/debug": "2.8.*",
+            "symfony/filesystem": "2.8.*",
+            "symfony/translation": "2.8.*",
+            "symfony/yaml": "2.8.*",
+            "zendframework/zend-cache": "2.5.1",
+            "zendframework/zend-config": "2.5.1",
+            "zendframework/zend-eventmanager": "2.5.1",
+            "zendframework/zend-filter": "2.5.1",
+            "zendframework/zend-i18n": "2.5.1",
+            "zendframework/zend-json": "2.5.1",
+            "zendframework/zend-math": "2.5.1",
+            "zendframework/zend-serializer": "2.5.*",
+            "zendframework/zend-servicemanager": "2.5.*",
+            "zendframework/zend-stdlib": "2.5.1"
+        },
+        "suggest": {
+            "league/oauth2-google": "Needed for Google XOAUTH2 authentication"
+        },
+        "time": "2017-11-04T09:26:05+00:00",
+        "type": "library",
+        "installation-source": "dist",
+        "autoload": {
+            "classmap": [
+                "class.phpmailer.php",
+                "class.phpmaileroauth.php",
+                "class.phpmaileroauthgoogle.php",
+                "class.smtp.php",
+                "class.pop3.php",
+                "extras/EasyPeasyICS.php",
+                "extras/ntlm_sasl_client.php"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "LGPL-2.1"
+        ],
+        "authors": [
+            {
+                "name": "Jim Jagielski",
+                "email": "jimjag@gmail.com"
+            },
+            {
+                "name": "Marcus Bointon",
+                "email": "phpmailer@synchromedia.co.uk"
+            },
+            {
+                "name": "Andy Prevost",
+                "email": "codeworxtech@users.sourceforge.net"
+            },
+            {
+                "name": "Brent R. Matzelle"
+            }
+        ],
+        "description": "PHPMailer is a full-featured email creation and transfer class for PHP"
+    },
+    {
+        "name": "pimple/pimple",
+        "version": "v3.2.3",
+        "version_normalized": "3.2.3.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/silexphp/Pimple.git",
+            "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/silexphp/Pimple/zipball/9e403941ef9d65d20cba7d54e29fe906db42cf32",
+            "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.0",
+            "psr/container": "^1.0"
+        },
+        "require-dev": {
+            "symfony/phpunit-bridge": "^3.2"
+        },
+        "time": "2018-01-21T07:42:36+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "3.2.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-0": {
+                "Pimple": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Fabien Potencier",
+                "email": "fabien@symfony.com"
+            }
+        ],
+        "description": "Pimple, a simple Dependency Injection Container",
+        "homepage": "http://pimple.sensiolabs.org",
+        "keywords": [
+            "container",
+            "dependency injection"
+        ]
+    },
+    {
+        "name": "psr/container",
+        "version": "1.0.0",
+        "version_normalized": "1.0.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/php-fig/container.git",
+            "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+            "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.0"
+        },
+        "time": "2017-02-14T16:28:37+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.0.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Psr\\Container\\": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "PHP-FIG",
+                "homepage": "http://www.php-fig.org/"
+            }
+        ],
+        "description": "Common Container Interface (PHP FIG PSR-11)",
+        "homepage": "https://github.com/php-fig/container",
+        "keywords": [
+            "PSR-11",
+            "container",
+            "container-interface",
+            "container-interop",
+            "psr"
+        ]
+    },
+    {
+        "name": "psr/http-message",
+        "version": "1.0.1",
+        "version_normalized": "1.0.1.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/php-fig/http-message.git",
+            "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+            "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.0"
+        },
+        "time": "2016-08-06T14:39:51+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.0.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Psr\\Http\\Message\\": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "PHP-FIG",
+                "homepage": "http://www.php-fig.org/"
+            }
+        ],
+        "description": "Common interface for HTTP messages",
+        "homepage": "https://github.com/php-fig/http-message",
+        "keywords": [
+            "http",
+            "http-message",
+            "psr",
+            "psr-7",
+            "request",
+            "response"
+        ]
+    },
+    {
+        "name": "raveren/kint",
+        "version": "1.1",
+        "version_normalized": "1.1.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/kint-php/kint.git",
+            "reference": "a8549198558560b24e2879c6bac2875de5371483"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/kint-php/kint/zipball/a8549198558560b24e2879c6bac2875de5371483",
+            "reference": "a8549198558560b24e2879c6bac2875de5371483",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.1.0"
+        },
+        "time": "2017-01-15T14:23:43+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.0.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "files": [
+                "Kint.class.php"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Rokas Šleinius",
+                "homepage": "https://github.com/kint-php"
+            },
+            {
+                "name": "Contributors",
+                "homepage": "https://github.com/kint-php/kint/contributors"
+            }
+        ],
+        "description": "Kint - debugging helper for PHP developers",
+        "homepage": "https://github.com/kint-php/kint",
+        "keywords": [
+            "debug",
+            "kint",
+            "php"
+        ],
+        "abandoned": "kint-php/kint"
+    },
+    {
         "name": "slim/slim",
         "version": "3.9.2",
         "version_normalized": "3.9.2.0",
@@ -1211,228 +1310,6 @@
         ]
     },
     {
-        "name": "doctrine/inflector",
-        "version": "v1.3.0",
-        "version_normalized": "1.3.0.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/doctrine/inflector.git",
-            "reference": "5527a48b7313d15261292c149e55e26eae771b0a"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/doctrine/inflector/zipball/5527a48b7313d15261292c149e55e26eae771b0a",
-            "reference": "5527a48b7313d15261292c149e55e26eae771b0a",
-            "shasum": ""
-        },
-        "require": {
-            "php": "^7.1"
-        },
-        "require-dev": {
-            "phpunit/phpunit": "^6.2"
-        },
-        "time": "2018-01-09T20:05:19+00:00",
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.3.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "MIT"
-        ],
-        "authors": [
-            {
-                "name": "Roman Borschel",
-                "email": "roman@code-factory.org"
-            },
-            {
-                "name": "Benjamin Eberlei",
-                "email": "kontakt@beberlei.de"
-            },
-            {
-                "name": "Guilherme Blanco",
-                "email": "guilhermeblanco@gmail.com"
-            },
-            {
-                "name": "Jonathan Wage",
-                "email": "jonwage@gmail.com"
-            },
-            {
-                "name": "Johannes Schmitt",
-                "email": "schmittjoh@gmail.com"
-            }
-        ],
-        "description": "Common String Manipulations with regard to casing and singular/plural rules.",
-        "homepage": "http://www.doctrine-project.org",
-        "keywords": [
-            "inflection",
-            "pluralize",
-            "singularize",
-            "string"
-        ]
-    },
-    {
-        "name": "pimple/pimple",
-        "version": "v3.2.3",
-        "version_normalized": "3.2.3.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/silexphp/Pimple.git",
-            "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/silexphp/Pimple/zipball/9e403941ef9d65d20cba7d54e29fe906db42cf32",
-            "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.3.0",
-            "psr/container": "^1.0"
-        },
-        "require-dev": {
-            "symfony/phpunit-bridge": "^3.2"
-        },
-        "time": "2018-01-21T07:42:36+00:00",
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "3.2.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-0": {
-                "Pimple": "src/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "MIT"
-        ],
-        "authors": [
-            {
-                "name": "Fabien Potencier",
-                "email": "fabien@symfony.com"
-            }
-        ],
-        "description": "Pimple, a simple Dependency Injection Container",
-        "homepage": "http://pimple.sensiolabs.org",
-        "keywords": [
-            "container",
-            "dependency injection"
-        ]
-    },
-    {
-        "name": "nikic/fast-route",
-        "version": "v1.3.0",
-        "version_normalized": "1.3.0.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/nikic/FastRoute.git",
-            "reference": "181d480e08d9476e61381e04a71b34dc0432e812"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/nikic/FastRoute/zipball/181d480e08d9476e61381e04a71b34dc0432e812",
-            "reference": "181d480e08d9476e61381e04a71b34dc0432e812",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.4.0"
-        },
-        "require-dev": {
-            "phpunit/phpunit": "^4.8.35|~5.7"
-        },
-        "time": "2018-02-13T20:26:39+00:00",
-        "type": "library",
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "FastRoute\\": "src/"
-            },
-            "files": [
-                "src/functions.php"
-            ]
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "BSD-3-Clause"
-        ],
-        "authors": [
-            {
-                "name": "Nikita Popov",
-                "email": "nikic@php.net"
-            }
-        ],
-        "description": "Fast request router for PHP",
-        "keywords": [
-            "router",
-            "routing"
-        ]
-    },
-    {
-        "name": "Libertempo/libertempo-api",
-        "version": "v0.7.0",
-        "version_normalized": "0.7.0.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/Libertempo/libertempo-api.git",
-            "reference": "dba1f29d480772d489924dca86e89761967c2f69"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/Libertempo/libertempo-api/zipball/dba1f29d480772d489924dca86e89761967c2f69",
-            "reference": "dba1f29d480772d489924dca86e89761967c2f69",
-            "shasum": ""
-        },
-        "require": {
-            "doctrine/dbal": "2.5",
-            "raveren/kint": "^1.0",
-            "slim/slim": "^3.5"
-        },
-        "require-dev": {
-            "atoum/atoum": "3.0.0"
-        },
-        "time": "2018-03-12T19:40:09+00:00",
-        "type": "library",
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "LibertAPI\\": "."
-            }
-        },
-        "license": [
-            "AGPL-3.0"
-        ],
-        "authors": [
-            {
-                "name": "wouldsmina",
-                "role": "Developer"
-            },
-            {
-                "name": "Prytoegrian",
-                "email": "prytoegrian@protonmail.com",
-                "homepage": "https://github.com/Prytoegrian",
-                "role": "Developer"
-            }
-        ],
-        "support": {
-            "email": "libertempo@lists.tuxfamily.org",
-            "irc": "irc://irc.tuxfamily.org/#Libertempo",
-            "source": "https://github.com/Libertempo/libertempo-api/tree/v0.7.0",
-            "issues": "https://github.com/Libertempo/libertempo-api/issues"
-        }
-    },
-    {
         "name": "symfony/options-resolver",
         "version": "v3.4.6",
         "version_normalized": "3.4.6.0",
@@ -1486,6 +1363,130 @@
             "config",
             "configuration",
             "options"
+        ]
+    },
+    {
+        "name": "tecnickcom/tcpdf",
+        "version": "6.2.6",
+        "version_normalized": "6.2.6.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/tecnickcom/TCPDF.git",
+            "reference": "a2e8f5b505a7a14a4ed960313c4baf699fd1f4bb"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/a2e8f5b505a7a14a4ed960313c4baf699fd1f4bb",
+            "reference": "a2e8f5b505a7a14a4ed960313c4baf699fd1f4bb",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.0"
+        },
+        "time": "2015-01-28T18:51:40+00:00",
+        "type": "library",
+        "installation-source": "dist",
+        "autoload": {
+            "classmap": [
+                "fonts",
+                "config",
+                "include",
+                "tcpdf.php",
+                "tcpdf_parser.php",
+                "tcpdf_import.php",
+                "tcpdf_barcodes_1d.php",
+                "tcpdf_barcodes_2d.php",
+                "include/tcpdf_colors.php",
+                "include/tcpdf_filters.php",
+                "include/tcpdf_font_data.php",
+                "include/tcpdf_fonts.php",
+                "include/tcpdf_images.php",
+                "include/tcpdf_static.php",
+                "include/barcodes/datamatrix.php",
+                "include/barcodes/pdf417.php",
+                "include/barcodes/qrcode.php"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "LGPLv3"
+        ],
+        "authors": [
+            {
+                "name": "Nicola Asuni",
+                "email": "info@tecnick.com",
+                "homepage": "http://nicolaasuni.tecnick.com"
+            }
+        ],
+        "description": "TCPDF is a PHP class for generating PDF documents and barcodes.",
+        "homepage": "http://www.tcpdf.org/",
+        "keywords": [
+            "PDFD32000-2008",
+            "TCPDF",
+            "barcodes",
+            "datamatrix",
+            "pdf",
+            "pdf417",
+            "qrcode"
+        ]
+    },
+    {
+        "name": "yohang/calendr",
+        "version": "2.0.0",
+        "version_normalized": "2.0.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/yohang/CalendR.git",
+            "reference": "019c651adbb952fed4d76f944cee5b46bf687be5"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/yohang/CalendR/zipball/019c651adbb952fed4d76f944cee5b46bf687be5",
+            "reference": "019c651adbb952fed4d76f944cee5b46bf687be5",
+            "shasum": ""
+        },
+        "require": {
+            "php": "^5.5|^7.0",
+            "symfony/options-resolver": "^2.7|^3.0"
+        },
+        "require-dev": {
+            "doctrine/cache": "^1.5",
+            "doctrine/common": "^2.5",
+            "doctrine/orm": "^2.5",
+            "phpunit/phpunit": "^4.0",
+            "silex/silex": "^1.3",
+            "twig/twig": "^1.23"
+        },
+        "time": "2016-04-17T15:22:39+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "2.0.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-0": {
+                "CalendR": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Yohan GIARELLI",
+                "email": "yohan@giarel.li",
+                "homepage": "http://yohan.giarel.li"
+            }
+        ],
+        "description": "Object Oriented calendar management",
+        "homepage": "https://github.com/yohang/CalendR",
+        "keywords": [
+            "calendar",
+            "date",
+            "events"
         ]
     }
 ]


### PR DESCRIPTION
Puisque nous avons dis que Mondaran était la dernière version compatible php 5.6, j'officialise le truc en rendant obligatoire php7 à partir d'Akhaten. En plus d'avoir un moteur refondu (et donc des performances accrues), l'apport notable de cette version est l'arrivée du typage. Bon, c'est pas encore ça, et vu la nature de php ça le sera probablement jamais vraiment, mais c'est un premier pas. L'industrie estime qu'un langage typé a 15% de défauts en moins, donc c'est un vrai intérêt de fiabilité.