### PR TITLE
Correction bug reliquats fix #639

### DIFF
--- a/App/ProtoControllers/Responsable/Traitement/Conge.php
+++ b/App/ProtoControllers/Responsable/Traitement/Conge.php
@@ -503,7 +503,7 @@ class Conge extends \App\ProtoControllers\Responsable\ATraitement
     {
         $config = new \App\Libraries\Configuration($sql);
         $jourDemande = date("Y-m-d");
-        if (0 === $config->getDateLimiteReliquats()) {
+        if (0 == $config->getDateLimiteReliquats()) {
             return true;
         }
         return $jourDemande < $_SESSION['config']['date_limite_reliquats'];


### PR DESCRIPTION
Le test donnait systématiquement false car le zero retourné est une chaine de caractère :s J'ai modifié le test plutôt que l'objet configuration car cette fonction retourne soit une date soit "0".