### PR TITLE
Responsable en premier + correction defaut multi groupe

### DIFF
--- a/App/ProtoControllers/Groupe/Responsable.php
+++ b/App/ProtoControllers/Groupe/Responsable.php
@@ -22,10 +22,11 @@ class Responsable {
      */
     public static function getListResponsableByGroupeIds(array $groupeIds)
     {
+        $groupeIds = array_map('intval', $groupeIds);
         $sql = \includes\SQL::singleton();
         $req = 'SELECT gr_login
                 FROM conges_groupe_resp
-                WHERE gr_gid IN (\'' . implode(',', $groupeIds) . '\')';
+                WHERE gr_gid IN (' . implode(',', $groupeIds) . ')';
         $query = $sql->query($req);
 
         $respLogin = [];

--- a/App/ProtoControllers/HautResponsable/Utilisateur.php
+++ b/App/ProtoControllers/HautResponsable/Utilisateur.php
@@ -1078,7 +1078,7 @@ enctype="application/x-www-form-urlencoded" class="form-group">';
                 WHERE login="' . $data['oldLogin'] . '" ' ;
         $sql->query($req);
 
-        $req = 'UPDATE conges_user 
+        $req = 'UPDATE conges_users
                 SET u_login="' . $data['login'] . '"
                 WHERE u_login="' . $data['oldLogin'] . '" ';
 

--- a/App/Views/Calendrier/Mois.php
+++ b/App/Views/Calendrier/Mois.php
@@ -42,10 +42,10 @@ require_once VIEW_PATH . 'Calendrier.php';
             <?php endforeach ?>
         </tr>
         <?php $index = 0; ?>
-        <?php foreach ($employesATrouver as $loginUtilisation => $nomComplet) : ?>
+        <?php foreach ($employesATrouver as $loginUtilisation => $employe) : ?>
         <?php ++$index; ?>
         <tr class="calendrier-employe">
-            <td class="calendrier-nom"><?= $nomComplet ?></td>
+            <td class="calendrier-nom"><?= $employe['nom'] ?></td>
             <?php foreach ($jours as $jour) : ?>
             <td class="calendrier-jour <?= getClassesJour($evenements, $loginUtilisation, $jour, $moisDemande) ?>">
                 <div class="triangle-top"></div>

--- a/calendrier.php
+++ b/calendrier.php
@@ -76,9 +76,24 @@ $employes = array_filter($tousEmployes, function ($employe) use ($utilisateursAT
     return 'Y' == $employe['u_is_active'] && in_array($employe['u_login'], $utilisateursATrouver);
 });
 
+$employesATrouver = [];
 foreach ($employes as $employe) {
-    $employesATrouver[$employe['u_login']] = \App\ProtoControllers\Utilisateur::getNomComplet($employe['u_prenom'], $employe['u_nom'], true);
+    $employesATrouver[$employe['u_login']] = [
+        'nom' => \App\ProtoControllers\Utilisateur::getNomComplet($employe['u_prenom'], $employe['u_nom'], true),
+        'isResponsable' => \App\ProtoControllers\Utilisateur::isResponsable($employe['u_login']),
+    ];
 }
+
+$responsablesPremier = function (array $a, array $b) {
+    if ($a['isResponsable'] && !$b['isResponsable']) {
+        return -1;
+    } elseif (!$a['isResponsable'] && $b['isResponsable']) {
+        return 1;
+    }
+    return strcmp($a['nom'], $b['nom']);
+};
+
+uasort($employesATrouver, $responsablesPremier);
 
 // Cette variable est utilisée par le fichier "Mois.php" pour ajouter
 // une séparation visuelle entre les responsables et les autres utilisateurs.


### PR DESCRIPTION
fix #650 

Lorsqu'un nom de responsable était postérieur à un nom d'employé dans l'ordre lexicographique, l'affichage du calendrier se mélangeait les pinceaux et affichait l'employé avant la séparation, le responsable en dessous. J'ai donc reprécisé l'ordre à appliquer.
De plus, quand il y avait plusieurs groupes à afficher, le calendrier ne présentait que les responsables du premier groupe ; c'est aussi corrigé.

Enfin, puisque je passais par là, j'ai constaté qu'il n'était pas possible de modifier un employé. Corrigé aussi.