### PR TITLE
Connexion obligatoire à l'API

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,109 +13,86 @@ $config = new \App\Libraries\Configuration($sql);
 $injectableCreator = new \App\Libraries\InjectableCreator($sql, $config);
 $api = $injectableCreator->get(\App\Libraries\ApiClient::class);
 
-/***** DEBUT DU PROG *****/
+function errorAuthentification() {
+    header_error();
+    echo  _('session_pas_de_compte_dans_dbconges') ."<br>\n";
+    echo  _('session_contactez_admin') ."\n";
+    bottom();
+}
 
 if (!session_is_valid()) {
-
-	/*** initialisation des variables ***/
-	/************************************/
-
-	// Si CAS alors on utilise le login CAS pour la session
-	if ( $config->getHowToConnectUser() == "cas") {
-        //redirection vers l'url d'authentification CAS
-        $usernameCAS = authentification_passwd_conges_CAS();
-        if ($usernameCAS == "") {
-                header_error();
-	                echo  _('session_pas_de_compte_dans_dbconges') ."<br>\n";
-	                echo  _('session_contactez_admin') ."\n";
-
-	                $URL_ACCUEIL_CONGES = $config->getUrlAccueil();
-	                deconnexion_CAS($URL_ACCUEIL_CONGES);
-	                bottom();
-	                exit;
-	        }
-	} elseif ( $config->getHowToConnectUser() == "SSO" ) {
-	// Si SSO, on utilise les identifiants de session pour se connecter
-	    if (session_id()!="")
-	        session_destroy();
-
-	        $usernameSSO = authentification_AD_SSO();
-	        if ($usernameSSO != "") {
-	                session_create( $usernameSSO );
-	                storeTokenApi($api, $usernameSSO, '');
-	        } else { //dans ce cas l'utilisateur n'a pas encore été enregistré dans la base de données db_conges
-	                header_error();
-
-	                echo  _('session_pas_de_compte_dans_dbconges') ."<br>\n";
-	                echo  _('session_contactez_admin') ."\n";
-
-	                bottom();
-	                exit;
-	        }
+	if ($config->getHowToConnectUser() == "cas") {
+        try {
+            $usernameCAS = authentification_passwd_conges_CAS();
+            if ($usernameCAS == "") { 
+                throw new \Exception("Nom d'utilisateur vide");
+            }
+            session_create($usernameCAS);
+            storeTokenApi($api, $usernameCAS, '');
+        } catch (\Exception $e) {
+            errorAuthentification();
+            deconnexion_CAS($config->getUrlAccueil());
+        }
+	} elseif ($config->getHowToConnectUser() == "SSO") {
+        if (session_id() != "") {
+            session_destroy();
+        }
+        try {
+            $usernameSSO = authentification_AD_SSO();
+            if ($usernameSSO == "") {
+                throw new \Exception("Nom d'utilisateur vide");
+            }
+            session_create($usernameSSO);
+            storeTokenApi($api, $usernameSSO, '');
+        } catch (\Exception $e) {
+            errorAuthentification();
+        }
 	} else {
 	    $session_username = isset($_POST['session_username']) ? $_POST['session_username'] : '';
 	    $session_password = isset($_POST['session_password']) ? $_POST['session_password'] : '';
+        if (session_id() != "") {
+            session_destroy();
+        }
 
-	    if (session_id()!="")
-	        session_destroy();
-
-        if (($session_username == "") || ($session_password == "")) { // si login et passwd non saisis
-                //  SAISIE LOGIN / PASSWORD :
-                session_saisie_user_password("", "", ""); // appel du formulaire d'authentification (login/password)
-
-                exit;
+        if (($session_username == "") || ($session_password == "")) {
+            session_saisie_user_password("", "", "");
         } else {
-            //  AUTHENTIFICATION :
-            // le user doit etre authentifié dans la table conges (login + passwd) ou dans le ldap.
-            // si on a trouve personne qui correspond au couple user/password
-
             if ($config->getHowToConnectUser() == "ldap" && $session_username != "admin") {
                 $username_ldap = authentification_ldap_conges($session_username,$session_password);
-                if ($username_ldap != $session_username)
-                {
-                        $session_username="";
-                        $session_password="";
-                        $erreur="login_passwd_incorrect";
-                        // appel du formulaire d'intentification (login/password)
-                        session_saisie_user_password($erreur, $session_username, $session_password);
-
-                        exit;
+                if ($username_ldap != $session_username) {
+                    $session_username="";
+                    $session_password="";
+                    $erreur="login_passwd_incorrect";
+                    session_saisie_user_password($erreur, $session_username, $session_password);
                 } else {
-                        if (valid_ldap_user($session_username)) { // LDAP ok, on vérifie ici que le compte existe dans la base de données des congés.
-                                // on initialise la nouvelle session
-                                session_create($session_username);
-                                storeTokenApi($api, $session_username, $session_password);
-                        } else { //dans ce cas l'utilisateur n'a pas encore été enregistré dans la base de données db_conges
-                                header_error();
-
-                                echo  _('session_pas_de_compte_dans_dbconges') ."<br>\n";
-                                echo  _('session_contactez_admin') ."\n";
-
-                                bottom();
-                                exit;
+                    try {
+                        if (!valid_ldap_user($session_username)) {
+                            throw new \Exception("Nom d'utilisateur invalide");
                         }
-                }
-            } elseif ($config->getHowToConnectUser() == "dbconges" || $session_username == "admin") { // fin du if test avec ldap
-                $username_conges = autentification_passwd_conges($session_username,$session_password);
-                if ($username_conges != $session_username) {
-                        $session_username="";
-                        $session_password="";
-                        $erreur="login_passwd_incorrect";
-                        // appel du formulaire d'intentification (login/password)
-                        session_saisie_user_password($erreur, $session_username, $session_password);
-
-                        exit;
-                } else {
-                        // on initialise la nouvelle session
                         session_create($session_username);
                         storeTokenApi($api, $session_username, $session_password);
+                    } catch (\Exception $e) {
+                        errorAuthentification();
+                    }
+                }
+            } elseif ($config->getHowToConnectUser() == "dbconges" || $session_username == "admin") {
+                $username_conges = authentification_passwd_conges($session_username,$session_password);
+                try {
+                    if ($username_conges != $session_username) {
+                        throw new \Exception("Noms d'utilisateurs différents");
+                    }
+                    session_create($session_username);
+                    storeTokenApi($api, $session_username, $session_password);
+                } catch (\Exception $e) {
+                    $session_username="";
+                    $session_password="";
+                    $erreur="login_passwd_incorrect";
+                    session_saisie_user_password($erreur, $session_username, $session_password);
                 }
             }
     	}
 	}
 }
-
-/*****************************************************************/
 
 if (isset($_SESSION['userlogin'])) {
 	$request= "SELECT u_nom, u_passwd, u_prenom, u_is_resp, u_is_hr, u_is_admin, u_is_active  FROM conges_users where u_login = '". \includes\SQL::quote($_SESSION['userlogin'])."' " ;
@@ -133,24 +110,19 @@ if (isset($_SESSION['userlogin'])) {
                 if('admin' === $_SESSION['userlogin']){
                     redirect(ROOT_PATH . 'admin/admin_index.php');
                 }
-		if( $is_active == "N") {
+		if($is_active == "N") {
 			header_error();
 			echo  _('session_compte_inactif') ."<br>\n";
 			echo  _('session_contactez_admin') ."\n";
 			bottom();
 			exit;
 		}
-        if ( $is_hr == "Y" ) {
-                    redirect( ROOT_PATH .'hr/hr_index.php');
+        if ($is_hr == "Y") {
+            redirect( ROOT_PATH .'hr/hr_index.php');
+		} elseif ($is_resp=="Y") {
+            redirect( ROOT_PATH .'responsable/resp_index.php');
+		} else {
+            redirect( ROOT_PATH . 'utilisateur/user_index.php');
 		}
-		elseif ( $is_resp=="Y" )
-		{
-                    redirect( ROOT_PATH .'responsable/resp_index.php');
-		}
-		else
-		{
-                    redirect( ROOT_PATH . 'utilisateur/user_index.php');
-		}
-
 	}
 }


### PR DESCRIPTION
Cf. #640 (a priori)

Si la connexion à l'API était en échec, l'application continuait à tourner comme si de rien n'était. Pour la plupart des actions dans `web`, ça ne pose pas de problème, excepté pour les quelques que nous avons déjà portées sur l'API, tel que l'affichage de la liste des plannings.

J'ai donc mis en place le bypass pour l'admin qui était en vigueur sur `web` et rendu l'accès à l'API obligatoire. Si la session n'a pas de token, alors ça se déconnecte. Pour le reste… j'ai dû faire du ménage pour bosser, je n'y voyais rien. J'en ai aussi profité pour standardiser les cas d'erreurs.

## Tester
pour tester ça, le mieux est d'avoir l'application configurée avec LDAP tout en cherchant à se connecter en admin. Sur beta, la connexion se fait bien, mais la liste des plannings est inaccessible, tandis que sur la branche, tout se passe bien. C'est le signe que la connexion à l'API se fait bien, et donc que le token se remplit parfaitement.